### PR TITLE
Populate database and table panels with fuzzy filtering

### DIFF
--- a/internal/db/conn.go
+++ b/internal/db/conn.go
@@ -68,11 +68,19 @@ func (c *conn) ListDatabases(ctx context.Context) ([]string, error) {
 }
 
 func (c *conn) ListTables(ctx context.Context, database string) ([]string, error) {
+	rels, err := c.ListRelations(ctx, database)
+	if err != nil {
+		return nil, err
+	}
+	return RelationNames(rels), nil
+}
+
+func (c *conn) ListRelations(ctx context.Context, database string) ([]Relation, error) {
 	q, err := c.q()
 	if err != nil {
 		return nil, err
 	}
-	return c.dialect.listTables(ctx, q, database)
+	return c.dialect.listRelations(ctx, q, database)
 }
 
 func (c *conn) TableColumns(ctx context.Context, database, table string) ([]Column, error) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -39,6 +39,41 @@ type Index struct {
 	Primary bool
 }
 
+// RelationKind distinguishes the two kinds of listable relation. The UI
+// shows them in separate sub-tabs of the [3] Tables panel.
+type RelationKind int
+
+const (
+	RelationTable RelationKind = iota
+	RelationView
+)
+
+// Relation is one entry of a namespace listing: a table or a view.
+type Relation struct {
+	Name string
+	Kind RelationKind
+}
+
+// RelationNames extracts the names of a relation slice, keeping order.
+func RelationNames(rels []Relation) []string {
+	out := make([]string, 0, len(rels))
+	for _, r := range rels {
+		out = append(out, r.Name)
+	}
+	return out
+}
+
+// FilterRelations returns the names of the relations of one kind.
+func FilterRelations(rels []Relation, kind RelationKind) []string {
+	var out []string
+	for _, r := range rels {
+		if r.Kind == kind {
+			out = append(out, r.Name)
+		}
+	}
+	return out
+}
+
 // ResultSet is a fully materialized, driver-agnostic query result.
 // Cell values are nil (SQL NULL), string, int64, float64, bool or
 // time.Time — never driver-private types or aliased []byte.
@@ -75,9 +110,12 @@ type Driver interface {
 	// MySQL/MariaDB, schemas of the connected database for PostgreSQL,
 	// attached databases for SQLite and DuckDB.
 	ListDatabases(ctx context.Context) ([]string, error)
-	// ListTables returns tables and views in the given namespace.
-	// An empty database means the connection's current/default one.
+	// ListTables returns the names of tables and views in the given
+	// namespace. An empty database means the connection's
+	// current/default one.
 	ListTables(ctx context.Context, database string) ([]string, error)
+	// ListRelations is ListTables with the table/view distinction kept.
+	ListRelations(ctx context.Context, database string) ([]Relation, error)
 	TableColumns(ctx context.Context, database, table string) ([]Column, error)
 	TableIndexes(ctx context.Context, database, table string) ([]Index, error)
 	TableDDL(ctx context.Context, database, table string) (string, error)
@@ -111,7 +149,9 @@ type Dialect interface {
 	LimitOffset(limit, offset int) string
 
 	listDatabases(ctx context.Context, q querier) ([]string, error)
-	listTables(ctx context.Context, q querier, database string) ([]string, error)
+	// listRelations returns tables and views with their kind; the
+	// name-only ListTables is derived from it.
+	listRelations(ctx context.Context, q querier, database string) ([]Relation, error)
 	tableColumns(ctx context.Context, q querier, database, table string) ([]Column, error)
 	tableIndexes(ctx context.Context, q querier, database, table string) ([]Index, error)
 	tableDDL(ctx context.Context, q querier, database, table string) (string, error)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -35,6 +35,7 @@ func seed(t *testing.T, drv Driver) {
 			email TEXT
 		)`,
 		`CREATE INDEX idx_users_name ON users (name)`,
+		`CREATE VIEW named_users AS SELECT id, name FROM users`,
 	}
 	for _, s := range stmts {
 		if _, err := drv.Exec(ctx, s); err != nil {
@@ -81,6 +82,28 @@ func engineSuite(t *testing.T, engine Engine, dsn string) {
 		}
 		if !slices.Contains(tables, "users") {
 			t.Fatalf("ListTables = %v, want to contain users", tables)
+		}
+	})
+
+	// The [3] Tables panel splits the listing into its Tables and Views
+	// sub-tabs, so the kind has to survive the driver boundary.
+	t.Run("ListRelations", func(t *testing.T) {
+		rels, err := drv.ListRelations(ctx, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		kinds := map[string]RelationKind{}
+		for _, r := range rels {
+			kinds[r.Name] = r.Kind
+		}
+		if kinds["users"] != RelationTable {
+			t.Errorf("users kind = %v, want RelationTable", kinds["users"])
+		}
+		if kinds["named_users"] != RelationView {
+			t.Errorf("named_users kind = %v, want RelationView", kinds["named_users"])
+		}
+		if got := FilterRelations(rels, RelationView); !slices.Contains(got, "named_users") {
+			t.Errorf("FilterRelations(views) = %v, want to contain named_users", got)
 		}
 	})
 

--- a/internal/db/dialect_duckdb.go
+++ b/internal/db/dialect_duckdb.go
@@ -45,14 +45,16 @@ func duckdbDBCond(database string) (string, []any) {
 	return "database_name = ?", []any{database}
 }
 
-func (duckdbDialect) listTables(ctx context.Context, q querier, database string) ([]string, error) {
+func (duckdbDialect) listRelations(ctx context.Context, q querier, database string) ([]Relation, error) {
 	cond, args := duckdbDBCond(database)
-	return scanStrings(ctx, q,
-		`SELECT table_name FROM duckdb_tables() WHERE `+cond+`
+	// duckdb_tables() and duckdb_views() are separate functions, so the
+	// kind column is a literal rather than a catalog value.
+	return scanRelations(ctx, q,
+		`SELECT table_name, 'table' FROM duckdb_tables() WHERE `+cond+`
 		 UNION ALL
-		 SELECT view_name FROM duckdb_views() WHERE NOT internal AND `+cond+`
+		 SELECT view_name, 'view' FROM duckdb_views() WHERE NOT internal AND `+cond+`
 		 ORDER BY 1`,
-		append(args, args...)...)
+		append(append([]any{}, args...), args...)...)
 }
 
 func (duckdbDialect) tableColumns(ctx context.Context, q querier, database, table string) ([]Column, error) {

--- a/internal/db/dialect_helpers.go
+++ b/internal/db/dialect_helpers.go
@@ -23,6 +23,30 @@ func scanStrings(ctx context.Context, q querier, query string, args ...any) ([]s
 	return out, rows.Err()
 }
 
+// scanRelations runs a query whose result is (name, kind) and normalizes
+// the engine's kind spelling. Anything containing "view" is a view;
+// everything else (BASE TABLE, LOCAL TEMPORARY, …) is a table.
+func scanRelations(ctx context.Context, q querier, query string, args ...any) ([]Relation, error) {
+	rows, err := q.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Relation
+	for rows.Next() {
+		var name, kind string
+		if err := rows.Scan(&name, &kind); err != nil {
+			return nil, err
+		}
+		rel := Relation{Name: name, Kind: RelationTable}
+		if strings.Contains(strings.ToLower(kind), "view") {
+			rel.Kind = RelationView
+		}
+		out = append(out, rel)
+	}
+	return out, rows.Err()
+}
+
 // synthesizeDDL builds a CREATE TABLE statement from introspected
 // columns, for engines that do not store the original DDL.
 func synthesizeDDL(d Dialect, database, table string, cols []Column) string {

--- a/internal/db/dialect_mysql.go
+++ b/internal/db/dialect_mysql.go
@@ -48,10 +48,11 @@ func mysqlSchemaCond(database string) (string, []any) {
 	return "table_schema = ?", []any{database}
 }
 
-func (mysqlDialect) listTables(ctx context.Context, q querier, database string) ([]string, error) {
+func (mysqlDialect) listRelations(ctx context.Context, q querier, database string) ([]Relation, error) {
 	cond, args := mysqlSchemaCond(database)
-	return scanStrings(ctx, q,
-		`SELECT table_name FROM information_schema.tables WHERE `+cond+` ORDER BY table_name`,
+	return scanRelations(ctx, q,
+		`SELECT table_name, table_type FROM information_schema.tables
+		 WHERE `+cond+` ORDER BY table_name`,
 		args...)
 }
 

--- a/internal/db/dialect_postgres.go
+++ b/internal/db/dialect_postgres.go
@@ -44,9 +44,9 @@ func pgSchema(database string) string {
 	return database
 }
 
-func (postgresDialect) listTables(ctx context.Context, q querier, database string) ([]string, error) {
-	return scanStrings(ctx, q,
-		`SELECT table_name FROM information_schema.tables
+func (postgresDialect) listRelations(ctx context.Context, q querier, database string) ([]Relation, error) {
+	return scanRelations(ctx, q,
+		`SELECT table_name, table_type FROM information_schema.tables
 		 WHERE table_schema = $1 ORDER BY table_name`,
 		pgSchema(database))
 }

--- a/internal/db/dialect_sqlite.go
+++ b/internal/db/dialect_sqlite.go
@@ -57,11 +57,11 @@ func sqliteSchema(d Dialect, database string) string {
 	return d.QuoteIdent(database)
 }
 
-func (d sqliteDialect) listTables(ctx context.Context, q querier, database string) ([]string, error) {
+func (d sqliteDialect) listRelations(ctx context.Context, q querier, database string) ([]Relation, error) {
 	// sqlite_master lives per attached database and cannot be
 	// parameterized by schema, so the (quoted) schema is interpolated.
-	return scanStrings(ctx, q,
-		`SELECT name FROM `+sqliteSchema(d, database)+`.sqlite_master
+	return scanRelations(ctx, q,
+		`SELECT name, type FROM `+sqliteSchema(d, database)+`.sqlite_master
 		 WHERE type IN ('table', 'view') AND name NOT LIKE 'sqlite_%'
 		 ORDER BY name`)
 }

--- a/internal/ui/browse.go
+++ b/internal/ui/browse.go
@@ -1,0 +1,107 @@
+package ui
+
+import (
+	"context"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/db"
+)
+
+// browseTimeout bounds catalog reads so a hung server cannot leave a panel
+// stuck in its loading state forever.
+const browseTimeout = 15 * time.Second
+
+// relationTab is a sub-tab of the [3] Tables panel.
+type relationTab int
+
+const (
+	tabTables relationTab = iota
+	tabViews
+	relationTabCount
+)
+
+var relationTabNames = [relationTabCount]string{"Tables", "Views"}
+
+// kind maps the sub-tab onto the driver's relation kind.
+func (t relationTab) kind() db.RelationKind {
+	if t == tabViews {
+		return db.RelationView
+	}
+	return db.RelationTable
+}
+
+// ---------- messages ----------
+
+// databasesLoadedMsg carries the result of a [2] Databases (re)load.
+type databasesLoadedMsg struct {
+	conn      string // the connection the load was started for
+	databases []string
+	err       error
+}
+
+// relationsLoadedMsg carries the result of a [3] Tables (re)load. Both
+// sub-tabs come from the same round trip, so switching tabs needs no query.
+type relationsLoadedMsg struct {
+	conn      string
+	database  string
+	relations []db.Relation
+	err       error
+}
+
+// ---------- commands ----------
+
+// loadDatabasesCmd lists the namespaces of the live connection.
+func loadDatabasesCmd(conn string, drv db.Driver) tea.Cmd {
+	if drv == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), browseTimeout)
+		defer cancel()
+		dbs, err := drv.ListDatabases(ctx)
+		return databasesLoadedMsg{conn: conn, databases: dbs, err: err}
+	}
+}
+
+// loadRelationsCmd lists the tables and views of one namespace.
+func loadRelationsCmd(conn string, drv db.Driver, database string) tea.Cmd {
+	if drv == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), browseTimeout)
+		defer cancel()
+		rels, err := drv.ListRelations(ctx, database)
+		return relationsLoadedMsg{conn: conn, database: database, relations: rels, err: err}
+	}
+}
+
+// ---------- pseudo-database ----------
+
+// pseudoDatabase is what single-database engines show in panel [2] when the
+// driver reports no namespace at all, so the panel is never empty and `enter`
+// still has something to drill into.
+const pseudoDatabase = "(default)"
+
+// namespaceList normalizes a driver listing for display: file-based engines
+// with nothing to show get the single pseudo entry.
+func namespaceList(engine db.Engine, dbs []string) []string {
+	// SQLite and DuckDB name their one namespace ("main", "memory", the
+	// file stem …); that name carries no choice, so it collapses into the
+	// pseudo entry. Attached databases still list normally.
+	if db.FileBased(engine) && len(dbs) <= 1 {
+		return []string{pseudoDatabase}
+	}
+	return dbs
+}
+
+// databaseArg turns a panel selection into the driver argument: the pseudo
+// entry means "the connection's current/default namespace".
+func databaseArg(name string) string {
+	if name == pseudoDatabase {
+		return ""
+	}
+	return name
+}

--- a/internal/ui/browse_test.go
+++ b/internal/ui/browse_test.go
@@ -1,0 +1,284 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/db"
+)
+
+// browsing returns a model whose [2]/[3] panels hold fixture content and a
+// live SQLite connection, so reloads have a driver to talk to.
+func browsing(t *testing.T) Model {
+	t.Helper()
+	m := sized(120, 40)
+	m = send(t, m, special(tea.KeyEnter, 0)) // connect the SQLite fixture
+	if m.driver == nil {
+		t.Fatal("fixture connection did not open")
+	}
+	return m
+}
+
+func TestFuzzyMatch(t *testing.T) {
+	cases := []struct {
+		pattern, s string
+		want       bool
+	}{
+		{"", "users", true},
+		{"usr", "users", true},
+		{"usr", "user_roles", true},
+		{"USR", "users", true},
+		{"srz", "users", false},
+		{"userss", "users", false},
+	}
+	for _, c := range cases {
+		if got := fuzzyMatch(c.pattern, c.s); got != c.want {
+			t.Errorf("fuzzyMatch(%q, %q) = %v, want %v", c.pattern, c.s, got, c.want)
+		}
+	}
+}
+
+// `/` narrows as you type and esc puts every row back.
+func TestFilterNarrowsAndEscRestores(t *testing.T) {
+	m := sized(120, 40)
+	m = send(t, m, press('3'), press('/'), press('u'), press('s'))
+	p := m.panels[panelTables]
+	if !p.filtering {
+		t.Fatal("/ did not open the inline filter")
+	}
+	if p.filter != "us" {
+		t.Fatalf("filter = %q, want %q", p.filter, "us")
+	}
+	// "accounts" matches too: fuzzy means subsequence, not prefix.
+	if got := p.items; len(got) != 2 || got[0] != "users" || got[1] != "accounts" {
+		t.Fatalf("filtered items = %v, want [users accounts]", got)
+	}
+	m = send(t, m, special(tea.KeyEscape, 0))
+	if p.filter != "" || p.filtering {
+		t.Fatalf("esc left filter %q (filtering=%v)", p.filter, p.filtering)
+	}
+	if len(p.items) != 4 {
+		t.Fatalf("items after esc = %v, want all four", p.items)
+	}
+}
+
+// While the filter captures keys, digits and `q` are text, not commands.
+func TestFilterCapturesGlobalKeys(t *testing.T) {
+	m := sized(120, 40)
+	m.panels[panelDatabases].setItems([]string{"app_dev", "app_test", "q2_reports"})
+	m = send(t, m, press('2'), press('/'), press('q'), press('2'))
+	if m.focus != panelDatabases {
+		t.Fatalf("focus = %v, want the filter to swallow the digit", m.focus)
+	}
+	p := m.panels[panelDatabases]
+	if p.filter != "q2" {
+		t.Fatalf("filter = %q, want %q", p.filter, "q2")
+	}
+	if got := p.items; len(got) != 1 || got[0] != "q2_reports" {
+		t.Fatalf("items = %v, want [q2_reports]", got)
+	}
+	// enter keeps the filter but hands the panel's keys back.
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if p.filtering {
+		t.Fatal("enter did not leave filter input mode")
+	}
+	if p.filter != "q2" {
+		t.Fatalf("enter dropped the filter: %q", p.filter)
+	}
+}
+
+// A filter that matches nothing leaves an empty panel, and enter on it is a
+// no-op rather than a crash.
+func TestFilterWithNoMatchIsSafe(t *testing.T) {
+	m := sized(120, 40)
+	m = send(t, m, press('3'), press('/'), press('z'), press('z'), press('z'))
+	if got := m.panels[panelTables].items; len(got) != 0 {
+		t.Fatalf("items = %v, want none", got)
+	}
+	m = send(t, m, special(tea.KeyEnter, 0), special(tea.KeyEscape, 0))
+	if len(m.panels[panelTables].items) != 4 {
+		t.Fatalf("esc did not restore the list: %v", m.panels[panelTables].items)
+	}
+}
+
+// `[`/`]` swap panel [3] between its two sub-tabs without touching the server.
+func TestSubTabSwitchesTablesAndViews(t *testing.T) {
+	m := sized(120, 40)
+	m.relations = []db.Relation{
+		{Name: "users", Kind: db.RelationTable},
+		{Name: "accounts", Kind: db.RelationTable},
+		{Name: "active_users", Kind: db.RelationView},
+	}
+	m.refreshRelations()
+	m = send(t, m, press('3'))
+	if got := m.panels[panelTables].items; len(got) != 2 {
+		t.Fatalf("tables tab = %v, want the two tables", got)
+	}
+	m = send(t, m, press(']'))
+	if m.tableTab != tabViews {
+		t.Fatalf("tab = %v, want tabViews", m.tableTab)
+	}
+	if got := m.panels[panelTables].items; len(got) != 1 || got[0] != "active_users" {
+		t.Fatalf("views tab = %v, want [active_users]", got)
+	}
+	m = send(t, m, press('['))
+	if m.tableTab != tabTables {
+		t.Fatalf("tab = %v, want tabTables", m.tableTab)
+	}
+}
+
+// Connecting a single-namespace engine shows the pseudo entry and loads its
+// tables without a database pick.
+func TestSingleDatabaseEngineGoesStraightToTables(t *testing.T) {
+	m := browsing(t)
+	if got := m.panels[panelDatabases].items; len(got) != 1 || got[0] != pseudoDatabase {
+		t.Fatalf("databases = %v, want [%s]", got, pseudoDatabase)
+	}
+	if m.database != "" {
+		t.Fatalf("database = %q, want the driver default", m.database)
+	}
+	if m.focus != panelTables {
+		t.Fatalf("focus = %v, want %v", m.focus, panelTables)
+	}
+	if m.panels[panelTables].loading {
+		t.Fatal("tables panel stayed in its loading state")
+	}
+}
+
+// Both panels reload through commands, and the results land as messages.
+func TestReloadPopulatesPanelsFromDriver(t *testing.T) {
+	m := browsing(t)
+	ctx := context.Background()
+	if _, err := m.driver.Exec(ctx, `CREATE TABLE IF NOT EXISTS widgets (id INTEGER)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.driver.Exec(ctx, `CREATE VIEW IF NOT EXISTS widget_ids AS SELECT id FROM widgets`); err != nil {
+		t.Fatal(err)
+	}
+
+	m = send(t, m, press('R'))
+	if !contains(m.panels[panelTables].items, "widgets") {
+		t.Fatalf("tables = %v, want to contain widgets", m.panels[panelTables].items)
+	}
+	m = send(t, m, press(']'))
+	if !contains(m.panels[panelTables].items, "widget_ids") {
+		t.Fatalf("views = %v, want to contain widget_ids", m.panels[panelTables].items)
+	}
+	if !logContains(m, "-- reload tables of") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+
+	m = send(t, m, press('2'), press('R'))
+	if got := m.panels[panelDatabases].items; len(got) != 1 || got[0] != pseudoDatabase {
+		t.Fatalf("databases after reload = %v", got)
+	}
+	if m.panels[panelDatabases].loading {
+		t.Fatal("databases panel stayed in its loading state")
+	}
+}
+
+// A failed load keeps the panel's previous content and reports in the log.
+func TestFailedLoadKeepsPreviousContent(t *testing.T) {
+	m := browsing(t)
+	before := append([]string(nil), m.panels[panelTables].items...)
+	if len(before) == 0 {
+		t.Fatal("fixture connection listed no tables")
+	}
+	m.panels[panelTables].loading = true
+	m = send(t, m, relationsLoadedMsg{
+		conn:     m.active,
+		database: m.database,
+		err:      context.DeadlineExceeded,
+	})
+	if got := m.panels[panelTables].items; !equal(got, before) {
+		t.Fatalf("items = %v, want the previous %v", got, before)
+	}
+	if m.panels[panelTables].loading {
+		t.Fatal("loading flag survived the error")
+	}
+	if !logContains(m, "FAILED") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+}
+
+// Replies for a connection that is no longer live are dropped.
+func TestStaleLoadIsIgnored(t *testing.T) {
+	m := browsing(t)
+	before := append([]string(nil), m.panels[panelTables].items...)
+	m = send(t, m, relationsLoadedMsg{
+		conn:      "some-other-connection",
+		database:  m.database,
+		relations: []db.Relation{{Name: "ghost", Kind: db.RelationTable}},
+	})
+	if got := m.panels[panelTables].items; !equal(got, before) {
+		t.Fatalf("stale reply landed: %v", got)
+	}
+}
+
+// Reloading without a connection must not dial anything.
+func TestReloadWithoutConnectionIsANoop(t *testing.T) {
+	m := sized(120, 40)
+	m = send(t, m, press('2'), press('R'))
+	if !logContains(m, "not connected") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	if m.panels[panelDatabases].loading {
+		t.Fatal("panel entered a loading state with no driver")
+	}
+}
+
+// The filter must not leak into the next connection's listing.
+func TestConnectResetsBrowseState(t *testing.T) {
+	m := browsing(t)
+	m = send(t, m, press('/'), press('u'))
+	if m.panels[panelTables].filter == "" {
+		t.Fatal("filter was not set")
+	}
+	// enter leaves input mode with the filter still applied, so the digit
+	// jumps panels instead of typing.
+	m = send(t, m, special(tea.KeyEnter, 0), press('1'), special(tea.KeyEnter, 0))
+	p := m.panels[panelTables]
+	if p.filter != "" || p.filtering {
+		t.Fatalf("filter survived the reconnect: %q", p.filter)
+	}
+	if m.tableTab != tabTables {
+		t.Fatalf("tab = %v, want tabTables", m.tableTab)
+	}
+}
+
+// The rendered panel shows the sub-tabs, the filter and the loading marker.
+func TestPanelRendersBrowseChrome(t *testing.T) {
+	m := sized(120, 40)
+	m = send(t, m, press('3'), press('/'), press('u'))
+	m.panels[panelTables].loading = true
+	out := m.View().Content
+	for _, want := range []string{"Tables", "Views", "/u", "loading…"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("view is missing %q", want)
+		}
+	}
+}
+
+func contains(items []string, want string) bool {
+	for _, it := range items {
+		if it == want {
+			return true
+		}
+	}
+	return false
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -32,6 +32,7 @@ type keyMap struct {
 	Refresh        key.Binding
 	Actions        key.Binding
 	Filter         key.Binding
+	ToggleTab      key.Binding
 	RunQuery       key.Binding
 	ClearHistory   key.Binding
 }
@@ -57,9 +58,10 @@ func newKeyMap() keyMap {
 		DropConnection: key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "remove connection")),
 		TestConnection: key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "test connection")),
 		Connect:        key.NewBinding(key.WithKeys("enter", "space"), key.WithHelp("enter", "connect")),
-		Refresh:        key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "refresh")),
+		Refresh:        key.NewBinding(key.WithKeys("R", "r"), key.WithHelp("R", "reload from server")),
 		Actions:        key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "actions")),
-		Filter:         key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "filter")),
+		Filter:         key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "fuzzy filter")),
+		ToggleTab:      key.NewBinding(key.WithKeys("[", "]"), key.WithHelp("[/]", "tables/views")),
 		RunQuery:       key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "run query")),
 		ClearHistory:   key.NewBinding(key.WithKeys("D"), key.WithHelp("D", "clear history")),
 	}
@@ -87,6 +89,7 @@ const (
 	actTestConnection
 	actRefresh
 	actFilter
+	actToggleTab
 	actRunQuery
 	actClearHistory
 )
@@ -109,10 +112,16 @@ func (k keyMap) panelActions(id panelID) []action {
 			{actDropConnection, k.DropConnection},
 			{actTestConnection, k.TestConnection},
 		}
-	case panelDatabases, panelTables:
+	case panelDatabases:
 		return []action{
 			{actRefresh, k.Refresh},
 			{actFilter, k.Filter},
+		}
+	case panelTables:
+		return []action{
+			{actRefresh, k.Refresh},
+			{actFilter, k.Filter},
+			{actToggleTab, k.ToggleTab},
 		}
 	case panelHistory:
 		return []action{

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -79,6 +79,14 @@ type Model struct {
 	driver    db.Driver
 	active    string // name of the connected profile, "" when none
 
+	// Browsing state: the namespace panel [3] currently shows, the
+	// relations it was filled from (both kinds, one round trip) and which
+	// sub-tab is selected.
+	database  string
+	relations []db.Relation
+	tableTab  relationTab
+	table     string // the relation the main view is showing
+
 	startupErr string
 
 	keys  keyMap
@@ -100,6 +108,7 @@ func New() Model {
 	for id := panelID(0); id < panelCount; id++ {
 		m.panels[id] = &sidePanel{id: id}
 	}
+	m.panels[panelTables].tabs = relationTabNames[:]
 
 	cfg, err := config.Load()
 	if err != nil {
@@ -159,6 +168,73 @@ func (m *Model) renameConnState(oldName, newName string) {
 	if m.active == oldName {
 		m.active = newName
 	}
+}
+
+// resetBrowse drops everything that belonged to the previous connection.
+func (m *Model) resetBrowse() {
+	m.database = ""
+	m.table = ""
+	m.relations = nil
+	m.tableTab = tabTables
+	for _, id := range []panelID{panelDatabases, panelTables} {
+		p := m.panels[id]
+		p.loading = false
+		p.clearFilter()
+		p.setItems(nil)
+	}
+	m.panels[panelTables].tab = int(m.tableTab)
+}
+
+// openDatabase makes name the browsed namespace and starts the table load.
+// The panel keeps its old rows until the reply lands.
+func (m *Model) openDatabase(name string) tea.Cmd {
+	m.database = databaseArg(name)
+	p := m.panels[panelTables]
+	p.clearFilter()
+	if m.driver == nil {
+		return nil
+	}
+	m.relations = nil
+	p.loading = true
+	return loadRelationsCmd(m.active, m.driver, m.database)
+}
+
+// refreshRelations repaints panel [3] from the cached relation list for the
+// selected sub-tab — switching tabs never hits the server.
+func (m *Model) refreshRelations() {
+	p := m.panels[panelTables]
+	p.tab = int(m.tableTab)
+	p.setItems(db.FilterRelations(m.relations, m.tableTab.kind()))
+}
+
+// reloadFocused re-runs the server query behind the focused panel.
+func (m *Model) reloadFocused() tea.Cmd {
+	if m.driver == nil {
+		return logCmd("-- reload %s skipped: not connected", panelTitles[m.focus])
+	}
+	switch m.focus {
+	case panelDatabases:
+		m.panels[panelDatabases].loading = true
+		return tea.Batch(
+			logCmd("-- reload databases of %s", m.active),
+			loadDatabasesCmd(m.active, m.driver),
+		)
+	case panelTables:
+		m.panels[panelTables].loading = true
+		return tea.Batch(
+			logCmd("-- reload tables of %s", displayDatabase(m.database)),
+			loadRelationsCmd(m.active, m.driver, m.database),
+		)
+	}
+	return logCmd("-- refresh %s", panelTitles[m.focus])
+}
+
+// displayDatabase names the browsed namespace for logs and the main view.
+func displayDatabase(database string) string {
+	if database == "" {
+		return pseudoDatabase
+	}
+	return database
 }
 
 // selectedConnection returns the profile under the cursor of panel [1].
@@ -223,13 +299,47 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.driver = msg.driver
 		m.active = msg.name
 		m.setConnStatus(msg.name, statusOK, "")
-		m.panels[panelDatabases].setItems(msg.databases)
-		m.panels[panelTables].setItems(nil)
-		return m, tea.Batch(
+		m.resetBrowse()
+		m.panels[panelDatabases].setItems(namespaceList(msg.driver.Engine(), msg.databases))
+		cmds := []tea.Cmd{
 			closeDriverCmd(prev),
 			logCmd("-- connect %s (%s)", msg.name, msg.dsn),
-			focusCmd(panelDatabases),
-		)
+		}
+		// Single-namespace engines (SQLite, DuckDB) have nothing to pick:
+		// go straight to their tables.
+		if dbs := m.panels[panelDatabases].items; len(dbs) == 1 {
+			cmds = append(cmds, m.openDatabase(dbs[0]), focusCmd(panelTables))
+		} else {
+			cmds = append(cmds, focusCmd(panelDatabases))
+		}
+		return m, tea.Batch(cmds...)
+
+	case databasesLoadedMsg:
+		// A reply for a connection that is no longer live is stale.
+		if msg.conn != m.active {
+			return m, nil
+		}
+		p := m.panels[panelDatabases]
+		p.loading = false
+		if msg.err != nil {
+			// The panel keeps its previous content; only the log knows.
+			return m, logCmd("-- list databases FAILED: %v", msg.err)
+		}
+		p.setItems(namespaceList(m.driver.Engine(), msg.databases))
+		return m, nil
+
+	case relationsLoadedMsg:
+		if msg.conn != m.active || msg.database != m.database {
+			return m, nil
+		}
+		p := m.panels[panelTables]
+		p.loading = false
+		if msg.err != nil {
+			return m, logCmd("-- list tables of %s FAILED: %v", displayDatabase(msg.database), msg.err)
+		}
+		m.relations = msg.relations
+		m.refreshRelations()
+		return m, nil
 
 	case connPersistedMsg:
 		if msg.err != nil {
@@ -248,11 +358,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return m, cmd
 		}
-		// 2. Global keys.
+		// 2. An open `/` filter captures every printable key, so digits
+		// and `q` type into the pattern instead of jumping or quitting.
+		if m.panels[m.focus].filtering {
+			return m.updateFilter(msg)
+		}
+		// 3. Global keys.
 		if handled, mm, cmd := m.updateGlobal(msg); handled {
 			return mm, cmd
 		}
-		// 3. Focused panel.
+		// 4. Focused panel.
 		return m.updateFocused(msg)
 	}
 	return m, nil
@@ -314,9 +429,18 @@ func (m Model) updateFocused(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.focus == panelConnections {
 			return m.runAction(actConnect)
 		}
-		return m, m.drillIn()
+		// Bind the command first: drillIn mutates m and Go would
+		// otherwise copy the pre-call model into the return value.
+		cmd := m.drillIn()
+		return m, cmd
 
 	case key.Matches(msg, k.Back):
+		// esc first drops an active filter; only an unfiltered panel
+		// hands the key on to the focus stack.
+		if p.filter != "" {
+			p.clearFilter()
+			return m, nil
+		}
 		if n := len(m.prev); n > 0 {
 			back := m.prev[n-1]
 			m.prev = m.prev[:n-1]
@@ -336,6 +460,32 @@ func (m Model) updateFocused(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	for _, a := range k.panelActions(m.focus) {
 		if key.Matches(msg, a.binding) {
 			return m.runAction(a.id)
+		}
+	}
+	return m, nil
+}
+
+// updateFilter is the inline `/` editor of the focused panel: every
+// keystroke re-narrows the list, esc restores it, enter keeps the filter and
+// hands the panel's normal keys back.
+func (m Model) updateFilter(msg tea.KeyPressMsg) (Model, tea.Cmd) {
+	p := m.panels[m.focus]
+	switch msg.Code {
+	case tea.KeyEscape:
+		p.clearFilter()
+	case tea.KeyEnter:
+		p.filtering = false
+	case tea.KeyBackspace:
+		if r := []rune(p.filter); len(r) > 0 {
+			p.setFilter(string(r[:len(r)-1]))
+		}
+	case tea.KeyUp:
+		p.move(-1)
+	case tea.KeyDown:
+		p.move(1)
+	default:
+		if msg.Text != "" {
+			p.setFilter(p.filter + msg.Text)
 		}
 	}
 	return m, nil
@@ -375,8 +525,7 @@ func (m Model) runAction(id actionID) (Model, tea.Cmd) {
 					if m.active == name {
 						closeCmd = closeDriverCmd(m.driver)
 						m.driver, m.active = nil, ""
-						m.panels[panelDatabases].setItems(nil)
-						m.panels[panelTables].setItems(nil)
+						m.resetBrowse()
 					}
 					delete(m.connState, name)
 					m.refreshConnections("")
@@ -390,14 +539,17 @@ func (m Model) runAction(id actionID) (Model, tea.Cmd) {
 		}
 
 	case actRefresh:
-		return m, logCmd("-- refresh %s", panelTitles[m.focus])
+		return m, m.reloadFocused()
 
 	case actFilter:
-		focus := m.focus
-		m.modal = newPromptModal("Filter "+panelTitles[focus], "substring", "",
-			func(m *Model, v string) tea.Cmd {
-				return logCmd("-- filter %s: %q", panelTitles[focus], v)
-			})
+		// The filter is inline, not a modal: typing narrows the panel on
+		// every keystroke and esc restores the full list.
+		m.panels[m.focus].filtering = true
+
+	case actToggleTab:
+		m.tableTab = (m.tableTab + 1) % relationTabCount
+		m.panels[panelTables].clearFilter()
+		m.refreshRelations()
 
 	case actRunQuery:
 		if sel := m.panels[panelHistory].selected(); sel != "" {
@@ -445,15 +597,18 @@ func (m Model) dialSelected(test bool) (Model, tea.Cmd) {
 
 // drillIn is `enter`: move one step deeper in the connection → database →
 // table chain, and record the resulting statement in the history panel.
-func (m Model) drillIn() tea.Cmd {
+func (m *Model) drillIn() tea.Cmd {
 	sel := m.panels[m.focus].selected()
 	if sel == "" {
 		return nil
 	}
 	switch m.focus {
 	case panelDatabases:
-		return tea.Batch(logCmd("USE %s;", sel), focusCmd(panelTables))
+		return tea.Batch(logCmd("USE %s;", sel), m.openDatabase(sel), focusCmd(panelTables))
 	case panelTables:
+		// The data grid is a separate issue; for now the main view only
+		// records which relation was opened.
+		m.table = sel
 		stmt := fmt.Sprintf("SELECT * FROM %s LIMIT 100;", sel)
 		return tea.Batch(logCmd("%s", stmt), func() tea.Msg { return historyEntryMsg{statement: stmt} })
 	case panelHistory:

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -347,11 +347,13 @@ func TestConnectSetsStatusAndListsDatabases(t *testing.T) {
 	if got := m.connState["local-sqlite"].status; got != statusOK {
 		t.Fatalf("status = %v, want statusOK", got)
 	}
-	if len(m.panels[panelDatabases].items) == 0 {
-		t.Fatal("databases panel was not populated")
+	// SQLite is a single-namespace engine: one pseudo entry, straight to
+	// its tables.
+	if got := m.panels[panelDatabases].items; len(got) != 1 || got[0] != pseudoDatabase {
+		t.Fatalf("databases panel = %v, want [%s]", got, pseudoDatabase)
 	}
-	if m.focus != panelDatabases {
-		t.Fatalf("focus = %v, want %v", m.focus, panelDatabases)
+	if m.focus != panelTables {
+		t.Fatalf("focus = %v, want %v", m.focus, panelTables)
 	}
 	if !logContains(m, "-- connect local-sqlite") {
 		t.Fatalf("command log = %v", m.commandLog)
@@ -432,8 +434,8 @@ func TestActionsMenuDispatchesSameActionAsKey(t *testing.T) {
 	if m.modal != nil {
 		t.Fatal("menu stayed open after enter")
 	}
-	if m.focus != panelDatabases {
-		t.Fatalf("focus = %v, want %v (connect should drill in)", m.focus, panelDatabases)
+	if m.focus != panelTables {
+		t.Fatalf("focus = %v, want %v (connect should drill in)", m.focus, panelTables)
 	}
 	if len(mm.entries) < 2 {
 		t.Fatalf("menu had %d entries, want the panel's actions", len(mm.entries))

--- a/internal/ui/panel.go
+++ b/internal/ui/panel.go
@@ -38,12 +38,30 @@ const (
 
 // sidePanel is a plain cursor-over-slice list. Bubbles' list component carries
 // filtering and pagination chrome we don't want in a lazygit-style column.
+//
+// all/allStatus hold everything the panel knows; items/status hold the rows
+// the current filter lets through and are what the cursor indexes into.
 type sidePanel struct {
-	id     panelID
-	items  []string
-	status []itemStatus // parallel to items; shorter means "idle" for the rest
-	cursor int
-	offset int // index of the first visible row, for scrolling
+	id        panelID
+	all       []string
+	allStatus []itemStatus // parallel to all; shorter means "idle" for the rest
+	items     []string
+	status    []itemStatus
+	cursor    int
+	offset    int // index of the first visible row, for scrolling
+
+	// filter is the fuzzy pattern narrowing the list; filtering reports
+	// whether `/` input mode is still capturing keys.
+	filter    string
+	filtering bool
+
+	// tabs are the sub-tab labels drawn next to the title ([3] Tables).
+	tabs []string
+	tab  int
+
+	// loading marks an in-flight reload: the previous content stays on
+	// screen with a "loading…" marker in the title.
+	loading bool
 }
 
 // statusAt reports the status of row i, defaulting to idle.
@@ -76,28 +94,80 @@ func (p *sidePanel) selected() string {
 }
 
 func (p *sidePanel) setItems(items []string) {
-	p.items = items
-	p.status = nil
-	p.move(0)
+	p.setItemsWithStatus(items, nil)
 }
 
-// setItemsWithStatus replaces the rows together with their tint.
+// setItemsWithStatus replaces the rows together with their tint. The filter
+// survives a reload, and so does the selection whenever the named row is
+// still present.
 func (p *sidePanel) setItemsWithStatus(items []string, status []itemStatus) {
-	p.items = items
-	p.status = status
+	keep := p.selected()
+	p.all = items
+	p.allStatus = status
+	p.applyFilter()
+	if keep == "" || !p.selectByName(keep) {
+		p.cursor, p.offset = 0, 0
+	}
+}
+
+// setFilter narrows the visible rows to the fuzzy matches of pattern.
+func (p *sidePanel) setFilter(pattern string) {
+	keep := p.selected()
+	p.filter = pattern
+	p.applyFilter()
+	if keep != "" {
+		p.selectByName(keep)
+	}
+}
+
+// clearFilter restores the full list and leaves `/` input mode.
+func (p *sidePanel) clearFilter() {
+	p.filtering = false
+	if p.filter == "" {
+		return
+	}
+	p.setFilter("")
+}
+
+// applyFilter recomputes items/status from all/allStatus.
+func (p *sidePanel) applyFilter() {
+	if p.filter == "" {
+		p.items, p.status = p.all, p.allStatus
+		p.move(0)
+		return
+	}
+	items := make([]string, 0, len(p.all))
+	var status []itemStatus
+	for i, it := range p.all {
+		if !fuzzyMatch(p.filter, it) {
+			continue
+		}
+		items = append(items, it)
+		if len(p.allStatus) > 0 {
+			st := statusIdle
+			if i < len(p.allStatus) {
+				st = p.allStatus[i]
+			}
+			status = append(status, st)
+		}
+	}
+	p.items, p.status = items, status
+	p.cursor, p.offset = 0, 0
 	p.move(0)
 }
 
-// selectByName moves the cursor onto the named row when it exists.
-func (p *sidePanel) selectByName(name string) {
+// selectByName moves the cursor onto the named row and reports whether the
+// row was there at all.
+func (p *sidePanel) selectByName(name string) bool {
 	for i, it := range p.items {
 		if it == name {
 			p.cursor = i
 			p.move(0)
-			return
+			return true
 		}
 	}
 	p.move(0)
+	return false
 }
 
 // visible returns the rows that fit in rows lines, scrolling the window so the
@@ -125,16 +195,57 @@ func (p *sidePanel) visible(rows int) []string {
 	return p.items[p.offset:end]
 }
 
-// render draws the panel body (title + rows) for a content box of w x h cells.
-func (p *sidePanel) render(s styles, focused bool, w, h int) string {
+// titleLine is the panel header: number, name, sub-tabs and load state.
+func (p *sidePanel) titleLine(s styles, focused bool) string {
 	titleStyle := s.title
 	if focused {
 		titleStyle = s.titleFocused
 	}
+	line := titleStyle.Render(fmt.Sprintf("[%d] %s", int(p.id)+1, panelTitles[p.id]))
+	if len(p.tabs) > 0 {
+		parts := make([]string, 0, len(p.tabs))
+		for i, t := range p.tabs {
+			if i == p.tab {
+				parts = append(parts, s.keyHint.Render(t))
+				continue
+			}
+			parts = append(parts, s.muted.Render(t))
+		}
+		line += " " + s.muted.Render("‹") + strings.Join(parts, s.muted.Render("|")) + s.muted.Render("›")
+	}
+	if p.loading {
+		line += " " + s.pending.Render("loading…")
+	}
+	return line
+}
+
+// filterLine is the inline `/` prompt; it only takes a row while a filter is
+// being typed or is still narrowing the list.
+func (p *sidePanel) filterLine(s styles) (string, bool) {
+	if !p.filtering && p.filter == "" {
+		return "", false
+	}
+	cursor := ""
+	if p.filtering {
+		cursor = "▏"
+	}
+	line := s.keyHint.Render("/"+p.filter) + cursor
+	if len(p.items) == 0 {
+		line += " " + s.danger.Render("no match")
+	}
+	return line, true
+}
+
+// render draws the panel body (title + rows) for a content box of w x h cells.
+func (p *sidePanel) render(s styles, focused bool, w, h int) string {
 	var b strings.Builder
-	b.WriteString(titleStyle.Render(fmt.Sprintf("[%d] %s", int(p.id)+1, panelTitles[p.id])))
+	b.WriteString(truncate(p.titleLine(s, focused), w))
 
 	rows := h - 1 // title line
+	if line, ok := p.filterLine(s); ok && rows > 0 {
+		b.WriteString("\n" + truncate(line, w))
+		rows--
+	}
 	if rows <= 0 {
 		return b.String()
 	}
@@ -153,4 +264,23 @@ func (p *sidePanel) render(s styles, focused bool, w, h int) string {
 		b.WriteString("\n" + style.Render(line))
 	}
 	return b.String()
+}
+
+// fuzzyMatch reports whether pattern occurs in s as a case-insensitive
+// subsequence — "usr" matches "users" and "user_roles". Cheap enough to run
+// on every keystroke, and no dependency needed.
+func fuzzyMatch(pattern, s string) bool {
+	if pattern == "" {
+		return true
+	}
+	pr := []rune(strings.ToLower(pattern))
+	i := 0
+	for _, c := range strings.ToLower(s) {
+		if c == pr[i] {
+			if i++; i == len(pr) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -148,9 +148,21 @@ func (m Model) mainContent(w, h int) string {
 		m.style.titleFocused.Render(panelTitles[m.focus]) + m.style.muted.Render(" — main view"),
 		"",
 		"selected: " + sel,
-		"",
-		m.style.muted.Render("no result set yet — connect and drill in with enter"),
 	}
+	if m.active != "" {
+		lines = append(lines,
+			"connection: "+m.active,
+			"database: "+displayDatabase(m.database),
+			fmt.Sprintf("relations: %d tables · %d views",
+				len(db.FilterRelations(m.relations, db.RelationTable)),
+				len(db.FilterRelations(m.relations, db.RelationView))),
+		)
+	}
+	if m.table != "" {
+		lines = append(lines, "opened: "+m.table)
+	}
+	lines = append(lines, "",
+		m.style.muted.Render("no result set yet — the data preview lands with the query view"))
 	return joinTruncated(lines, w, h)
 }
 

--- a/wiki/design/catalog-browsing.md
+++ b/wiki/design/catalog-browsing.md
@@ -1,0 +1,86 @@
+---
+type: Design Decision
+title: Catalog browsing in panels [2] and [3]
+description: How the Databases and Tables panels load asynchronously, filter fuzzily, and collapse single-namespace engines into one pseudo-database.
+tags: [tui, db, panels, filtering]
+generated:
+  by: claude-code/opus-5
+  at: 2026-08-09T00:00:00Z
+---
+
+# Catalog browsing
+
+## Decision
+
+Panels `[2] Databases` and `[3] Tables` are filled from the driver layer
+through `tea.Cmd`s only; `Update` never touches the database. Every load
+is a message round trip:
+
+- `loadDatabasesCmd` → `databasesLoadedMsg`
+- `loadRelationsCmd` → `relationsLoadedMsg`
+
+Both commands carry the connection name (and, for relations, the
+namespace) they were started for. The reducer drops a reply whose
+`conn`/`database` no longer matches the model, so a slow listing from a
+connection the user has since left cannot overwrite the current panel.
+
+Key choices:
+
+- **Loading never clears the panel.** `loading` is a flag on
+  `sidePanel`; the previous rows stay on screen with a `loading…` marker
+  in the title. A failed load only appends to the command log — see
+  [design/tui-shell-architecture](tui-shell-architecture.md) for the
+  message-reduction rule this follows.
+- **One round trip fills both sub-tabs.** `[3]` has `Tables` and `Views`
+  sub-tabs on `[`/`]`. The driver returns `[]db.Relation` (name + kind)
+  once; switching tabs re-filters the cached slice and never hits the
+  server. This is why `Driver` grew `ListRelations` next to the
+  name-only `ListTables`, and why the `Dialect` interface now has
+  `listRelations` instead of `listTables` (see
+  [design/db-driver-abstraction](db-driver-abstraction.md)).
+- **Kind normalization is central.** `scanRelations` maps every engine's
+  kind spelling with one rule: anything containing `view` is a view,
+  everything else (`BASE TABLE`, `LOCAL TEMPORARY`, …) is a table. Only
+  DuckDB needs literal kind columns, because `duckdb_tables()` and
+  `duckdb_views()` are separate functions.
+- **Single-namespace engines collapse to a pseudo entry.** For
+  file-based engines (SQLite, DuckDB) whose listing has at most one
+  entry, panel `[2]` shows `(default)` instead of the engine's own name
+  (`main`, `memory`, the file stem …) — that name is not a choice the
+  user makes. `databaseArg` maps the pseudo entry back to `""`, which
+  every dialect already reads as "the connection's current namespace".
+  On connect, a single-entry list is drilled into automatically and
+  focus lands on `[3]`. Attached databases still list normally.
+
+## Fuzzy filter
+
+`/` opens an **inline** filter inside the panel, not a modal: the
+pattern renders under the panel title and narrows the list on every
+keystroke. `fuzzyMatch` is a case-insensitive subsequence test (`usr`
+matches `users` and `user_roles`) — no dependency needed, and cheap
+enough to re-run per key.
+
+Consequences for key routing (the order in `Model.Update` is now
+modal → active filter → global keys → focused panel):
+
+- While the filter is capturing, printable keys are *text*: `2` and `q`
+  type into the pattern instead of jumping panels or quitting.
+- `enter` leaves input mode but keeps the filter applied, so the panel's
+  own keys work on the narrowed list.
+- `esc` clears the filter first; only an unfiltered panel passes `esc`
+  on to the focus stack.
+
+The panel keeps `all`/`allStatus` (everything) separate from
+`items`/`status` (what the filter lets through); the cursor always
+indexes the filtered slice, and a reload re-applies the filter and
+re-selects the previously selected row by name when it survives.
+
+## Alternatives rejected
+
+- **A filter prompt modal** (what the shell shipped with): it hides the
+  list while typing, which defeats filter-as-you-type.
+- **Querying per sub-tab**: two catalog queries where one suffices, and
+  a visible pause on every `[`/`]` press.
+- **Ranking matches by score**: subsequence order is stable and matches
+  the server's `ORDER BY`; re-ordering rows under the cursor while
+  typing is disorienting in a narrow column.

--- a/wiki/design/db-driver-abstraction.md
+++ b/wiki/design/db-driver-abstraction.md
@@ -27,7 +27,7 @@ Key choices:
   narrow `querier` interface. Introspection differences stay in one
   file per engine; connection handling, scanning, paging and exec are
   written once.
-- **Dialect methods are unexported** (`listTables`, `tableDDL`, ...)
+- **Dialect methods are unexported** (`listRelations`, `tableDDL`, ...)
   and `driverName()` too, so outside packages can use quoting and
   placeholders but cannot bypass the Driver.
 - **MariaDB = MySQL dialect** with separate `Engine`/display name — the
@@ -38,6 +38,11 @@ Key choices:
 - **Cancellation** — every method takes `context.Context`; the row scan
   loop also checks `ctx.Err()` between rows so materialization aborts
   promptly.
+- **Relations carry their kind** — the dialect method is
+  `listRelations`, returning `[]Relation` (name + table/view). The
+  name-only `Driver.ListTables` is derived from it, so the `[3] Tables`
+  panel can split its sub-tabs from one query — see
+  [design/catalog-browsing](catalog-browsing.md).
 - **Namespaces** — `ListDatabases` means: databases (MySQL/MariaDB),
   schemas of the connected database (PostgreSQL, which cannot query
   across databases on one connection), attached databases (SQLite,

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -12,6 +12,7 @@ concept with YAML frontmatter. Concept IDs are bundle-relative paths without
 - [design/db-driver-abstraction](design/db-driver-abstraction.md) — Design Decision — one generic Driver over `database/sql` plus a Dialect per engine; UI never imports concrete SQL drivers.
 - [design/connection-secrets](design/connection-secrets.md) — Design Decision — connections in TOML, passwords only in the OS keyring or a per-connect prompt.
 - [design/connection-form-modal](design/connection-form-modal.md) — Design Decision — one reusable multi-field modal with engine-driven field visibility.
+- [design/catalog-browsing](design/catalog-browsing.md) — Design Decision — async catalog loads, inline fuzzy filter, tables/views sub-tabs, pseudo-database for single-namespace engines.
 
 ## reference
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -38,3 +38,13 @@ Chronological history of wiki changes, newest last.
   `parseTime=true` is required for the `ResultSet` value contract, SQLite needs
   the `file:` URI form once options appear, and the redaction mask has to be
   URL-safe.
+- Added [design/catalog-browsing](design/catalog-browsing.md) with the database
+  and table panels (issue #4): catalog reads run as `tea.Cmd`s whose replies are
+  dropped when stale, `[3]` gained `Tables`/`Views` sub-tabs fed by one
+  `ListRelations` round trip, `/` filters inline by case-insensitive
+  subsequence, and SQLite/DuckDB collapse to a `(default)` pseudo-database that
+  maps back to the driver's empty-string namespace.
+- Updated [design/db-driver-abstraction](design/db-driver-abstraction.md) and
+  [reference/dialect-introspection-quirks](reference/dialect-introspection-quirks.md)
+  for the `listTables` → `listRelations` dialect change and the per-engine
+  spellings of the table/view kind column.

--- a/wiki/reference/dialect-introspection-quirks.md
+++ b/wiki/reference/dialect-introspection-quirks.md
@@ -22,6 +22,8 @@ sources:
 - `PRAGMA index_list` marks the implicit primary-key index with
   `origin = 'pk'`; `INTEGER PRIMARY KEY` (rowid alias) produces **no**
   index_list entry at all.
+- `sqlite_master.type` is already `'table'` / `'view'`, so the
+  relation-kind column costs nothing.
 - Original DDL comes from `sqlite_master.sql` (NULL for auto-created
   indexes — filter `sql IS NOT NULL`).
 - In-memory DSN: `:memory:`.
@@ -41,12 +43,19 @@ sources:
 - `duckdb_indexes().expressions` is a list too; cast to VARCHAR and
   parse for plain column indexes. Primary keys do not appear in
   `duckdb_indexes()`.
+- Tables and views live in *separate* functions, so a combined listing
+  is a `UNION ALL` with **literal** kind columns (`'table'` / `'view'`)
+  — there is no catalog column to read the kind from. Each branch needs
+  its own copy of the `database_name` argument.
 - `duckdb_tables().sql` / `duckdb_views().sql` hold reconstructed DDL.
 
 ## PostgreSQL (`jackc/pgx/v5/stdlib`, driver name `pgx`)
 
 - One connection sees one database — "databases" in the UI are the
   schemas of the connected database (`pg_namespace`).
+- `information_schema.tables.table_type` spells kinds as `BASE TABLE`,
+  `VIEW`, `FOREIGN`, `LOCAL TEMPORARY` — match on "contains view"
+  rather than equality.
 - No stored CREATE TABLE text; DDL is synthesized from
   `information_schema.columns`.
 - Primary key / index columns via `pg_index` with
@@ -58,6 +67,8 @@ sources:
 - Shared dialect; only `Engine`/display name differ.
 - `information_schema` throughout; empty database resolves via
   `table_schema = DATABASE()`.
+- `information_schema.tables.table_type` adds `SYSTEM VIEW` to the
+  standard set; the same "contains view" rule covers it.
 - `SHOW CREATE TABLE` returns two columns (name, DDL) — and a
   different column set for views; scan positionally.
 - Primary key detection: `columns.column_key = 'PRI'`; the PK index in


### PR DESCRIPTION
Adds `ListRelations` (table/view kind) to the driver layer, async catalog loading with stale-reply protection, fuzzy filtering, Tables|Views sub-tabs, panel reload, and auto-drill for file-based engines. Tested against in-process SQLite/DuckDB plus UI flow tests.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139rhNA79AoksWw97zoxwWA