### PR TITLE
Render paginated table data with sorting and WHERE filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ GUI database clients are heavy; raw CLI clients (`mysql`, `psql`) are fast but c
 | `?` | Help / all bindings |
 | `q` | Quit |
 
+In the data grid (`enter` on a table, `esc` back):
+
+| Key | Action |
+|-----|--------|
+| `h`/`l`, `←`/`→` | Move the cell cursor between columns |
+| `ctrl+f` / `ctrl+b`, `pgdn`/`pgup` | Next / previous page |
+| `s` | Sort the cursor column (ASC → DESC → off) |
+| `f` | Quick `WHERE` filter |
+| `v` | Show the full cell value (JSON pretty-printed) |
+
 ## Install
 
 ```sh

--- a/internal/db/conn.go
+++ b/internal/db/conn.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -116,26 +117,78 @@ func qualifiedTable(d Dialect, database, table string) string {
 	return d.QuoteIdent(database) + "." + d.QuoteIdent(table)
 }
 
-func (c *conn) QueryPage(ctx context.Context, database, table, filter string, sortBy *Sort, limit, offset int) (*ResultSet, error) {
+// writeWhere appends the filter's WHERE clause, if it has one.
+func writeWhere(b *strings.Builder, filter *Filter) {
+	if filter.empty() {
+		return
+	}
+	b.WriteString(" WHERE ")
+	b.WriteString(filter.Expr)
+}
+
+// PageSQL renders the statement QueryPage executes. The UI uses it to
+// show the exact SQL in the command log without running it twice.
+func PageSQL(d Dialect, database, table string, filter *Filter, sortBy *Sort, limit, offset int) string {
+	var b strings.Builder
+	b.WriteString("SELECT * FROM ")
+	b.WriteString(qualifiedTable(d, database, table))
+	writeWhere(&b, filter)
+	if sortBy != nil && sortBy.Column != "" {
+		b.WriteString(" ORDER BY ")
+		b.WriteString(d.QuoteIdent(sortBy.Column))
+		if sortBy.Desc {
+			b.WriteString(" DESC")
+		} else {
+			b.WriteString(" ASC")
+		}
+	}
+	b.WriteString(d.LimitOffset(limit, offset))
+	return b.String()
+}
+
+// CountSQL renders the statement CountRows executes.
+func CountSQL(d Dialect, database, table string, filter *Filter) string {
+	var b strings.Builder
+	b.WriteString("SELECT COUNT(*) FROM ")
+	b.WriteString(qualifiedTable(d, database, table))
+	writeWhere(&b, filter)
+	return b.String()
+}
+
+func (c *conn) QueryPage(ctx context.Context, database, table string, filter *Filter, sortBy *Sort, limit, offset int) (*ResultSet, error) {
 	if c.db == nil {
 		return nil, errNotConnected
 	}
-	var b strings.Builder
-	b.WriteString("SELECT * FROM ")
-	b.WriteString(qualifiedTable(c.dialect, database, table))
-	if strings.TrimSpace(filter) != "" {
-		b.WriteString(" WHERE ")
-		b.WriteString(filter)
+	q := PageSQL(c.dialect, database, table, filter, sortBy, limit, offset)
+	return c.Query(ctx, q, FilterArgs(filter)...)
+}
+
+func (c *conn) CountRows(ctx context.Context, database, table string, filter *Filter) (int64, error) {
+	if c.db == nil {
+		return 0, errNotConnected
 	}
-	if sortBy != nil && sortBy.Column != "" {
-		b.WriteString(" ORDER BY ")
-		b.WriteString(c.dialect.QuoteIdent(sortBy.Column))
-		if sortBy.Desc {
-			b.WriteString(" DESC")
+	rs, err := c.Query(ctx, CountSQL(c.dialect, database, table, filter), FilterArgs(filter)...)
+	if err != nil {
+		return 0, err
+	}
+	if len(rs.Rows) == 0 || len(rs.Rows[0]) == 0 {
+		return 0, errors.New("db: count returned no rows")
+	}
+	switch n := rs.Rows[0][0].(type) {
+	case int64:
+		return n, nil
+	case float64:
+		return int64(n), nil
+	case string:
+		// Some drivers hand big integers back as decimal text.
+		v, err := strconv.ParseInt(n, 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("db: unreadable count %q", n)
 		}
+		return v, nil
+	default:
+		return 0, fmt.Errorf("db: unreadable count of type %T", n)
 	}
-	b.WriteString(c.dialect.LimitOffset(limit, offset))
-	return c.Query(ctx, b.String())
 }
 
 func (c *conn) Exec(ctx context.Context, query string, args ...any) (ExecResult, error) {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -94,6 +95,34 @@ type Sort struct {
 	Desc   bool
 }
 
+// Filter is the WHERE fragment of a paged query. Expr is a SQL boolean
+// expression written with the dialect's placeholders and Args holds the
+// values they stand for, so user data never reaches the statement text.
+//
+// Verbatim marks a fragment lazysql could not take apart: Expr is then
+// the user's own SQL, interpolated as typed. The UI warns about that in
+// the command log. Raw is always what the user typed, for display.
+type Filter struct {
+	Expr     string
+	Args     []any
+	Verbatim bool
+	Raw      string
+}
+
+// empty reports whether the filter contributes no WHERE clause. A nil
+// filter is empty, which is why every method has a nil-safe receiver.
+func (f *Filter) empty() bool {
+	return f == nil || strings.TrimSpace(f.Expr) == ""
+}
+
+// FilterArgs returns the parameters of a possibly nil filter.
+func FilterArgs(f *Filter) []any {
+	if f == nil {
+		return nil
+	}
+	return f.Args
+}
+
 // Driver is the single abstraction UI code uses for database access.
 // Every method that touches the database takes a context and aborts
 // when it is cancelled.
@@ -120,10 +149,13 @@ type Driver interface {
 	TableIndexes(ctx context.Context, database, table string) ([]Index, error)
 	TableDDL(ctx context.Context, database, table string) (string, error)
 
-	// QueryPage reads one page of a table. filter is a raw SQL boolean
-	// expression supplied by the user (their own WHERE clause), or "".
-	// sort may be nil. Identifiers are quoted per dialect.
-	QueryPage(ctx context.Context, database, table, filter string, sortBy *Sort, limit, offset int) (*ResultSet, error)
+	// QueryPage reads one page of a table. filter and sortBy may be nil.
+	// Identifiers are quoted per dialect and filter arguments travel as
+	// query parameters.
+	QueryPage(ctx context.Context, database, table string, filter *Filter, sortBy *Sort, limit, offset int) (*ResultSet, error)
+	// CountRows returns how many rows the same table+filter matches. It
+	// is a separate round trip so the page can render before it lands.
+	CountRows(ctx context.Context, database, table string, filter *Filter) (int64, error)
 
 	// Exec runs a statement with parameters (dialect placeholder style).
 	Exec(ctx context.Context, query string, args ...any) (ExecResult, error)

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -160,7 +160,7 @@ func engineSuite(t *testing.T, engine Engine, dsn string) {
 	})
 
 	t.Run("QueryPage", func(t *testing.T) {
-		rs, err := drv.QueryPage(ctx, "", "users", "", &Sort{Column: "id"}, 2, 1)
+		rs, err := drv.QueryPage(ctx, "", "users", nil, &Sort{Column: "id"}, 2, 1)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -176,7 +176,8 @@ func engineSuite(t *testing.T, engine Engine, dsn string) {
 	})
 
 	t.Run("QueryPageFilterSort", func(t *testing.T) {
-		rs, err := drv.QueryPage(ctx, "", "users", "email IS NOT NULL", &Sort{Column: "name", Desc: true}, 10, 0)
+		f := ParseFilter(drv.Dialect(), "email IS NOT NULL")
+		rs, err := drv.QueryPage(ctx, "", "users", f, &Sort{Column: "name", Desc: true}, 10, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -185,6 +186,55 @@ func engineSuite(t *testing.T, engine Engine, dsn string) {
 		}
 		if got := rs.Rows[0][1]; got != "carol" {
 			t.Errorf("first row = %v, want carol (DESC)", got)
+		}
+	})
+
+	// A parameterized filter has to reach the engine as a parameter, and
+	// the count has to see the same rows the page does.
+	t.Run("QueryPageBoundFilter", func(t *testing.T) {
+		f := ParseFilter(drv.Dialect(), "name = 'bob'")
+		if f.Verbatim || len(f.Args) != 1 {
+			t.Fatalf("filter = %+v, want one bound argument", f)
+		}
+		rs, err := drv.QueryPage(ctx, "", "users", f, nil, 10, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rs.Rows) != 1 || rs.Rows[0][1] != "bob" {
+			t.Fatalf("rows = %v, want just bob", rs.Rows)
+		}
+		n, err := drv.CountRows(ctx, "", "users", f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 1 {
+			t.Fatalf("CountRows = %d, want 1", n)
+		}
+	})
+
+	t.Run("CountRows", func(t *testing.T) {
+		n, err := drv.CountRows(ctx, "", "users", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if n != 3 {
+			t.Fatalf("CountRows = %d, want 3", n)
+		}
+	})
+
+	// A value that would break out of a string literal must not: it is
+	// bound, so it can only ever match no rows.
+	t.Run("FilterInjectionIsBound", func(t *testing.T) {
+		f := ParseFilter(drv.Dialect(), `name = 'x'' OR 1=1 --'`)
+		if f.Verbatim {
+			t.Fatalf("filter %+v fell back to verbatim", f)
+		}
+		rs, err := drv.QueryPage(ctx, "", "users", f, nil, 10, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(rs.Rows) != 0 {
+			t.Fatalf("rows = %v, want none", rs.Rows)
 		}
 	})
 
@@ -218,7 +268,7 @@ func engineSuite(t *testing.T, engine Engine, dsn string) {
 		if _, err := drv.Exec(ctx, "CREATE TABLE "+quoted+" (x INTEGER)"); err != nil {
 			t.Fatalf("create with quoted ident: %v", err)
 		}
-		if _, err := drv.QueryPage(ctx, "", `weird "table`, "", nil, 5, 0); err != nil {
+		if _, err := drv.QueryPage(ctx, "", `weird "table`, nil, nil, 5, 0); err != nil {
 			t.Fatalf("QueryPage on quoted ident: %v", err)
 		}
 	})

--- a/internal/db/filter.go
+++ b/internal/db/filter.go
@@ -1,0 +1,224 @@
+package db
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// The quick filter of the data grid is free-form SQL: the user types a
+// WHERE fragment and expects it to work. Interpolating that straight
+// into the statement is exactly the injection shape lazysql must not
+// have, so ParseFilter first tries to take the fragment apart into
+// comparisons whose *values* can travel as bound parameters. Only a
+// fragment it cannot recognise stays verbatim, and it is flagged so the
+// UI can warn about it.
+
+// comparisonRe matches one `column <op> <literal>` term. The column is a
+// bare, double-quoted or backtick-quoted identifier; the literal is
+// validated separately by parseLiteral.
+var comparisonRe = regexp.MustCompile(
+	`(?is)^\s*([A-Za-z_][A-Za-z0-9_$]*|"(?:[^"]|"")+"|` + "`(?:[^`]|``)+`" + `)\s*` +
+		`(=|<>|!=|>=|<=|>|<|not\s+like|like|ilike)\s*(.+?)\s*$`)
+
+// nullRe matches `column IS [NOT] NULL`, which takes no parameter.
+var nullRe = regexp.MustCompile(
+	`(?is)^\s*([A-Za-z_][A-Za-z0-9_$]*|"(?:[^"]|"")+"|` + "`(?:[^`]|``)+`" + `)\s*` +
+		`is\s+(not\s+)?null\s*$`)
+
+var (
+	intRe   = regexp.MustCompile(`^[+-]?\d+$`)
+	floatRe = regexp.MustCompile(`^[+-]?(\d+\.\d*|\.\d+|\d+)([eE][+-]?\d+)?$`)
+)
+
+// ParseFilter turns a user-typed WHERE fragment into a Filter. A leading
+// `WHERE` is tolerated. An empty fragment yields nil, meaning "no
+// filter". Anything that is not a chain of simple comparisons joined by
+// AND is kept verbatim and marked Verbatim so callers can warn.
+func ParseFilter(d Dialect, raw string) *Filter {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nil
+	}
+	if rest, ok := cutKeyword(s, "where"); ok {
+		s = strings.TrimSpace(rest)
+	}
+	verbatim := &Filter{Expr: s, Raw: raw, Verbatim: true}
+
+	terms, ok := splitAnd(s)
+	if !ok {
+		return verbatim
+	}
+	exprs := make([]string, 0, len(terms))
+	var args []any
+	for _, t := range terms {
+		expr, val, hasVal, ok := parseTerm(d, t, len(args)+1)
+		if !ok {
+			return verbatim
+		}
+		exprs = append(exprs, expr)
+		if hasVal {
+			args = append(args, val)
+		}
+	}
+	return &Filter{Expr: strings.Join(exprs, " AND "), Args: args, Raw: raw}
+}
+
+// parseTerm renders one comparison with a quoted identifier and, unless
+// it is an IS [NOT] NULL test, a placeholder for position n.
+func parseTerm(d Dialect, term string, n int) (expr string, val any, hasVal, ok bool) {
+	if mm := nullRe.FindStringSubmatch(term); mm != nil {
+		op := "IS NULL"
+		if strings.TrimSpace(mm[2]) != "" {
+			op = "IS NOT NULL"
+		}
+		return d.QuoteIdent(unquoteIdent(mm[1])) + " " + op, nil, false, true
+	}
+	mm := comparisonRe.FindStringSubmatch(term)
+	if mm == nil {
+		return "", nil, false, false
+	}
+	lit, ok := parseLiteral(mm[3])
+	if !ok {
+		return "", nil, false, false
+	}
+	op := strings.ToUpper(strings.Join(strings.Fields(mm[2]), " "))
+	return d.QuoteIdent(unquoteIdent(mm[1])) + " " + op + " " + d.Placeholder(n), lit, true, true
+}
+
+// parseLiteral recognises the value syntaxes worth binding: quoted
+// strings, numbers and booleans. NULL is deliberately absent — `col =
+// NULL` is never what the user means, so such a fragment falls through
+// to the verbatim path instead of being silently rewritten.
+func parseLiteral(s string) (any, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, false
+	}
+	if len(s) >= 2 && s[0] == '\'' && s[len(s)-1] == '\'' {
+		body := s[1 : len(s)-1]
+		// A lone quote inside means the literal ended early and more SQL
+		// follows, e.g. `'a' OR 1=1`; only doubled quotes are escapes.
+		if strings.Contains(strings.ReplaceAll(body, "''", ""), "'") {
+			return nil, false
+		}
+		return strings.ReplaceAll(body, "''", "'"), true
+	}
+	switch strings.ToUpper(s) {
+	case "TRUE":
+		return true, true
+	case "FALSE":
+		return false, true
+	}
+	if intRe.MatchString(s) {
+		if v, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return v, true
+		}
+	}
+	if floatRe.MatchString(s) {
+		if v, err := strconv.ParseFloat(s, 64); err == nil {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+// splitAnd splits a fragment on top-level AND. It reports false when the
+// fragment contains anything the naive splitter must not guess at:
+// parentheses, OR, or an unterminated quote.
+func splitAnd(s string) ([]string, bool) {
+	var terms []string
+	var cur strings.Builder
+	var quote byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if quote != 0 {
+			cur.WriteByte(c)
+			if c == quote {
+				// A doubled quote is an escape, not the end.
+				if i+1 < len(s) && s[i+1] == quote {
+					cur.WriteByte(quote)
+					i++
+					continue
+				}
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"', '`':
+			quote = c
+			cur.WriteByte(c)
+			continue
+		case '(', ')', ';':
+			return nil, false
+		}
+		if _, ok := cutKeywordAt(s, i, "or"); ok {
+			return nil, false
+		}
+		if _, ok := cutKeywordAt(s, i, "and"); ok {
+			terms = append(terms, cur.String())
+			cur.Reset()
+			i += len("and") - 1
+			continue
+		}
+		cur.WriteByte(c)
+	}
+	if quote != 0 {
+		return nil, false
+	}
+	terms = append(terms, cur.String())
+	for _, t := range terms {
+		if strings.TrimSpace(t) == "" {
+			return nil, false
+		}
+	}
+	return terms, true
+}
+
+// cutKeywordAt reports whether the word kw starts at s[i] on a word
+// boundary, case-insensitively.
+func cutKeywordAt(s string, i int, kw string) (string, bool) {
+	if i+len(kw) > len(s) {
+		return "", false
+	}
+	if !strings.EqualFold(s[i:i+len(kw)], kw) {
+		return "", false
+	}
+	if i > 0 && isIdentByte(s[i-1]) {
+		return "", false
+	}
+	if j := i + len(kw); j < len(s) && isIdentByte(s[j]) {
+		return "", false
+	}
+	return s[i+len(kw):], true
+}
+
+// cutKeyword strips a leading keyword such as `WHERE`.
+func cutKeyword(s, kw string) (string, bool) {
+	return cutKeywordAt(s, 0, kw)
+}
+
+func isIdentByte(c byte) bool {
+	return c == '_' || c == '$' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+// unquoteIdent strips the quoting the user typed so the dialect can
+// apply its own.
+func unquoteIdent(s string) string {
+	if len(s) < 2 {
+		return s
+	}
+	switch s[0] {
+	case '"':
+		if s[len(s)-1] == '"' {
+			return strings.ReplaceAll(s[1:len(s)-1], `""`, `"`)
+		}
+	case '`':
+		if s[len(s)-1] == '`' {
+			return strings.ReplaceAll(s[1:len(s)-1], "``", "`")
+		}
+	}
+	return s
+}

--- a/internal/db/filter_test.go
+++ b/internal/db/filter_test.go
@@ -1,0 +1,163 @@
+package db
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestParseFilterBindsSimpleComparisons(t *testing.T) {
+	d, _ := DialectFor(EngineSQLite)
+	cases := []struct {
+		in       string
+		wantExpr string
+		wantArgs []any
+	}{
+		{`id = 1`, `"id" = ?`, []any{int64(1)}},
+		{`id>=10`, `"id" >= ?`, []any{int64(10)}},
+		{`price < 9.5`, `"price" < ?`, []any{9.5}},
+		{`name = 'bob'`, `"name" = ?`, []any{"bob"}},
+		{`name LIKE 'a%'`, `"name" LIKE ?`, []any{"a%"}},
+		{`name not   like 'a%'`, `"name" NOT LIKE ?`, []any{"a%"}},
+		{`active = true`, `"active" = ?`, []any{true}},
+		{`email IS NULL`, `"email" IS NULL`, nil},
+		{`email is not null`, `"email" IS NOT NULL`, nil},
+		{`WHERE id <> 3`, `"id" <> ?`, []any{int64(3)}},
+		{`id > 5 AND name = 'bob'`, `"id" > ? AND "name" = ?`, []any{int64(5), "bob"}},
+		{`"odd col" = 'x'`, `"odd col" = ?`, []any{"x"}},
+		{"`odd col` = 'x'", `"odd col" = ?`, []any{"x"}},
+		// A quote closed by doubling stays one literal.
+		{`name = 'O''Hara'`, `"name" = ?`, []any{"O'Hara"}},
+		// AND inside a literal is data, not a separator.
+		{`name = 'a and b'`, `"name" = ?`, []any{"a and b"}},
+	}
+	for _, c := range cases {
+		got := ParseFilter(d, c.in)
+		if got == nil {
+			t.Errorf("ParseFilter(%q) = nil", c.in)
+			continue
+		}
+		if got.Verbatim {
+			t.Errorf("ParseFilter(%q) fell back to verbatim", c.in)
+			continue
+		}
+		if got.Expr != c.wantExpr {
+			t.Errorf("ParseFilter(%q).Expr = %q, want %q", c.in, got.Expr, c.wantExpr)
+		}
+		if !slices.Equal(got.Args, c.wantArgs) {
+			t.Errorf("ParseFilter(%q).Args = %v, want %v", c.in, got.Args, c.wantArgs)
+		}
+		if got.Raw != c.in {
+			t.Errorf("ParseFilter(%q).Raw = %q", c.in, got.Raw)
+		}
+	}
+}
+
+func TestParseFilterNumbersPostgresPlaceholders(t *testing.T) {
+	d, _ := DialectFor(EnginePostgres)
+	f := ParseFilter(d, `id > 5 AND name = 'bob'`)
+	if want := `"id" > $1 AND "name" = $2`; f.Expr != want {
+		t.Fatalf("Expr = %q, want %q", f.Expr, want)
+	}
+}
+
+// Anything the parser does not fully recognise must survive as the user
+// typed it and be flagged, never silently dropped or half-rewritten.
+func TestParseFilterFallsBackToVerbatim(t *testing.T) {
+	d, _ := DialectFor(EngineSQLite)
+	for _, in := range []string{
+		`id IN (1,2,3)`,
+		`id = 1 OR id = 2`,
+		`lower(name) = 'bob'`,
+		`id = other_column`,
+		`name = 'unterminated`,
+		`id = 1; DROP TABLE users`,
+		`id = NULL`,
+		`id BETWEEN 1 AND 5`,
+	} {
+		f := ParseFilter(d, in)
+		if f == nil {
+			t.Errorf("ParseFilter(%q) = nil, want a verbatim filter", in)
+			continue
+		}
+		if !f.Verbatim {
+			t.Errorf("ParseFilter(%q) claimed to be parameterized: %+v", in, f)
+		}
+		if f.Expr != in {
+			t.Errorf("ParseFilter(%q).Expr = %q, want it unchanged", in, f.Expr)
+		}
+	}
+}
+
+func TestParseFilterEmpty(t *testing.T) {
+	d, _ := DialectFor(EngineSQLite)
+	for _, in := range []string{"", "   ", "\t"} {
+		if f := ParseFilter(d, in); f != nil {
+			t.Errorf("ParseFilter(%q) = %+v, want nil", in, f)
+		}
+	}
+}
+
+func TestPageSQL(t *testing.T) {
+	d, _ := DialectFor(EngineSQLite)
+	f := ParseFilter(d, "id > 5")
+	got := PageSQL(d, "", "users", f, &Sort{Column: "name", Desc: true}, 100, 200)
+	want := `SELECT * FROM "users" WHERE "id" > ? ORDER BY "name" DESC LIMIT 100 OFFSET 200`
+	if got != want {
+		t.Errorf("PageSQL = %q, want %q", got, want)
+	}
+	if got := CountSQL(d, "app", "users", f); got != `SELECT COUNT(*) FROM "app"."users" WHERE "id" > ?` {
+		t.Errorf("CountSQL = %q", got)
+	}
+	if got := PageSQL(d, "", "users", nil, nil, 10, 0); got != `SELECT * FROM "users" LIMIT 10 OFFSET 0` {
+		t.Errorf("unfiltered PageSQL = %q", got)
+	}
+}
+
+// Browsing a big table must cost one page, not one table scan into
+// memory: the page query is bounded by LIMIT and stays fast at any
+// offset.
+func TestQueryPageOnLargeTableFetchesOnlyThePage(t *testing.T) {
+	ctx := context.Background()
+	drv := openTest(t, EngineSQLite, ":memory:")
+	if _, err := drv.Exec(ctx, `CREATE TABLE big (id INTEGER PRIMARY KEY, name TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	const rows = 100_000
+	_, err := drv.Exec(ctx, fmt.Sprintf(`
+		INSERT INTO big (id, name)
+		WITH RECURSIVE seq(n) AS (
+			SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < %d
+		)
+		SELECT n, 'row-' || n FROM seq`, rows))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := drv.CountRows(ctx, "", "big", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != rows {
+		t.Fatalf("CountRows = %d, want %d", n, rows)
+	}
+
+	start := time.Now()
+	rs, err := drv.QueryPage(ctx, "", "big", nil, &Sort{Column: "id"}, 100, 99_900)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rs.Rows) != 100 {
+		t.Fatalf("got %d rows, want the 100-row page", len(rs.Rows))
+	}
+	if got := rs.Rows[0][0]; got != int64(99_901) {
+		t.Fatalf("first row id = %v, want 99901", got)
+	}
+	// Generous by two orders of magnitude: this only has to fail if the
+	// page query degenerates into materializing the whole table.
+	if el := time.Since(start); el > 2*time.Second {
+		t.Fatalf("last-page query took %s", el)
+	}
+}

--- a/internal/ui/data.go
+++ b/internal/ui/data.go
@@ -1,0 +1,375 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/db"
+)
+
+// dataPageSize is how many rows one page of the grid holds. The grid
+// never keeps more than one page in memory, which is what makes a
+// 100k-row table exactly as cheap to browse as a 100-row one.
+const dataPageSize = 100
+
+// queryTimeout bounds a page read. It is longer than the catalog
+// timeout because a filtered scan of a large table legitimately takes
+// longer than an introspection query.
+const queryTimeout = 30 * time.Second
+
+// dataView is the state of the main view's Data tab: one page of one
+// relation plus everything that shaped the query behind it.
+//
+// The cell cursor (row, col) is deliberately part of this state rather
+// than of the renderer: inline editing reuses it.
+type dataView struct {
+	// Identity of the page on screen. Replies that do not match are
+	// stale and get dropped.
+	conn     string
+	database string
+	table    string
+
+	cols []db.Column
+	rows [][]any
+
+	// Query shape. filter and sort survive paging; the filter also
+	// survives a sort change, so the three compose.
+	page   int
+	filter *db.Filter
+	sort   *db.Sort
+
+	// total is the COUNT(*) behind the same filter. It arrives in its
+	// own round trip, so until it does the status line omits it.
+	total    int64
+	hasTotal bool
+
+	// Cell cursor. The row and column scroll windows are derived from it
+	// at render time rather than stored, so a resize can never leave a
+	// stale offset behind.
+	row, col int
+
+	loading bool
+	err     string
+
+	// req is bumped on every reload; a reply carrying an older req
+	// belongs to a query the user has already moved past.
+	req int
+}
+
+// open reports whether a relation is being browsed at all.
+func (d dataView) open() bool { return d.table != "" }
+
+// offset is the row offset of the current page in the full result.
+func (d dataView) offset() int { return d.page * dataPageSize }
+
+// pageCount is how many pages the count implies; 0 when unknown.
+func (d dataView) pageCount() int {
+	if !d.hasTotal {
+		return 0
+	}
+	if d.total <= 0 {
+		return 1
+	}
+	return int((d.total + dataPageSize - 1) / dataPageSize)
+}
+
+// sortOn returns the sort direction for a column name, if it is the one
+// being sorted on.
+func (d dataView) sortOn(name string) (desc, ok bool) {
+	if d.sort == nil || d.sort.Column != name {
+		return false, false
+	}
+	return d.sort.Desc, true
+}
+
+// clampCursor keeps the cell cursor inside the page after it changed
+// shape (new page, fewer columns, empty result).
+func (d *dataView) clampCursor() {
+	if d.row >= len(d.rows) {
+		d.row = len(d.rows) - 1
+	}
+	if d.row < 0 {
+		d.row = 0
+	}
+	if d.col >= len(d.cols) {
+		d.col = len(d.cols) - 1
+	}
+	if d.col < 0 {
+		d.col = 0
+	}
+}
+
+// cell returns the value under the cursor.
+func (d dataView) cell() (any, bool) {
+	if d.row < 0 || d.row >= len(d.rows) {
+		return nil, false
+	}
+	if d.col < 0 || d.col >= len(d.rows[d.row]) {
+		return nil, false
+	}
+	return d.rows[d.row][d.col], true
+}
+
+// ---------- messages ----------
+
+// pageLoadedMsg carries the result of one page query.
+type pageLoadedMsg struct {
+	req    int
+	conn   string
+	table  string
+	result *db.ResultSet
+	err    error
+}
+
+// rowCountMsg carries the COUNT(*) that runs alongside the page query.
+type rowCountMsg struct {
+	req   int
+	conn  string
+	table string
+	total int64
+	err   error
+}
+
+// ---------- commands ----------
+
+func loadPageCmd(drv db.Driver, d dataView, req int) tea.Cmd {
+	if drv == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+		rs, err := drv.QueryPage(ctx, d.database, d.table, d.filter, d.sort, dataPageSize, d.offset())
+		return pageLoadedMsg{req: req, conn: d.conn, table: d.table, result: rs, err: err}
+	}
+}
+
+func countRowsCmd(drv db.Driver, d dataView, req int) tea.Cmd {
+	if drv == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+		n, err := drv.CountRows(ctx, d.database, d.table, d.filter)
+		return rowCountMsg{req: req, conn: d.conn, table: d.table, total: n, err: err}
+	}
+}
+
+// ---------- model wiring ----------
+
+// openTable starts browsing a relation from its first page. Filter and
+// sort belong to the relation that was open, so they do not carry over.
+func (m *Model) openTable(name string) tea.Cmd {
+	m.table = name
+	if m.driver == nil {
+		m.data = dataView{}
+		return logCmd("-- open %s skipped: not connected", name)
+	}
+	m.data = dataView{
+		conn:     m.active,
+		database: m.database,
+		table:    name,
+		req:      m.data.req,
+	}
+	return m.reloadPage()
+}
+
+// reloadPage re-runs the page query and the count for the current
+// filter/sort/page, and logs the exact SQL both of them execute.
+func (m *Model) reloadPage() tea.Cmd {
+	if m.driver == nil || !m.data.open() {
+		return nil
+	}
+	m.data.req++
+	m.data.loading = true
+	m.data.err = ""
+	d := m.data
+	dialect := m.driver.Dialect()
+
+	pageSQL := db.PageSQL(dialect, d.database, d.table, d.filter, d.sort, dataPageSize, d.offset())
+	countSQL := db.CountSQL(dialect, d.database, d.table, d.filter)
+
+	var cmds []tea.Cmd
+	// The warning goes first so it is not lost above the statement it
+	// is about.
+	if d.filter != nil && d.filter.Verbatim {
+		cmds = append(cmds, logCmd(
+			"-- WARNING: filter %q could not be parameterized — appended verbatim", d.filter.Raw))
+	}
+	cmds = append(cmds,
+		logCmd("%s", sqlLogLine(pageSQL, d.filter)),
+		logCmd("%s", sqlLogLine(countSQL, d.filter)),
+		func() tea.Msg { return historyEntryMsg{statement: pageSQL + ";"} },
+		loadPageCmd(m.driver, d, m.data.req),
+		countRowsCmd(m.driver, d, m.data.req),
+	)
+	return tea.Batch(cmds...)
+}
+
+// sqlLogLine renders a statement for the command log, with its bound
+// arguments spelled out after it.
+func sqlLogLine(query string, f *db.Filter) string {
+	if f == nil || len(f.Args) == 0 {
+		return query + ";"
+	}
+	return fmt.Sprintf("%s;  -- args %v", query, f.Args)
+}
+
+// fresh reports whether a reply still belongs to the page on screen.
+func (m Model) fresh(req int, conn, table string) bool {
+	return req == m.data.req && conn == m.active && table == m.data.table
+}
+
+// setDataFilter applies a new WHERE fragment and returns to page one.
+// An empty fragment clears the filter.
+func (m *Model) setDataFilter(raw string) tea.Cmd {
+	if !m.data.open() || m.driver == nil {
+		return nil
+	}
+	m.data.filter = db.ParseFilter(m.driver.Dialect(), raw)
+	m.data.page = 0
+	m.data.row = 0
+	return m.reloadPage()
+}
+
+// toggleSort cycles the column under the cursor through ASC, DESC and
+// unsorted. The filter is untouched, so the two compose.
+func (m *Model) toggleSort() tea.Cmd {
+	if !m.data.open() || m.data.col >= len(m.data.cols) {
+		return nil
+	}
+	name := m.data.cols[m.data.col].Name
+	switch {
+	case m.data.sort == nil || m.data.sort.Column != name:
+		m.data.sort = &db.Sort{Column: name}
+	case !m.data.sort.Desc:
+		m.data.sort = &db.Sort{Column: name, Desc: true}
+	default:
+		m.data.sort = nil
+	}
+	// A different ordering makes the old offset meaningless.
+	m.data.page = 0
+	m.data.row = 0
+	return m.reloadPage()
+}
+
+// turnPage moves by whole pages. It refuses to walk off either end so a
+// mistyped page key cannot leave the grid on an empty page.
+func (m *Model) turnPage(delta int) tea.Cmd {
+	if !m.data.open() {
+		return nil
+	}
+	next := m.data.page + delta
+	if next < 0 {
+		return nil
+	}
+	if next > m.data.page {
+		if m.data.hasTotal && next*dataPageSize >= int(m.data.total) {
+			return logCmd("-- already on the last page")
+		}
+		if !m.data.hasTotal && len(m.data.rows) < dataPageSize {
+			return logCmd("-- already on the last page")
+		}
+	}
+	if next == m.data.page {
+		return nil
+	}
+	m.data.page = next
+	m.data.row = 0
+	return m.reloadPage()
+}
+
+// updateData is the key handler of the focused main view. It runs in
+// place of updateFocused, so navigation keys mean cells here.
+func (m Model) updateData(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	k := m.keys
+	switch {
+	case key.Matches(msg, k.Down):
+		m.data.row++
+		m.data.clampCursor()
+		return m, nil
+	case key.Matches(msg, k.Up):
+		m.data.row--
+		m.data.clampCursor()
+		return m, nil
+	case key.Matches(msg, k.Back):
+		m.focusBack()
+		return m, nil
+	case key.Matches(msg, k.Enter):
+		// enter re-runs the page: the relation is already open, so the
+		// only thing left to drill into is fresh data.
+		cmd := m.reloadPage()
+		return m, cmd
+	case key.Matches(msg, k.Actions):
+		m.modal = m.actionsMenu()
+		return m, nil
+	}
+	for _, a := range k.panelActions(panelMain) {
+		if key.Matches(msg, a.binding) {
+			return m.runAction(a.id)
+		}
+	}
+	return m, nil
+}
+
+// focusBack pops the focus stack, the same way `esc` does in a panel.
+func (m *Model) focusBack() {
+	if n := len(m.prev); n > 0 {
+		back := m.prev[n-1]
+		m.prev = m.prev[:n-1]
+		m.focus = back
+		return
+	}
+	m.focus = panelTables
+}
+
+// dataActions handles the main view's context actions. It is called
+// from runAction so a key press and the `a` menu share one path.
+func (m Model) dataActions(id actionID) (Model, tea.Cmd, bool) {
+	switch id {
+	case actColLeft:
+		m.data.col--
+		m.data.clampCursor()
+	case actColRight:
+		m.data.col++
+		m.data.clampCursor()
+	case actNextPage:
+		cmd := m.turnPage(1)
+		return m, cmd, true
+	case actPrevPage:
+		cmd := m.turnPage(-1)
+		return m, cmd, true
+	case actSortColumn:
+		cmd := m.toggleSort()
+		return m, cmd, true
+	case actWhereFilter:
+		cur := ""
+		if m.data.filter != nil {
+			cur = m.data.filter.Raw
+		}
+		m.modal = newPromptModal(
+			"Filter rows — WHERE",
+			"id > 100 AND name LIKE 'a%'",
+			cur,
+			func(mm *Model, value string) tea.Cmd { return mm.setDataFilter(value) },
+		)
+	case actViewCell:
+		v, ok := m.data.cell()
+		if !ok {
+			return m, nil, true
+		}
+		name := ""
+		if m.data.col < len(m.data.cols) {
+			name = m.data.cols[m.data.col].Name
+		}
+		m.modal = newCellModal(name, v)
+	default:
+		return m, nil, false
+	}
+	return m, nil, true
+}

--- a/internal/ui/data_test.go
+++ b/internal/ui/data_test.go
@@ -1,0 +1,443 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/db"
+)
+
+// gridRows is deliberately more than two pages, so paging has somewhere
+// to go and the last page is a partial one.
+const gridRows = 250
+
+// dataBrowsing returns a model with the `grid` fixture table open in the
+// main view. The fixture has a NULL column, a JSON column and a column
+// wide enough to force truncation.
+func dataBrowsing(t *testing.T) Model {
+	t.Helper()
+	m := browsing(t)
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`DROP TABLE IF EXISTS grid`,
+		`CREATE TABLE grid (id INTEGER PRIMARY KEY, name TEXT, note TEXT, payload TEXT)`,
+		`INSERT INTO grid (id, name, note, payload)
+		 WITH RECURSIVE seq(n) AS (
+			SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < 250
+		 )
+		 SELECT n, 'name-' || n, NULL,
+		        '{"n":' || n || ',"label":"a rather long payload value for column truncation"}'
+		 FROM seq`,
+	} {
+		if _, err := m.driver.Exec(ctx, stmt); err != nil {
+			t.Fatalf("fixture %q: %v", stmt, err)
+		}
+	}
+	m = send(t, m, press('3'), press('R'))
+	if !m.panels[panelTables].selectByName("grid") {
+		t.Fatalf("fixture table not listed: %v", m.panels[panelTables].items)
+	}
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if m.focus != panelMain {
+		t.Fatalf("focus = %v, want the data grid", m.focus)
+	}
+	return m
+}
+
+// ctrl builds the KeyPressMsg for a control chord.
+func ctrl(r rune) tea.KeyPressMsg {
+	return tea.KeyPressMsg{Code: r, Mod: tea.ModCtrl}
+}
+
+// Opening a relation fetches exactly one page, whatever the table's
+// size, and reports the total separately.
+func TestOpenTableFetchesOnePage(t *testing.T) {
+	m := dataBrowsing(t)
+	if got := len(m.data.rows); got != dataPageSize {
+		t.Fatalf("rows in memory = %d, want %d", got, dataPageSize)
+	}
+	if !m.data.hasTotal || m.data.total != gridRows {
+		t.Fatalf("total = %d (known=%v), want %d", m.data.total, m.data.hasTotal, gridRows)
+	}
+	if got := len(m.data.cols); got != 4 {
+		t.Fatalf("columns = %d, want 4", got)
+	}
+	if !logContains(m, "LIMIT 100 OFFSET 0") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+}
+
+// The grid shows the header, the types, the values, a dim NULL and a
+// status line naming the page.
+func TestGridRendersHeaderRowsAndStatus(t *testing.T) {
+	m := dataBrowsing(t)
+	out := m.View().Content
+	for _, want := range []string{"id", "name", "payload", "name-1", nullText, "rows 1–100 of ~250", "(page 1/3)"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("view is missing %q", want)
+		}
+	}
+}
+
+// Paging moves by whole pages, keeps to the ends, and asks the server
+// for the matching OFFSET.
+func TestPagingWalksAndClamps(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, ctrl('f'))
+	if m.data.page != 1 {
+		t.Fatalf("page = %d, want 1", m.data.page)
+	}
+	if !logContains(m, "LIMIT 100 OFFSET 100") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	if !strings.Contains(m.View().Content, "rows 101–200 of ~250") {
+		t.Fatal("status line does not follow the page")
+	}
+
+	// Last page is partial.
+	m = send(t, m, ctrl('f'))
+	if got := len(m.data.rows); got != 50 {
+		t.Fatalf("last page rows = %d, want 50", got)
+	}
+	// And there is nothing past it.
+	m = send(t, m, ctrl('f'))
+	if m.data.page != 2 {
+		t.Fatalf("page = %d, want to stop at the last page", m.data.page)
+	}
+
+	m = send(t, m, special(tea.KeyPgUp, 0), special(tea.KeyPgUp, 0), special(tea.KeyPgUp, 0))
+	if m.data.page != 0 {
+		t.Fatalf("page = %d, want to stop at the first page", m.data.page)
+	}
+}
+
+// `s` cycles the column under the cursor through ASC, DESC and back to
+// unsorted, and the ordering reaches the query.
+func TestSortCyclesAndReachesTheQuery(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('l')) // cursor onto `name`
+	if m.data.col != 1 {
+		t.Fatalf("column cursor = %d, want 1", m.data.col)
+	}
+
+	m = send(t, m, press('s'))
+	if m.data.sort == nil || m.data.sort.Column != "name" || m.data.sort.Desc {
+		t.Fatalf("sort = %+v, want name ASC", m.data.sort)
+	}
+	if !logContains(m, `ORDER BY "name" ASC`) {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	// Text ordering, so name-1 sorts before name-10 and name-2.
+	if got := m.data.rows[0][1]; got != "name-1" {
+		t.Fatalf("first row = %v, want name-1", got)
+	}
+	if !strings.Contains(m.View().Content, "▲") {
+		t.Error("ascending sort is not marked in the header")
+	}
+
+	m = send(t, m, press('s'))
+	if m.data.sort == nil || !m.data.sort.Desc {
+		t.Fatalf("sort = %+v, want name DESC", m.data.sort)
+	}
+	if !logContains(m, `ORDER BY "name" DESC`) {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	if got := m.data.rows[0][1]; got != "name-99" {
+		t.Fatalf("first row = %v, want name-99", got)
+	}
+
+	m = send(t, m, press('s'))
+	if m.data.sort != nil {
+		t.Fatalf("sort = %+v, want the third press to clear it", m.data.sort)
+	}
+}
+
+// `f` takes a WHERE fragment, binds its value, and the filter then
+// survives both paging and a sort change.
+func TestFilterIsBoundAndComposesWithSortAndPaging(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('f'))
+	p, ok := m.modal.(*promptModal)
+	if !ok {
+		t.Fatalf("f opened %T, want the WHERE prompt", m.modal)
+	}
+	p.input.SetValue("id > 100")
+	m = send(t, m, special(tea.KeyEnter, 0))
+
+	if m.modal != nil {
+		t.Fatal("prompt stayed open")
+	}
+	if m.data.filter == nil || m.data.filter.Verbatim {
+		t.Fatalf("filter = %+v, want a parameterized one", m.data.filter)
+	}
+	if !logContains(m, `WHERE "id" > ?`) || !logContains(m, "-- args [100]") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	if m.data.total != gridRows-100 {
+		t.Fatalf("total = %d, want the filtered count %d", m.data.total, gridRows-100)
+	}
+
+	// Paging keeps the filter …
+	m = send(t, m, ctrl('f'))
+	if m.data.filter == nil || m.data.filter.Raw != "id > 100" {
+		t.Fatalf("filter lost across a page turn: %+v", m.data.filter)
+	}
+	if !logContains(m, `WHERE "id" > ? LIMIT 100 OFFSET 100`) {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+
+	// … and so does sorting, which also returns to the first page.
+	m = send(t, m, press('s'))
+	if m.data.filter == nil || m.data.filter.Raw != "id > 100" {
+		t.Fatalf("filter lost across a sort: %+v", m.data.filter)
+	}
+	if m.data.page != 0 {
+		t.Fatalf("page = %d, want a sort to return to the first page", m.data.page)
+	}
+	if !logContains(m, `WHERE "id" > ? ORDER BY "id" ASC LIMIT 100 OFFSET 0`) {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+
+	// An empty fragment clears it.
+	m = send(t, m, press('f'))
+	m.modal.(*promptModal).input.SetValue("")
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if m.data.filter != nil {
+		t.Fatalf("filter = %+v, want it cleared", m.data.filter)
+	}
+}
+
+// A fragment the parser cannot take apart still runs, but the command
+// log and the status line both say it was not parameterized.
+func TestVerbatimFilterWarns(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('f'))
+	m.modal.(*promptModal).input.SetValue("id IN (1,2,3)")
+	m = send(t, m, special(tea.KeyEnter, 0))
+
+	if m.data.filter == nil || !m.data.filter.Verbatim {
+		t.Fatalf("filter = %+v, want a verbatim one", m.data.filter)
+	}
+	if !logContains(m, "WARNING") || !logContains(m, "could not be parameterized") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	if len(m.data.rows) != 3 {
+		t.Fatalf("rows = %d, want the 3 the fragment selects", len(m.data.rows))
+	}
+	if !strings.Contains(m.View().Content, "where (verbatim)") {
+		t.Error("the grid does not flag the verbatim filter")
+	}
+}
+
+// A bad fragment leaves the previous page on screen and reports why.
+func TestBrokenFilterKeepsThePageAndReports(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('f'))
+	m.modal.(*promptModal).input.SetValue("no_such_column IN (1, 2)")
+	m = send(t, m, special(tea.KeyEnter, 0))
+
+	if len(m.data.rows) != dataPageSize {
+		t.Fatalf("rows = %d, want the previous page to survive", len(m.data.rows))
+	}
+	if m.data.err == "" {
+		t.Fatal("the grid does not know the query failed")
+	}
+	if !logContains(m, "FAILED") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	if m.data.loading {
+		t.Fatal("loading flag survived the error")
+	}
+}
+
+// `h`/`l` walk the cell cursor and clamp at both ends; `j`/`k` walk rows.
+func TestCellCursorMovesAndClamps(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('l'), press('l'), press('l'), press('l'), press('l'))
+	if got := m.data.col; got != len(m.data.cols)-1 {
+		t.Fatalf("column = %d, want it clamped to %d", got, len(m.data.cols)-1)
+	}
+	m = send(t, m, press('h'), press('h'), press('h'), press('h'), press('h'))
+	if m.data.col != 0 {
+		t.Fatalf("column = %d, want 0", m.data.col)
+	}
+	m = send(t, m, press('j'), press('j'))
+	if m.data.row != 2 {
+		t.Fatalf("row = %d, want 2", m.data.row)
+	}
+	m = send(t, m, press('k'), press('k'), press('k'), press('k'))
+	if m.data.row != 0 {
+		t.Fatalf("row = %d, want 0", m.data.row)
+	}
+}
+
+// `v` shows the untruncated value, pretty-printing JSON.
+func TestViewCellPrettyPrintsJSON(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('l'), press('l'), press('l'), press('v')) // payload column
+	c, ok := m.modal.(*cellModal)
+	if !ok {
+		t.Fatalf("v opened %T, want the cell modal", m.modal)
+	}
+	if len(c.lines) < 3 {
+		t.Fatalf("cell body = %v, want indented JSON", c.lines)
+	}
+	if !strings.Contains(c.title, "json") {
+		t.Errorf("title = %q, want it to mention json", c.title)
+	}
+	body := strings.Join(c.lines, "\n")
+	if !strings.Contains(body, `"label"`) || !strings.Contains(body, "truncation") {
+		t.Errorf("cell body does not hold the whole value: %q", body)
+	}
+	m = send(t, m, special(tea.KeyEscape, 0))
+	if m.modal != nil {
+		t.Fatal("esc did not close the cell modal")
+	}
+}
+
+// A NULL cell reads as NULL rather than as an empty popup.
+func TestViewCellShowsNull(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('l'), press('l'), press('v')) // note column, all NULL
+	c, ok := m.modal.(*cellModal)
+	if !ok {
+		t.Fatalf("v opened %T, want the cell modal", m.modal)
+	}
+	if len(c.lines) != 1 || c.lines[0] != nullText {
+		t.Fatalf("cell body = %v, want [%s]", c.lines, nullText)
+	}
+}
+
+// A wide table scrolls sideways: the window follows the cursor and the
+// grid says which columns are on screen.
+func TestWideTableScrollsHorizontally(t *testing.T) {
+	m := dataBrowsing(t)
+	// Narrow enough that four columns cannot share the main view.
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
+	m = next.(Model)
+
+	cols := m.buildGrid()
+	start, end := columnWindow(cols, 0, 30)
+	if start != 0 || end >= len(cols) {
+		t.Fatalf("window at the first column = [%d,%d), want a partial window from 0", start, end)
+	}
+	lastStart, lastEnd := columnWindow(cols, len(cols)-1, 30)
+	if len(cols)-1 < lastStart || len(cols)-1 >= lastEnd {
+		t.Fatalf("window [%d,%d) does not contain the cursor column %d", lastStart, lastEnd, len(cols)-1)
+	}
+	if lastStart == 0 {
+		t.Fatal("window did not scroll to reach the last column")
+	}
+
+	m = send(t, m, press('l'), press('l'), press('l'))
+	if out := m.View().Content; !strings.Contains(out, "columns ") {
+		t.Error("the grid does not report the visible column range")
+	}
+}
+
+// The grid survives every terminal size the shell claims to support.
+func TestGridRendersAtManySizes(t *testing.T) {
+	m := dataBrowsing(t)
+	for _, size := range [][2]int{{60, 18}, {80, 24}, {200, 60}, {61, 19}} {
+		for _, mode := range []screenMode{screenNormal, screenHalf, screenFull} {
+			next, _ := m.Update(tea.WindowSizeMsg{Width: size[0], Height: size[1]})
+			m = next.(Model)
+			m.screen = mode
+			if out := m.View().Content; out == "" {
+				t.Fatalf("%dx%d mode %v rendered nothing", size[0], size[1], mode)
+			}
+		}
+	}
+}
+
+// A reply for a query the user has already moved past is dropped.
+func TestStalePageReplyIsIgnored(t *testing.T) {
+	m := dataBrowsing(t)
+	before := len(m.data.rows)
+	m = send(t, m, pageLoadedMsg{
+		req:    m.data.req - 1,
+		conn:   m.active,
+		table:  m.data.table,
+		result: &db.ResultSet{Columns: []db.Column{{Name: "ghost"}}, Rows: [][]any{{1}}},
+	})
+	if len(m.data.rows) != before || len(m.data.cols) == 1 {
+		t.Fatal("a stale page reply landed")
+	}
+	m = send(t, m, rowCountMsg{req: m.data.req, conn: "other-connection", table: m.data.table, total: 7})
+	if m.data.total != gridRows {
+		t.Fatalf("total = %d, want the stale count dropped", m.data.total)
+	}
+}
+
+// With a relation open the grid joins the tab cycle after [4]; without
+// one, tab skips it.
+func TestTabCycleIncludesTheGridWhenOpen(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('4'), special(tea.KeyTab, 0))
+	if m.focus != panelMain {
+		t.Fatalf("focus = %v, want the grid after [4]", m.focus)
+	}
+	m = send(t, m, special(tea.KeyTab, 0))
+	if m.focus != panelConnections {
+		t.Fatalf("focus = %v, want to wrap to [1]", m.focus)
+	}
+	m = send(t, m, special(tea.KeyTab, tea.ModShift))
+	if m.focus != panelMain {
+		t.Fatalf("shift+tab: focus = %v, want the grid", m.focus)
+	}
+
+	m.data = dataView{}
+	m.focus = panelHistory
+	m = send(t, m, special(tea.KeyTab, 0))
+	if m.focus != panelConnections {
+		t.Fatalf("focus = %v, want tab to skip a closed grid", m.focus)
+	}
+}
+
+// esc leaves the grid for the panel that opened it, and switching
+// namespaces closes the page altogether.
+func TestEscLeavesGridAndDatabaseSwitchClosesIt(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, special(tea.KeyEscape, 0))
+	if m.focus != panelTables {
+		t.Fatalf("focus = %v, want %v", m.focus, panelTables)
+	}
+	if !m.data.open() {
+		t.Fatal("esc closed the page instead of only moving focus")
+	}
+
+	m = send(t, m, press('2'), special(tea.KeyEnter, 0))
+	if m.data.open() {
+		t.Fatal("the page survived a namespace switch")
+	}
+}
+
+// Opening a second relation starts clean rather than carrying the
+// previous one's filter and sort over.
+func TestOpeningAnotherTableResetsQueryShape(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('f'))
+	m.modal.(*promptModal).input.SetValue("id > 100")
+	m = send(t, m, special(tea.KeyEnter, 0), press('s'))
+	if m.data.filter == nil || m.data.sort == nil {
+		t.Fatal("fixture did not set up a filter and a sort")
+	}
+
+	if _, err := m.driver.Exec(context.Background(),
+		`CREATE TABLE IF NOT EXISTS other (id INTEGER)`); err != nil {
+		t.Fatal(err)
+	}
+	m = send(t, m, press('3'), press('R'))
+	m.panels[panelTables].selectByName("other")
+	m = send(t, m, special(tea.KeyEnter, 0))
+
+	if m.data.table != "other" {
+		t.Fatalf("table = %q, want other", m.data.table)
+	}
+	if m.data.filter != nil || m.data.sort != nil || m.data.page != 0 {
+		t.Fatalf("query shape carried over: %+v", m.data)
+	}
+}

--- a/internal/ui/datagrid.go
+++ b/internal/ui/datagrid.go
@@ -1,0 +1,307 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"lazysql/internal/db"
+)
+
+// Grid geometry. Columns are sized to their content within these
+// bounds; anything wider is truncated with an ellipsis and can still be
+// read in full with `v`.
+const (
+	minColWidth = 4
+	maxColWidth = 32
+	colGap      = 1
+)
+
+// nullText is how SQL NULL reads in the grid. It is styled dim so it
+// cannot be confused with the string "NULL".
+const nullText = "NULL"
+
+// gridColumn is one rendered column: its header, its type and the
+// already-formatted cells of the page under it.
+type gridColumn struct {
+	header string // name plus the sort marker, if any
+	typ    string
+	width  int
+	cells  []string
+	nulls  []bool
+}
+
+// buildGrid formats the whole page once so column widths, the header
+// and every row agree on the same strings.
+func (m Model) buildGrid() []gridColumn {
+	d := m.data
+	cols := make([]gridColumn, len(d.cols))
+	for i, c := range d.cols {
+		header := c.Name
+		if desc, ok := d.sortOn(c.Name); ok {
+			if desc {
+				header += " ▼"
+			} else {
+				header += " ▲"
+			}
+		}
+		g := gridColumn{
+			header: header,
+			typ:    strings.ToLower(c.DataType),
+			cells:  make([]string, len(d.rows)),
+			nulls:  make([]bool, len(d.rows)),
+			width:  maxInt(lipgloss.Width(header), lipgloss.Width(c.DataType)),
+		}
+		for r, row := range d.rows {
+			var v any
+			if i < len(row) {
+				v = row[i]
+			}
+			g.nulls[r] = v == nil
+			g.cells[r] = flatten(db.FormatValue(v, nullText))
+			if w := lipgloss.Width(g.cells[r]); w > g.width {
+				g.width = w
+			}
+		}
+		if g.width < minColWidth {
+			g.width = minColWidth
+		}
+		if g.width > maxColWidth {
+			g.width = maxColWidth
+		}
+		cols[i] = g
+	}
+	return cols
+}
+
+// flatten collapses whitespace that would otherwise break the row into
+// several lines.
+func flatten(s string) string {
+	if !strings.ContainsAny(s, "\n\r\t") {
+		return s
+	}
+	return strings.Join(strings.Fields(strings.NewReplacer("\n", " ", "\r", " ", "\t", " ").Replace(s)), " ")
+}
+
+// columnWindow picks the slice of columns that fits in w cells while
+// keeping the cursor column visible. The window is derived from the
+// cursor rather than remembered, so it survives a resize: the cursor
+// stays put and the window re-packs around it.
+func columnWindow(cols []gridColumn, cursor, w int) (start, end int) {
+	if len(cols) == 0 {
+		return 0, 0
+	}
+	if cursor < 0 {
+		cursor = 0
+	}
+	for start = 0; start <= cursor; start++ {
+		total := 0
+		for end = start; end < len(cols); end++ {
+			need := cols[end].width
+			if end > start {
+				need += colGap
+			}
+			if total+need > w {
+				break
+			}
+			total += need
+		}
+		if end == start {
+			end = start + 1 // never render zero columns
+		}
+		if cursor < end {
+			return start, end
+		}
+	}
+	return cursor, cursor + 1
+}
+
+// rowWindow keeps the cursor row on screen: the page is anchored at the
+// top until the cursor passes the last visible row, then it follows.
+func rowWindow(n, cursor, rows int) (start, end int) {
+	if rows <= 0 || n == 0 {
+		return 0, 0
+	}
+	if cursor < rows {
+		start = 0
+	} else {
+		start = cursor - rows + 1
+	}
+	end = start + rows
+	if end > n {
+		end = n
+	}
+	return start, end
+}
+
+// dataContent renders the main view's Data tab into a w x h content box.
+func (m Model) dataContent(w, h int) string {
+	d := m.data
+	lines := []string{m.dataTitle(w)}
+
+	// header (2 lines) + status (1 line) + the title already written
+	bodyRows := h - 4
+	if bodyRows < 0 {
+		bodyRows = 0
+	}
+
+	switch {
+	case len(d.cols) == 0 && d.loading:
+		lines = append(lines, "", m.style.pending.Render("running query…"))
+	case d.err != "":
+		lines = append(lines, "", m.style.danger.Render(truncate(d.err, w)))
+	case len(d.cols) == 0:
+		lines = append(lines, "", m.style.muted.Render("no columns"))
+	default:
+		cols := m.buildGrid()
+		cs, ce := columnWindow(cols, d.col, w)
+		rs, re := rowWindow(len(d.rows), d.row, bodyRows)
+
+		lines = append(lines, m.gridHeader(cols[cs:ce], cs, w))
+		for r := rs; r < re; r++ {
+			lines = append(lines, m.gridRow(cols[cs:ce], cs, r, w))
+		}
+		if len(d.rows) == 0 {
+			lines = append(lines, m.style.muted.Render("no rows match"))
+		}
+		if cs > 0 || ce < len(cols) {
+			lines = append(lines, m.style.muted.Render(fmt.Sprintf(
+				"columns %d–%d of %d — h/l scrolls", cs+1, ce, len(cols))))
+		}
+	}
+
+	// The status line is pinned to the bottom of the box.
+	body := joinTruncated(lines, w, maxInt(h-1, 1))
+	pad := h - 1 - lipgloss.Height(body)
+	if pad > 0 {
+		body += strings.Repeat("\n", pad)
+	}
+	return body + "\n" + truncate(m.dataStatus(), w)
+}
+
+// dataTitle is the tab strip of the main view plus the relation and its
+// load state.
+func (m Model) dataTitle(w int) string {
+	title := m.style.titleFocused.Render("Data")
+	if m.focus != panelMain {
+		title = m.style.title.Render("Data")
+	}
+	line := title + m.style.muted.Render(" — "+displayDatabase(m.data.database)+".") + m.data.table
+	if m.data.loading {
+		line += " " + m.style.pending.Render("loading…")
+	}
+	return truncate(line, w)
+}
+
+// gridHeader renders the column names and, under them, their types.
+func (m Model) gridHeader(cols []gridColumn, first, w int) string {
+	var names, types strings.Builder
+	for i, c := range cols {
+		if i > 0 {
+			names.WriteString(strings.Repeat(" ", colGap))
+			types.WriteString(strings.Repeat(" ", colGap))
+		}
+		style := m.style.gridHeader
+		if first+i == m.data.col && m.focus == panelMain {
+			style = m.style.gridHeaderCursor
+		}
+		names.WriteString(style.Render(pad(truncate(c.header, c.width), c.width)))
+		types.WriteString(m.style.muted.Render(pad(truncate(c.typ, c.width), c.width)))
+	}
+	return truncate(names.String(), w) + "\n" + truncate(types.String(), w)
+}
+
+// gridRow renders one row of the page, tinting the cursor row and, more
+// strongly, the cursor cell.
+func (m Model) gridRow(cols []gridColumn, first, r, w int) string {
+	var b strings.Builder
+	onRow := r == m.data.row && m.focus == panelMain
+	for i, c := range cols {
+		if i > 0 {
+			gap := strings.Repeat(" ", colGap)
+			if onRow {
+				gap = m.style.rowCursor.Render(gap)
+			}
+			b.WriteString(gap)
+		}
+		text := ""
+		isNull := false
+		if r < len(c.cells) {
+			text, isNull = c.cells[r], c.nulls[r]
+		}
+		b.WriteString(m.cellStyle(onRow, first+i == m.data.col, isNull).
+			Render(pad(truncate(text, c.width), c.width)))
+	}
+	return truncate(b.String(), w)
+}
+
+// cellStyle picks the tint of one cell from the cursor position and
+// whether the value is NULL.
+func (m Model) cellStyle(onRow, onCol, isNull bool) lipgloss.Style {
+	style := lipgloss.NewStyle()
+	switch {
+	case onRow && onCol && m.focus == panelMain:
+		style = m.style.cellCursor
+	case onRow:
+		style = m.style.rowCursor
+	}
+	if isNull {
+		style = style.Foreground(colorMuted)
+	}
+	return style
+}
+
+// dataStatus is the bottom line: which rows of how many are on screen,
+// which page they are, and the filter and sort that produced them.
+func (m Model) dataStatus() string {
+	d := m.data
+	var parts []string
+
+	switch {
+	case len(d.rows) == 0 && d.hasTotal && d.total == 0:
+		parts = append(parts, "rows 0 of 0")
+	case len(d.rows) == 0:
+		parts = append(parts, "no rows")
+	default:
+		span := fmt.Sprintf("rows %d–%d", d.offset()+1, d.offset()+len(d.rows))
+		if d.hasTotal {
+			span += fmt.Sprintf(" of ~%d", d.total)
+		}
+		parts = append(parts, span)
+	}
+	page := fmt.Sprintf("(page %d", d.page+1)
+	if n := d.pageCount(); n > 0 {
+		page += fmt.Sprintf("/%d", n)
+	}
+	parts = append(parts, page+")")
+
+	line := m.style.muted.Render(strings.Join(parts, " "))
+	if d.sort != nil {
+		dir := "asc"
+		if d.sort.Desc {
+			dir = "desc"
+		}
+		line += m.style.keyHint.Render(fmt.Sprintf("  sort %s %s", d.sort.Column, dir))
+	}
+	if d.filter != nil {
+		style := m.style.keyHint
+		mark := "where "
+		if d.filter.Verbatim {
+			// Verbatim means the fragment was not parameterized; the
+			// grid says so as loudly as the command log does.
+			style = m.style.danger
+			mark = "where (verbatim) "
+		}
+		line += style.Render("  " + mark + d.filter.Raw)
+	}
+	return line
+}
+
+// pad right-pads s to w display cells.
+func pad(s string, w int) string {
+	if n := w - lipgloss.Width(s); n > 0 {
+		return s + strings.Repeat(" ", n)
+	}
+	return s
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -35,6 +35,15 @@ type keyMap struct {
 	ToggleTab      key.Binding
 	RunQuery       key.Binding
 	ClearHistory   key.Binding
+
+	// Data grid (the focusable main view).
+	ColLeft     key.Binding
+	ColRight    key.Binding
+	NextPage    key.Binding
+	PrevPage    key.Binding
+	SortColumn  key.Binding
+	WhereFilter key.Binding
+	ViewCell    key.Binding
 }
 
 func newKeyMap() keyMap {
@@ -64,6 +73,14 @@ func newKeyMap() keyMap {
 		ToggleTab:      key.NewBinding(key.WithKeys("[", "]"), key.WithHelp("[/]", "tables/views")),
 		RunQuery:       key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "run query")),
 		ClearHistory:   key.NewBinding(key.WithKeys("D"), key.WithHelp("D", "clear history")),
+
+		ColLeft:     key.NewBinding(key.WithKeys("h", "left"), key.WithHelp("h/←", "prev column")),
+		ColRight:    key.NewBinding(key.WithKeys("l", "right"), key.WithHelp("l/→", "next column")),
+		NextPage:    key.NewBinding(key.WithKeys("ctrl+f", "pgdown"), key.WithHelp("ctrl+f", "next page")),
+		PrevPage:    key.NewBinding(key.WithKeys("ctrl+b", "pgup"), key.WithHelp("ctrl+b", "prev page")),
+		SortColumn:  key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "sort column")),
+		WhereFilter: key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "where filter")),
+		ViewCell:    key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "view cell")),
 	}
 }
 
@@ -92,6 +109,13 @@ const (
 	actToggleTab
 	actRunQuery
 	actClearHistory
+	actColLeft
+	actColRight
+	actNextPage
+	actPrevPage
+	actSortColumn
+	actWhereFilter
+	actViewCell
 )
 
 // action pairs a dispatchable action with the binding that documents it.
@@ -127,6 +151,17 @@ func (k keyMap) panelActions(id panelID) []action {
 		return []action{
 			{actRunQuery, k.RunQuery},
 			{actClearHistory, k.ClearHistory},
+		}
+	case panelMain:
+		return []action{
+			{actColLeft, k.ColLeft},
+			{actColRight, k.ColRight},
+			{actNextPage, k.NextPage},
+			{actPrevPage, k.PrevPage},
+			{actSortColumn, k.SortColumn},
+			{actWhereFilter, k.WhereFilter},
+			{actViewCell, k.ViewCell},
+			{actRefresh, k.Refresh},
 		}
 	}
 	return nil

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -9,6 +11,8 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+
+	"lazysql/internal/db"
 )
 
 // modal is the interface every popup implements. While a modal is open the
@@ -193,6 +197,99 @@ func (p *promptModal) view(s styles, maxW, maxH int) string {
 		"",
 		s.muted.Render("enter submit · esc cancel"),
 	))
+}
+
+// ---------- cell ----------
+
+// cellModal shows one cell's full value, which the grid can only show
+// truncated. JSON is pretty-printed, because a JSON column is exactly
+// the case where the truncated grid text is useless.
+type cellModal struct {
+	title  string
+	lines  []string
+	offset int
+}
+
+func newCellModal(column string, value any) *cellModal {
+	title := "Cell"
+	if column != "" {
+		title = "Cell — " + column
+	}
+	text := db.FormatValue(value, nullText)
+	if value == nil {
+		text = nullText
+	} else if pretty, ok := prettyJSON(text); ok {
+		text = pretty
+		title += " (json)"
+	}
+	return &cellModal{title: title, lines: strings.Split(text, "\n")}
+}
+
+// prettyJSON re-indents s when it is a JSON object or array. Scalars
+// are left alone: re-indenting a bare number or string gains nothing.
+func prettyJSON(s string) (string, bool) {
+	trimmed := strings.TrimSpace(s)
+	if len(trimmed) == 0 || (trimmed[0] != '{' && trimmed[0] != '[') {
+		return "", false
+	}
+	var buf bytes.Buffer
+	if err := json.Indent(&buf, []byte(trimmed), "", "  "); err != nil {
+		return "", false
+	}
+	return buf.String(), true
+}
+
+func (c *cellModal) update(msg tea.KeyPressMsg, m *Model) (bool, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q", "enter", "v":
+		return true, nil
+	case "down", "j":
+		c.offset++
+	case "up", "k":
+		c.offset--
+	case "pgdown", "ctrl+f":
+		c.offset += 10
+	case "pgup", "ctrl+b":
+		c.offset -= 10
+	case "g", "home":
+		c.offset = 0
+	case "G", "end":
+		c.offset = len(c.lines)
+	}
+	return false, nil
+}
+
+func (c *cellModal) view(s styles, maxW, maxH int) string {
+	width := min(maxW-8, 80)
+	if width < 8 {
+		width = 8
+	}
+	rows := maxH - 6
+	if rows < 1 {
+		rows = 1
+	}
+	if rows > len(c.lines) {
+		rows = len(c.lines)
+	}
+	if maxOff := len(c.lines) - rows; c.offset > maxOff {
+		c.offset = maxOff
+	}
+	if c.offset < 0 {
+		c.offset = 0
+	}
+
+	var b strings.Builder
+	b.WriteString(s.modalTitle.Render(truncate(c.title, width)) + "\n\n")
+	for _, line := range c.lines[c.offset : c.offset+rows] {
+		b.WriteString(truncate(line, width) + "\n")
+	}
+	footer := "esc close"
+	if len(c.lines) > rows {
+		footer = fmt.Sprintf("lines %d–%d of %d · ↑/↓ scroll · esc close",
+			c.offset+1, c.offset+rows, len(c.lines))
+	}
+	b.WriteString("\n" + s.muted.Render(footer))
+	return s.modal.Render(b.String())
 }
 
 // ---------- help ----------

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -87,6 +87,9 @@ type Model struct {
 	tableTab  relationTab
 	table     string // the relation the main view is showing
 
+	// data is the main view's Data tab: one page of m.table.
+	data dataView
+
 	startupErr string
 
 	keys  keyMap
@@ -174,8 +177,12 @@ func (m *Model) renameConnState(oldName, newName string) {
 func (m *Model) resetBrowse() {
 	m.database = ""
 	m.table = ""
+	m.data = dataView{}
 	m.relations = nil
 	m.tableTab = tabTables
+	if m.focus == panelMain {
+		m.focus = panelTables
+	}
 	for _, id := range []panelID{panelDatabases, panelTables} {
 		p := m.panels[id]
 		p.loading = false
@@ -189,6 +196,12 @@ func (m *Model) resetBrowse() {
 // The panel keeps its old rows until the reply lands.
 func (m *Model) openDatabase(name string) tea.Cmd {
 	m.database = databaseArg(name)
+	// The open page belongs to the namespace we are leaving.
+	m.table = ""
+	m.data = dataView{}
+	if m.focus == panelMain {
+		m.focus = panelTables
+	}
 	p := m.panels[panelTables]
 	p.clearFilter()
 	if m.driver == nil {
@@ -225,6 +238,8 @@ func (m *Model) reloadFocused() tea.Cmd {
 			logCmd("-- reload tables of %s", displayDatabase(m.database)),
 			loadRelationsCmd(m.active, m.driver, m.database),
 		)
+	case panelMain:
+		return m.reloadPage()
 	}
 	return logCmd("-- refresh %s", panelTitles[m.focus])
 }
@@ -341,6 +356,35 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.refreshRelations()
 		return m, nil
 
+	case pageLoadedMsg:
+		if !m.fresh(msg.req, msg.conn, msg.table) {
+			return m, nil
+		}
+		m.data.loading = false
+		if msg.err != nil {
+			// The previous page stays on screen; the grid and the log
+			// both name the failure.
+			m.data.err = msg.err.Error()
+			return m, logCmd("-- select from %s FAILED: %v", msg.table, msg.err)
+		}
+		m.data.cols = msg.result.Columns
+		m.data.rows = msg.result.Rows
+		m.data.clampCursor()
+		return m, nil
+
+	case rowCountMsg:
+		if !m.fresh(msg.req, msg.conn, msg.table) {
+			return m, nil
+		}
+		if msg.err != nil {
+			// A missing count only costs the "of ~N" part of the status
+			// line, so it never blocks browsing.
+			m.data.hasTotal = false
+			return m, logCmd("-- count %s FAILED: %v", msg.table, msg.err)
+		}
+		m.data.total, m.data.hasTotal = msg.total, true
+		return m, nil
+
 	case connPersistedMsg:
 		if msg.err != nil {
 			return m, logCmd("-- %s %s FAILED: %v", msg.verb, msg.name, msg.err)
@@ -360,14 +404,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		// 2. An open `/` filter captures every printable key, so digits
 		// and `q` type into the pattern instead of jumping or quitting.
-		if m.panels[m.focus].filtering {
+		if m.focus < panelCount && m.panels[m.focus].filtering {
 			return m.updateFilter(msg)
 		}
 		// 3. Global keys.
 		if handled, mm, cmd := m.updateGlobal(msg); handled {
 			return mm, cmd
 		}
-		// 4. Focused panel.
+		// 4. The focused view: the data grid, or a side panel.
+		if m.focus == panelMain {
+			return m.updateData(msg)
+		}
 		return m.updateFocused(msg)
 	}
 	return m, nil
@@ -393,11 +440,11 @@ func (m Model) updateGlobal(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
 		return true, m, nil
 
 	case key.Matches(msg, k.NextPanel):
-		m.setFocus((m.focus + 1) % panelCount)
+		m.setFocus(m.cycleFocus(1))
 		return true, m, nil
 
 	case key.Matches(msg, k.PrevPanel):
-		m.setFocus((m.focus + panelCount - 1) % panelCount)
+		m.setFocus(m.cycleFocus(-1))
 		return true, m, nil
 
 	case key.Matches(msg, k.ScreenNext):
@@ -494,6 +541,10 @@ func (m Model) updateFilter(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 // runAction performs a context action. Both a key press and an entry in the
 // `a` actions menu reach the panel behaviour through here.
 func (m Model) runAction(id actionID) (Model, tea.Cmd) {
+	// The data grid's actions live with the grid.
+	if mm, cmd, handled := m.dataActions(id); handled {
+		return mm, cmd
+	}
 	switch id {
 	case actConnect:
 		return m.dialSelected(false)
@@ -606,15 +657,28 @@ func (m *Model) drillIn() tea.Cmd {
 	case panelDatabases:
 		return tea.Batch(logCmd("USE %s;", sel), m.openDatabase(sel), focusCmd(panelTables))
 	case panelTables:
-		// The data grid is a separate issue; for now the main view only
-		// records which relation was opened.
-		m.table = sel
-		stmt := fmt.Sprintf("SELECT * FROM %s LIMIT 100;", sel)
-		return tea.Batch(logCmd("%s", stmt), func() tea.Msg { return historyEntryMsg{statement: stmt} })
+		// Opening a relation loads its first page and hands focus to the
+		// grid; `esc` there comes straight back here.
+		return tea.Batch(m.openTable(sel), focusCmd(panelMain))
 	case panelHistory:
 		return logCmd("%s", sel)
 	}
 	return nil
+}
+
+// cycleFocus is the `tab` order: the four numbered panels, and the main
+// view too whenever a relation is open in it. Without an open relation
+// the grid has nothing to show, so tab skips it.
+func (m Model) cycleFocus(delta int) panelID {
+	n := int(panelCount)
+	if m.data.open() {
+		n++
+	}
+	cur := int(m.focus)
+	if cur >= n {
+		cur = int(panelTables)
+	}
+	return panelID(((cur+delta)%n + n) % n)
 }
 
 func (m *Model) setFocus(id panelID) {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -443,23 +444,33 @@ func TestActionsMenuDispatchesSameActionAsKey(t *testing.T) {
 }
 
 func TestDrillInLogsAndRecordsHistory(t *testing.T) {
-	// Start on [2] Databases: drilling in from [1] Connections opens a live
-	// connection, which the dedicated connect tests cover.
-	m := sized(120, 40)
-	m = send(t, m,
-		press('2'),
-		special(tea.KeyEnter, 0), // database -> tables
-		special(tea.KeyEnter, 0), // table -> select
-	)
+	// Drilling in from [1] Connections opens a live connection, which the
+	// dedicated connect tests cover; this one starts from a connected
+	// model and walks database -> table -> data.
+	m := browsing(t)
+	if _, err := m.driver.Exec(context.Background(),
+		`CREATE TABLE IF NOT EXISTS drill (id INTEGER)`); err != nil {
+		t.Fatal(err)
+	}
+	m = send(t, m, press('2'), special(tea.KeyEnter, 0)) // database -> tables
 	if m.focus != panelTables {
 		t.Fatalf("focus = %v, want %v", m.focus, panelTables)
+	}
+	m.panels[panelTables].selectByName("drill")
+	m = send(t, m, special(tea.KeyEnter, 0)) // table -> data grid
+
+	if m.focus != panelMain {
+		t.Fatalf("focus = %v, want the data grid", m.focus)
 	}
 	hist := m.panels[panelHistory].items
 	if len(hist) != 1 || !strings.HasPrefix(hist[0], "SELECT * FROM ") {
 		t.Fatalf("history = %v, want one SELECT entry", hist)
 	}
-	if len(m.commandLog) != 2 {
-		t.Fatalf("command log = %v, want 2 entries", m.commandLog)
+	if !logContains(m, `SELECT * FROM "drill" LIMIT 100 OFFSET 0;`) {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	if !logContains(m, `SELECT COUNT(*) FROM "drill";`) {
+		t.Fatalf("command log is missing the count: %v", m.commandLog)
 	}
 }
 
@@ -560,7 +571,7 @@ func TestRendersAtManySizes(t *testing.T) {
 // them must actually be handled.
 func TestOptionsBarAndHelpShareOneSource(t *testing.T) {
 	k := newKeyMap()
-	for id := panelID(0); id < panelCount; id++ {
+	for id := panelID(0); id <= panelMain; id++ {
 		helpKeys := map[string]bool{}
 		for _, group := range k.helpGroups(id) {
 			for _, b := range group {
@@ -583,7 +594,7 @@ func TestEveryDocumentedKeyIsBound(t *testing.T) {
 			global[ks] = true
 		}
 	}
-	for id := panelID(0); id < panelCount; id++ {
+	for id := panelID(0); id <= panelMain; id++ {
 		actions := map[string]bool{}
 		for _, a := range k.panelActions(id) {
 			for _, ks := range a.binding.Keys() {
@@ -608,7 +619,7 @@ func TestEveryDocumentedKeyIsBound(t *testing.T) {
 func TestPanelActionsDoNotShadowGlobalKeys(t *testing.T) {
 	k := newKeyMap()
 	globals := append(k.global(), k.navigation()...)
-	for id := panelID(0); id < panelCount; id++ {
+	for id := panelID(0); id <= panelMain; id++ {
 		for _, a := range k.panelActions(id) {
 			for _, g := range globals {
 				for _, gk := range g.Keys() {

--- a/internal/ui/panel.go
+++ b/internal/ui/panel.go
@@ -18,11 +18,18 @@ const (
 	panelCount
 )
 
-var panelTitles = [panelCount]string{
+// panelMain is the focusable main view. It is not a side panel — it has
+// no number, no entry in Model.panels and no slot in the side column —
+// but it takes focus like one so the keybinding table, the options bar,
+// the actions menu and `?` stay keyed by a single identifier.
+const panelMain = panelCount
+
+var panelTitles = [panelCount + 1]string{
 	"Connections",
 	"Databases",
 	"Tables",
 	"Query history",
+	"Data",
 }
 
 // itemStatus tints a row. The [1] Connections panel uses it to show which

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -31,6 +31,13 @@ type styles struct {
 	modalTitle lipgloss.Style
 	danger     lipgloss.Style
 	pending    lipgloss.Style
+
+	// Data grid. The row tint is deliberately weaker than the cell tint
+	// so the cell cursor stays readable inside the highlighted row.
+	gridHeader       lipgloss.Style
+	gridHeaderCursor lipgloss.Style
+	rowCursor        lipgloss.Style
+	cellCursor       lipgloss.Style
 }
 
 func newStyles() styles {
@@ -53,6 +60,11 @@ func newStyles() styles {
 		modalTitle: lipgloss.NewStyle().Bold(true).Foreground(colorGreen),
 		danger:     lipgloss.NewStyle().Foreground(colorRed),
 		pending:    lipgloss.NewStyle().Foreground(colorYellow),
+
+		gridHeader:       lipgloss.NewStyle().Bold(true),
+		gridHeaderCursor: lipgloss.NewStyle().Bold(true).Foreground(colorCyan),
+		rowCursor:        lipgloss.NewStyle().Background(lipgloss.Color("236")),
+		cellCursor:       lipgloss.NewStyle().Background(lipgloss.Color("240")).Bold(true),
 	}
 }
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -31,7 +31,11 @@ func (m Model) View() tea.View {
 	bodyH := m.height - 1 // options bar
 	var body string
 	if m.screen == screenFull {
-		body = m.renderPanel(m.focus, m.width, bodyH)
+		if m.focus == panelMain {
+			body = m.renderMainColumn(m.width, bodyH)
+		} else {
+			body = m.renderPanel(m.focus, m.width, bodyH)
+		}
 	} else {
 		sideW := m.width / 3
 		if sideW < 24 {
@@ -83,7 +87,10 @@ func (m Model) panelHeights(bodyH int) [panelCount]int {
 	var out [panelCount]int
 	const collapsed = 3 // top border + title + bottom border
 
-	if m.screen == screenHalf && bodyH >= collapsed*int(panelCount)+2 {
+	// Half mode expands the focused *side* panel. With the main view
+	// focused there is nothing in the column to expand, so it keeps the
+	// even split.
+	if m.screen == screenHalf && m.focus < panelCount && bodyH >= collapsed*int(panelCount)+2 {
 		for id := panelID(0); id < panelCount; id++ {
 			out[id] = collapsed
 		}
@@ -125,7 +132,11 @@ func (m Model) renderMainColumn(w, h int) string {
 	}
 	mainH := h - logH
 
-	main := m.style.blurredBorder.
+	border := m.style.blurredBorder
+	if m.focus == panelMain {
+		border = m.style.focusedBorder
+	}
+	main := border.
 		Width(w).Height(mainH).
 		Render(m.mainContent(maxInt(w-2, 1), maxInt(mainH-2, 1)))
 	if logH <= 0 {
@@ -134,11 +145,18 @@ func (m Model) renderMainColumn(w, h int) string {
 	return lipgloss.JoinVertical(lipgloss.Left, main, m.renderCommandLog(w, logH))
 }
 
-// mainContent is the placeholder detail view for the focused selection. The
-// result grid replaces it once the driver layer lands.
+// mainContent is the main view: the Data tab of the open relation, the
+// selected connection's settings, or — with nothing opened yet — a
+// summary of what the focused panel points at.
 func (m Model) mainContent(w, h int) string {
 	if m.focus == panelConnections {
 		return m.connectionDetail(w, h)
+	}
+	if m.data.open() {
+		return m.dataContent(w, h)
+	}
+	if m.focus >= panelCount {
+		return m.style.muted.Render("no relation open — pick one in [3] Tables")
 	}
 	sel := m.panels[m.focus].selected()
 	if sel == "" {

--- a/wiki/design/data-grid.md
+++ b/wiki/design/data-grid.md
@@ -1,0 +1,130 @@
+---
+type: Design Decision
+title: Paginated data grid with sorting and quick filter
+description: How the main view browses a relation one page at a time, how the cell cursor and the column window work, and why the quick filter is parsed before it reaches SQL.
+tags: [tui, db, main-view, pagination, sorting, filtering, security]
+generated:
+  by: claude-code/opus-5
+  at: 2026-08-09T00:00:00Z
+---
+
+# Data grid
+
+## Decision
+
+The main view's **Data** tab renders exactly one page of one relation.
+`dataView` (in `internal/ui/data.go`) holds that page plus everything
+that shaped the query behind it: `page`, `filter`, `sort`, the cell
+cursor `(row, col)`, and a `req` sequence number.
+
+### Only the page is fetched
+
+Opening a relation, turning a page, sorting and filtering all funnel
+through `Model.reloadPage`, which issues **two** independent commands:
+
+- `loadPageCmd` → `pageLoadedMsg` — `SELECT * … LIMIT 100 OFFSET n`
+- `countRowsCmd` → `rowCountMsg` — `SELECT COUNT(*) …` behind the same
+  filter
+
+The count is a separate round trip on purpose: the grid renders as soon
+as the page lands, and the status line grows its `of ~N` part later. A
+slow or failing count costs the total and nothing else — browsing keeps
+working. `dataPageSize` is 100, so a 100k-row table costs the same as a
+100-row one: the model never holds more than one page.
+
+Both replies carry `req` plus the connection and table they were started
+for. `Model.fresh` drops anything that no longer matches, so a page the
+user has already sorted or paged past cannot overwrite the current one.
+
+### Sort, filter and paging compose
+
+`filter` and `sort` live next to `page` in the same struct, and
+`reloadPage` always rebuilds the statement from all three. So a filter
+survives paging and sorting; a sort survives paging. Changing the filter
+or the sort resets `page` to 0, because an offset into a differently
+ordered or differently sized result means nothing.
+
+`s` cycles the column under the cursor ASC → DESC → unsorted, marked in
+the header with `▲`/`▼`.
+
+### Scroll windows are derived, not stored
+
+Both the visible row range and the visible column range are computed
+from the cell cursor at render time (`rowWindow`, `columnWindow`) rather
+than kept in the model. `View` has a value receiver, so a window stored
+during rendering would be thrown away anyway — and deriving it means a
+resize can never leave a stale offset behind. The rule is the usual one:
+anchored at the start until the cursor passes the last visible slot,
+then following the cursor.
+
+Column widths come from the *whole page*, not the visible rows, so
+scrolling vertically never makes the grid jitter sideways. Widths are
+clamped to `[4, 32]` cells and over-long cells are truncated with an
+ellipsis; `v` opens the untruncated value in a scrollable modal, which
+pretty-prints it when it is a JSON object or array.
+
+`NULL` renders as a dim `NULL`, which is what distinguishes it from the
+string `"NULL"`.
+
+### The main view is a focus target
+
+Focus is still a single `panelID`, but the enum gained
+`panelMain = panelCount`: a value that takes focus like a side panel yet
+has no number, no `Model.panels` entry and no slot in the side column.
+That keeps one keybinding table, one options bar and one `?` listing
+covering the grid too. `enter` on `[3] Tables` opens the relation and
+moves focus there; `esc` pops the focus stack straight back.
+
+Any code indexing `Model.panels` or `panelHeights` by focus has to guard
+`m.focus < panelCount` — half screen mode, for instance, expands the
+focused *side* panel and keeps the even split when the grid is focused.
+
+## Quick filter: parse first, interpolate last
+
+`f` prompts for a WHERE fragment. Interpolating that into the statement
+is the injection shape lazysql must not have, so `db.ParseFilter` first
+tries to take the fragment apart into a chain of
+`column <op> <literal>` terms joined by `AND`. What it recognises it
+rewrites: identifiers through `Dialect.QuoteIdent`, values into
+`Dialect.Placeholder(n)` with the value bound as a query parameter.
+
+Recognised: `= <> != > >= < <= LIKE NOT LIKE ILIKE` against a quoted
+string, integer, float or boolean, plus `IS [NOT] NULL`. Bare, double-
+quoted and backtick-quoted identifiers all work.
+
+Anything else — parentheses, `OR`, function calls, `IN`, `BETWEEN`,
+column-to-column comparisons, `= NULL`, an unterminated literal — is
+kept **verbatim**: it still runs, because a quick filter that refuses
+half of SQL is useless, but `Filter.Verbatim` is set and both the
+command log (`-- WARNING: filter … could not be parameterized`) and the
+grid's status line (`where (verbatim) …`) say so.
+
+`col = NULL` is deliberately *not* rewritten: it is never what the user
+means, and silently binding it would hide the mistake.
+
+## Command log
+
+`reloadPage` logs both statements it executes, with bound arguments
+spelled out after them (`… -- args [100]`), and records the page
+`SELECT` in `[4] Query history`. The verbatim warning is logged *before*
+the statement it is about, so it cannot scroll out of sight above it.
+
+## Consequences
+
+- Inline editing (a later issue) reuses `dataView.row/col` unchanged;
+  the cursor is model state precisely so it can.
+- `COUNT(*)` on a very large unindexed table can be slower than the page
+  query. It is asynchronous and its failure is non-fatal, but the status
+  line can lag behind the grid by a moment on such tables.
+- `Driver.QueryPage` takes a `*db.Filter` rather than a string, so the
+  parameterization decision is made once, in one place, and cannot be
+  bypassed by a caller assembling its own WHERE text.
+
+## See also
+
+- [catalog-browsing](catalog-browsing.md) — how the relation reaches the
+  grid in the first place.
+- [db-driver-abstraction](db-driver-abstraction.md) — the `Driver` and
+  `Dialect` interfaces this builds on.
+- [../reference/sqlite-double-quoted-strings](../reference/sqlite-double-quoted-strings.md)
+  — why a filter on a misspelled column silently matches nothing there.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -13,9 +13,11 @@ concept with YAML frontmatter. Concept IDs are bundle-relative paths without
 - [design/connection-secrets](design/connection-secrets.md) — Design Decision — connections in TOML, passwords only in the OS keyring or a per-connect prompt.
 - [design/connection-form-modal](design/connection-form-modal.md) — Design Decision — one reusable multi-field modal with engine-driven field visibility.
 - [design/catalog-browsing](design/catalog-browsing.md) — Design Decision — async catalog loads, inline fuzzy filter, tables/views sub-tabs, pseudo-database for single-namespace engines.
+- [design/data-grid](design/data-grid.md) — Design Decision — one-page-at-a-time main view, derived scroll windows, the `panelMain` focus target, and the parse-first quick filter.
 
 ## reference
 
 - [reference/lipgloss-v2-sizing](reference/lipgloss-v2-sizing.md) — Reference — `Style.Width`/`Height` in lipgloss v2 are total block size, not content size.
 - [reference/dsn-formats](reference/dsn-formats.md) — Dialect Note — per-engine DSN shapes and their escaping/URI quirks.
 - [reference/dialect-introspection-quirks](reference/dialect-introspection-quirks.md) — Dialect Note — engine-specific introspection gotchas (PRAGMA placeholders, duckdb_* functions, pg_index, SHOW CREATE TABLE).
+- [reference/sqlite-double-quoted-strings](reference/sqlite-double-quoted-strings.md) — Dialect Note — SQLite reads an unresolvable double-quoted identifier as a string literal, so a filter on a misspelled column matches nothing instead of erroring.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -48,3 +48,20 @@ Chronological history of wiki changes, newest last.
   [reference/dialect-introspection-quirks](reference/dialect-introspection-quirks.md)
   for the `listTables` → `listRelations` dialect change and the per-engine
   spellings of the table/view kind column.
+- Added [design/data-grid](design/data-grid.md) with the paginated main view
+  (issue #5): one 100-row page in memory at a time, the page query and its
+  `COUNT(*)` as two independent commands so a slow count never blocks the grid,
+  row and column scroll windows derived from the cell cursor instead of stored,
+  and `panelMain` as a focus target that has no number and no `Model.panels`
+  slot but shares the one keybinding table.
+- Documented the quick filter's parse-first rule in the same concept:
+  `db.ParseFilter` rewrites recognised `column <op> <literal>` chains into
+  quoted identifiers plus bound placeholders, and only an unrecognised fragment
+  stays verbatim — flagged in `Filter.Verbatim`, warned about in the command
+  log and marked `where (verbatim)` in the status line. `Driver.QueryPage` now
+  takes a `*db.Filter` so no caller can assemble its own WHERE text.
+- Added [reference/sqlite-double-quoted-strings](reference/sqlite-double-quoted-strings.md):
+  found while writing the filter tests — SQLite reads a double-quoted token that
+  matches no column as a string literal, so `"typo" = 1` quietly matches nothing
+  instead of erroring. Safety is unaffected (the value is still bound), but a
+  missing column is not a way to provoke a query failure there.

--- a/wiki/reference/sqlite-double-quoted-strings.md
+++ b/wiki/reference/sqlite-double-quoted-strings.md
@@ -1,0 +1,38 @@
+---
+type: Dialect Note
+title: SQLite treats unresolvable double-quoted identifiers as string literals
+description: Why a quick filter naming a column that does not exist returns zero rows on SQLite instead of raising an error.
+tags: [db, dialect, sqlite, filtering, quoting]
+generated:
+  by: claude-code/opus-5
+  at: 2026-08-09T00:00:00Z
+sources:
+  - resource: https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted
+---
+
+# SQLite: double-quoted strings
+
+For compatibility with old applications, SQLite accepts a double-quoted
+token that resolves to no identifier as a **string literal** instead of
+raising `no such column`. The standard-conforming behaviour is
+compile-time optional (`SQLITE_DQS`) and is off in the build behind
+`modernc.org/sqlite`.
+
+Consequence for lazysql's quick filter: `db.ParseFilter` rewrites
+`no_such_column = 1` into `"no_such_column" = ?`, and SQLite then
+evaluates `'no_such_column' = 1`, which is false for every row. The user
+sees an empty grid rather than an error naming the typo.
+
+This is a diagnosis quirk, not a safety one — the *value* is still bound
+as a parameter, so nothing about it is injectable. Engines that follow
+the standard (PostgreSQL, DuckDB, and MySQL with `ANSI_QUOTES`) raise a
+real error for the same fragment, which the grid surfaces normally.
+
+Worth knowing when writing tests: a fragment naming a missing column is
+**not** a way to provoke a query failure on SQLite. Use something the
+parser keeps verbatim instead, e.g. `no_such_column IN (1, 2)`.
+
+## See also
+
+- [../design/data-grid](../design/data-grid.md) — the filter parser.
+- [dialect-introspection-quirks](dialect-introspection-quirks.md)


### PR DESCRIPTION
Custom data grid renderer with pagination, async row count, sort cycling, WHERE filter, cell cursor, horizontal scroll for wide tables, and an untruncated-value modal. Tests include a 100k-row paging proof and multi-size render coverage.

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139rhNA79AoksWw97zoxwWA