### PR TITLE
Add Structure, Indexes, and DDL tabs to main view

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	charm.land/bubbletea/v2 v2.0.8
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/BurntSushi/toml v1.6.0
+	github.com/atotto/clipboard v0.1.4
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/marcboeker/go-duckdb/v2 v2.4.3
@@ -17,7 +18,6 @@ require (
 require (
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/apache/arrow-go/v18 v18.4.1 // indirect
-	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/ultraviolet v0.0.0-20260703014108-f5a850f9c2b7 // indirect
 	github.com/charmbracelet/x/ansi v0.11.7 // indirect

--- a/internal/db/conn.go
+++ b/internal/db/conn.go
@@ -100,6 +100,14 @@ func (c *conn) TableIndexes(ctx context.Context, database, table string) ([]Inde
 	return c.dialect.tableIndexes(ctx, q, database, table)
 }
 
+func (c *conn) TableForeignKeys(ctx context.Context, database, table string) ([]ForeignKey, error) {
+	q, err := c.q()
+	if err != nil {
+		return nil, err
+	}
+	return c.dialect.tableForeignKeys(ctx, q, database, table)
+}
+
 func (c *conn) TableDDL(ctx context.Context, database, table string) (string, error) {
 	q, err := c.q()
 	if err != nil {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -24,12 +24,18 @@ const (
 )
 
 // Column describes one column of a table or result set.
+//
+// Extra carries the engine's own note about how the value is produced —
+// "auto_increment", "identity always", "autoincrement", "stored" — and
+// is empty whenever the engine has nothing to say. It is display-only:
+// no code branches on its contents.
 type Column struct {
 	Name       string
 	DataType   string
 	Nullable   bool
 	Default    *string
 	PrimaryKey bool
+	Extra      string
 }
 
 // Index describes one index on a table.
@@ -38,6 +44,23 @@ type Index struct {
 	Columns []string
 	Unique  bool
 	Primary bool
+}
+
+// ForeignKey describes one foreign key constraint. Columns and
+// RefColumns are positionally paired: Columns[i] references
+// RefColumns[i] of RefTable. RefTable is schema-qualified only when the
+// referenced table lives outside the constrained table's namespace.
+//
+// OnUpdate/OnDelete are the referential actions spelled the SQL way
+// ("CASCADE", "SET NULL", …); "NO ACTION" and the empty string both
+// mean the engine's default.
+type ForeignKey struct {
+	Name       string
+	Columns    []string
+	RefTable   string
+	RefColumns []string
+	OnUpdate   string
+	OnDelete   string
 }
 
 // RelationKind distinguishes the two kinds of listable relation. The UI
@@ -147,6 +170,7 @@ type Driver interface {
 	ListRelations(ctx context.Context, database string) ([]Relation, error)
 	TableColumns(ctx context.Context, database, table string) ([]Column, error)
 	TableIndexes(ctx context.Context, database, table string) ([]Index, error)
+	TableForeignKeys(ctx context.Context, database, table string) ([]ForeignKey, error)
 	TableDDL(ctx context.Context, database, table string) (string, error)
 
 	// QueryPage reads one page of a table. filter and sortBy may be nil.
@@ -186,6 +210,7 @@ type Dialect interface {
 	listRelations(ctx context.Context, q querier, database string) ([]Relation, error)
 	tableColumns(ctx context.Context, q querier, database, table string) ([]Column, error)
 	tableIndexes(ctx context.Context, q querier, database, table string) ([]Index, error)
+	tableForeignKeys(ctx context.Context, q querier, database, table string) ([]ForeignKey, error)
 	tableDDL(ctx context.Context, q querier, database, table string) (string, error)
 }
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -36,6 +36,11 @@ func seed(t *testing.T, drv Driver) {
 		)`,
 		`CREATE INDEX idx_users_name ON users (name)`,
 		`CREATE VIEW named_users AS SELECT id, name FROM users`,
+		// orders exists so the Indexes tab has a foreign key to show.
+		`CREATE TABLE orders (
+			id INTEGER PRIMARY KEY,
+			user_id INTEGER NOT NULL REFERENCES users (id)
+		)`,
 	}
 	for _, s := range stmts {
 		if _, err := drv.Exec(ctx, s); err != nil {
@@ -146,6 +151,39 @@ func engineSuite(t *testing.T, engine Engine, dsn string) {
 		}
 		if !found {
 			t.Fatalf("idx_users_name not in %+v", idx)
+		}
+	})
+
+	// The Indexes tab lists foreign keys under the indexes, so every
+	// engine has to report the referenced table and columns.
+	t.Run("TableForeignKeys", func(t *testing.T) {
+		fks, err := drv.TableForeignKeys(ctx, "", "orders")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fks) != 1 {
+			t.Fatalf("got %d foreign keys, want 1: %+v", len(fks), fks)
+		}
+		fk := fks[0]
+		if !slices.Equal(fk.Columns, []string{"user_id"}) {
+			t.Errorf("columns = %v, want [user_id]", fk.Columns)
+		}
+		if fk.RefTable != "users" {
+			t.Errorf("referenced table = %q, want users", fk.RefTable)
+		}
+		if !slices.Equal(fk.RefColumns, []string{"id"}) {
+			t.Errorf("referenced columns = %v, want [id]", fk.RefColumns)
+		}
+	})
+
+	// A table without foreign keys reports none rather than failing.
+	t.Run("TableForeignKeysNone", func(t *testing.T) {
+		fks, err := drv.TableForeignKeys(ctx, "", "users")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(fks) != 0 {
+			t.Fatalf("got %+v, want no foreign keys", fks)
 		}
 	})
 

--- a/internal/db/dialect_duckdb.go
+++ b/internal/db/dialect_duckdb.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	_ "github.com/marcboeker/go-duckdb/v2"
@@ -91,15 +92,68 @@ func (duckdbDialect) tableColumns(ctx context.Context, q querier, database, tabl
 		if err := rows.Scan(&name, &typ, &nullable, &def); err != nil {
 			return nil, err
 		}
-		cols = append(cols, Column{
+		c := Column{
 			Name:       name,
 			DataType:   typ,
 			Nullable:   nullable,
 			Default:    def,
 			PrimaryKey: pkCols[name],
-		})
+		}
+		if def != nil && strings.HasPrefix(strings.ToLower(*def), "nextval(") {
+			c.Extra = "sequence"
+		}
+		cols = append(cols, c)
 	}
 	return cols, rows.Err()
+}
+
+// duckdbFKRef pulls the referenced table and columns out of a
+// constraint_text such as
+// "FOREIGN KEY (user_id) REFERENCES users(id)". duckdb_constraints()
+// exposes the constrained columns as a list but spells the reference
+// only inside that text, and its column names have changed between
+// DuckDB versions — parsing the text works on every version.
+var duckdbFKRef = regexp.MustCompile(`(?i)REFERENCES\s+([^\s(]+)\s*\(([^)]*)\)`)
+
+func (duckdbDialect) tableForeignKeys(ctx context.Context, q querier, database, table string) ([]ForeignKey, error) {
+	cond, args := duckdbDBCond(database)
+	rows, err := q.QueryContext(ctx,
+		`SELECT constraint_text, CAST(constraint_column_names AS VARCHAR)
+		 FROM duckdb_constraints()
+		 WHERE `+cond+` AND table_name = ? AND constraint_type = 'FOREIGN KEY'
+		 ORDER BY constraint_index`,
+		append(append([]any{}, args...), table)...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var fks []ForeignKey
+	for rows.Next() {
+		var text, colList string
+		if err := rows.Scan(&text, &colList); err != nil {
+			return nil, err
+		}
+		fk := ForeignKey{Columns: splitDuckList(colList)}
+		if m := duckdbFKRef.FindStringSubmatch(text); m != nil {
+			fk.RefTable = strings.Trim(m[1], `"`)
+			fk.RefColumns = splitDuckList(m[2])
+		}
+		fks = append(fks, fk)
+	}
+	return fks, rows.Err()
+}
+
+// splitDuckList splits a VARCHAR-rendered DuckDB list ("[a, b]") or a
+// plain comma-separated column list into its trimmed, unquoted parts.
+func splitDuckList(s string) []string {
+	var out []string
+	for _, c := range strings.Split(strings.Trim(s, "[]"), ",") {
+		if c = strings.Trim(strings.TrimSpace(c), `'"`); c != "" {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func (duckdbDialect) tableIndexes(ctx context.Context, q querier, database, table string) ([]Index, error) {
@@ -125,13 +179,7 @@ func (duckdbDialect) tableIndexes(ctx context.Context, q querier, database, tabl
 		if err := rows.Scan(&name, &unique, &exprs); err != nil {
 			return nil, err
 		}
-		var cols []string
-		for _, c := range strings.Split(strings.Trim(exprs, "[]"), ",") {
-			if c = strings.Trim(strings.TrimSpace(c), `'"`); c != "" {
-				cols = append(cols, c)
-			}
-		}
-		idx = append(idx, Index{Name: name, Columns: cols, Unique: unique})
+		idx = append(idx, Index{Name: name, Columns: splitDuckList(exprs), Unique: unique})
 	}
 	return idx, rows.Err()
 }

--- a/internal/db/dialect_helpers.go
+++ b/internal/db/dialect_helpers.go
@@ -48,8 +48,10 @@ func scanRelations(ctx context.Context, q querier, query string, args ...any) ([
 }
 
 // synthesizeDDL builds a CREATE TABLE statement from introspected
-// columns, for engines that do not store the original DDL.
-func synthesizeDDL(d Dialect, database, table string, cols []Column) string {
+// metadata, for engines that do not store the original DDL. Indexes and
+// foreign keys may be nil; the primary-key index is skipped because the
+// PRIMARY KEY clause already carries it.
+func synthesizeDDL(d Dialect, database, table string, cols []Column, idx []Index, fks []ForeignKey) string {
 	var b strings.Builder
 	b.WriteString("CREATE TABLE ")
 	b.WriteString(qualifiedTable(d, database, table))
@@ -79,6 +81,85 @@ func synthesizeDDL(d Dialect, database, table string, cols []Column) string {
 		b.WriteString(strings.Join(pk, ", "))
 		b.WriteString(")")
 	}
+	for _, fk := range fks {
+		b.WriteString(",\n  ")
+		if fk.Name != "" {
+			b.WriteString("CONSTRAINT " + d.QuoteIdent(fk.Name) + " ")
+		}
+		b.WriteString("FOREIGN KEY (" + quoteAll(d, fk.Columns) + ")")
+		b.WriteString(" REFERENCES " + quoteQualified(d, fk.RefTable))
+		if len(fk.RefColumns) > 0 {
+			b.WriteString(" (" + quoteAll(d, fk.RefColumns) + ")")
+		}
+		if act := referentialAction(fk.OnDelete); act != "" {
+			b.WriteString(" ON DELETE " + act)
+		}
+		if act := referentialAction(fk.OnUpdate); act != "" {
+			b.WriteString(" ON UPDATE " + act)
+		}
+	}
 	b.WriteString("\n);")
+
+	// Secondary indexes are separate statements in every dialect that
+	// needs a synthesized DDL.
+	for _, ix := range idx {
+		if ix.Primary || len(ix.Columns) == 0 {
+			continue
+		}
+		b.WriteString("\n\nCREATE ")
+		if ix.Unique {
+			b.WriteString("UNIQUE ")
+		}
+		b.WriteString("INDEX " + d.QuoteIdent(ix.Name) + " ON ")
+		b.WriteString(qualifiedTable(d, database, table))
+		b.WriteString(" (" + quoteAll(d, ix.Columns) + ");")
+	}
 	return b.String()
+}
+
+// quoteAll quotes a column list for a parenthesized clause.
+func quoteAll(d Dialect, names []string) string {
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		out = append(out, d.QuoteIdent(n))
+	}
+	return strings.Join(out, ", ")
+}
+
+// quoteQualified quotes a possibly schema-qualified table name, so
+// "other.users" becomes two quoted parts rather than one odd identifier.
+func quoteQualified(d Dialect, name string) string {
+	parts := strings.Split(name, ".")
+	for i, p := range parts {
+		parts[i] = d.QuoteIdent(p)
+	}
+	return strings.Join(parts, ".")
+}
+
+// referentialAction normalizes an ON UPDATE/ON DELETE rule for display
+// and for generated DDL. The default rule contributes no clause.
+func referentialAction(rule string) string {
+	rule = strings.ToUpper(strings.TrimSpace(rule))
+	if rule == "" || rule == "NO ACTION" {
+		return ""
+	}
+	return rule
+}
+
+// appendFKColumn accumulates row-per-column foreign key listings: rows
+// arrive ordered by constraint and key position, so a row either
+// extends the constraint being built or starts a new one.
+func appendFKColumn(fks []ForeignKey, fk ForeignKey, col, refCol string) []ForeignKey {
+	if n := len(fks); n > 0 && fks[n-1].Name == fk.Name && fks[n-1].RefTable == fk.RefTable {
+		fks[n-1].Columns = append(fks[n-1].Columns, col)
+		if refCol != "" {
+			fks[n-1].RefColumns = append(fks[n-1].RefColumns, refCol)
+		}
+		return fks
+	}
+	fk.Columns = []string{col}
+	if refCol != "" {
+		fk.RefColumns = []string{refCol}
+	}
+	return append(fks, fk)
 }

--- a/internal/db/dialect_mysql.go
+++ b/internal/db/dialect_mysql.go
@@ -42,10 +42,16 @@ func (mysqlDialect) listDatabases(ctx context.Context, q querier) ([]string, err
 // schemaCond returns the table_schema predicate and its args; an empty
 // database means the connection's current one.
 func mysqlSchemaCond(database string) (string, []any) {
+	return mysqlSchemaCondOn("", database)
+}
+
+// mysqlSchemaCondOn is schemaCond for a joined query, where the column
+// needs a table alias in front of it ("k.").
+func mysqlSchemaCondOn(prefix, database string) (string, []any) {
 	if database == "" {
-		return "table_schema = DATABASE()", nil
+		return prefix + "table_schema = DATABASE()", nil
 	}
-	return "table_schema = ?", []any{database}
+	return prefix + "table_schema = ?", []any{database}
 }
 
 func (mysqlDialect) listRelations(ctx context.Context, q querier, database string) ([]Relation, error) {
@@ -59,7 +65,7 @@ func (mysqlDialect) listRelations(ctx context.Context, q querier, database strin
 func (mysqlDialect) tableColumns(ctx context.Context, q querier, database, table string) ([]Column, error) {
 	cond, args := mysqlSchemaCond(database)
 	rows, err := q.QueryContext(ctx,
-		`SELECT column_name, column_type, is_nullable, column_default, column_key
+		`SELECT column_name, column_type, is_nullable, column_default, column_key, extra
 		 FROM information_schema.columns
 		 WHERE `+cond+` AND table_name = ?
 		 ORDER BY ordinal_position`,
@@ -72,19 +78,68 @@ func (mysqlDialect) tableColumns(ctx context.Context, q querier, database, table
 	var cols []Column
 	for rows.Next() {
 		var name, typ, nullable, key string
-		var def *string
-		if err := rows.Scan(&name, &typ, &nullable, &def, &key); err != nil {
+		var def, extra *string
+		if err := rows.Scan(&name, &typ, &nullable, &def, &key, &extra); err != nil {
 			return nil, err
 		}
-		cols = append(cols, Column{
+		c := Column{
 			Name:       name,
 			DataType:   typ,
 			Nullable:   nullable == "YES",
 			Default:    def,
 			PrimaryKey: key == "PRI",
-		})
+		}
+		if extra != nil {
+			c.Extra = *extra
+		}
+		cols = append(cols, c)
 	}
 	return cols, rows.Err()
+}
+
+func (mysqlDialect) tableForeignKeys(ctx context.Context, q querier, database, table string) ([]ForeignKey, error) {
+	cond, args := mysqlSchemaCondOn("k.", database)
+	// referential_constraints holds the ON UPDATE/ON DELETE rules;
+	// key_column_usage holds one row per key column, in key order.
+	rows, err := q.QueryContext(ctx,
+		`SELECT k.constraint_name, k.column_name,
+		        k.referenced_table_schema, k.referenced_table_name, k.referenced_column_name,
+		        r.update_rule, r.delete_rule
+		 FROM information_schema.key_column_usage k
+		 JOIN information_schema.referential_constraints r
+		   ON r.constraint_schema = k.constraint_schema
+		  AND r.constraint_name = k.constraint_name
+		  AND r.table_name = k.table_name
+		 WHERE `+cond+` AND k.table_name = ? AND k.referenced_table_name IS NOT NULL
+		 ORDER BY k.constraint_name, k.ordinal_position`,
+		append(args, table)...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var fks []ForeignKey
+	for rows.Next() {
+		var name, col, refTable, onUpdate, onDelete string
+		var refSchema, refCol *string
+		if err := rows.Scan(&name, &col, &refSchema, &refTable, &refCol, &onUpdate, &onDelete); err != nil {
+			return nil, err
+		}
+		if refSchema != nil && database != "" && *refSchema != database {
+			refTable = *refSchema + "." + refTable
+		}
+		fk := ForeignKey{Name: name, RefTable: refTable, OnUpdate: onUpdate, OnDelete: onDelete}
+		fks = appendFKColumn(fks, fk, col, derefOr(refCol, ""))
+	}
+	return fks, rows.Err()
+}
+
+// derefOr reads a nullable string column with a fallback.
+func derefOr(s *string, fallback string) string {
+	if s == nil {
+		return fallback
+	}
+	return *s
 }
 
 func (mysqlDialect) tableIndexes(ctx context.Context, q querier, database, table string) ([]Index, error) {

--- a/internal/db/dialect_postgres.go
+++ b/internal/db/dialect_postgres.go
@@ -55,6 +55,7 @@ func (d postgresDialect) tableColumns(ctx context.Context, q querier, database, 
 	schema := pgSchema(database)
 	rows, err := q.QueryContext(ctx,
 		`SELECT c.column_name, c.data_type, c.is_nullable, c.column_default,
+		        c.is_identity, c.identity_generation, c.is_generated,
 		        EXISTS (
 		          SELECT 1 FROM pg_index i
 		          JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY (i.indkey)
@@ -73,9 +74,11 @@ func (d postgresDialect) tableColumns(ctx context.Context, q querier, database, 
 	var cols []Column
 	for rows.Next() {
 		var name, typ, nullable string
-		var def *string
+		var def, identityGen *string
+		var isIdentity, isGenerated string
 		var pk bool
-		if err := rows.Scan(&name, &typ, &nullable, &def, &pk); err != nil {
+		if err := rows.Scan(&name, &typ, &nullable, &def,
+			&isIdentity, &identityGen, &isGenerated, &pk); err != nil {
 			return nil, err
 		}
 		cols = append(cols, Column{
@@ -84,9 +87,81 @@ func (d postgresDialect) tableColumns(ctx context.Context, q querier, database, 
 			Nullable:   nullable == "YES",
 			Default:    def,
 			PrimaryKey: pk,
+			Extra:      pgColumnExtra(isIdentity, derefOr(identityGen, ""), isGenerated, def),
 		})
 	}
 	return cols, rows.Err()
+}
+
+// pgColumnExtra spells out how PostgreSQL produces a column's value.
+// Identity columns and generated columns say so directly; the older
+// serial types only show up as a nextval() default.
+func pgColumnExtra(isIdentity, identityGen, isGenerated string, def *string) string {
+	switch {
+	case isIdentity == "YES":
+		if identityGen != "" {
+			return "identity " + strings.ToLower(identityGen)
+		}
+		return "identity"
+	case isGenerated == "ALWAYS":
+		return "generated"
+	case def != nil && strings.HasPrefix(strings.ToLower(*def), "nextval("):
+		return "serial"
+	}
+	return ""
+}
+
+// pgReferentialActions maps pg_constraint's single-char confupdtype and
+// confdeltype codes onto their SQL spelling.
+var pgReferentialActions = map[string]string{
+	"a": "NO ACTION",
+	"r": "RESTRICT",
+	"c": "CASCADE",
+	"n": "SET NULL",
+	"d": "SET DEFAULT",
+}
+
+func (d postgresDialect) tableForeignKeys(ctx context.Context, q querier, database, table string) ([]ForeignKey, error) {
+	schema := pgSchema(database)
+	// conkey and confkey are positionally paired arrays, so they are
+	// unnested together: row i of the pair is key column i.
+	rows, err := q.QueryContext(ctx,
+		// confupdtype/confdeltype are of the internal "char" type; the
+		// cast keeps the pgx decoder on the plain-string path.
+		`SELECT c.conname, a.attname, ns.nspname, cl.relname, af.attname,
+		        c.confupdtype::text, c.confdeltype::text
+		 FROM pg_constraint c
+		 JOIN LATERAL unnest(c.conkey, c.confkey) WITH ORDINALITY AS k(att, fatt, ord) ON true
+		 JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.att
+		 JOIN pg_class cl ON cl.oid = c.confrelid
+		 JOIN pg_namespace ns ON ns.oid = cl.relnamespace
+		 JOIN pg_attribute af ON af.attrelid = c.confrelid AND af.attnum = k.fatt
+		 WHERE c.conrelid = to_regclass($1) AND c.contype = 'f'
+		 ORDER BY c.conname, k.ord`,
+		d.QuoteIdent(schema)+"."+d.QuoteIdent(table))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var fks []ForeignKey
+	for rows.Next() {
+		var name, col, refSchema, refTable, refCol, upd, del string
+		if err := rows.Scan(&name, &col, &refSchema, &refTable, &refCol, &upd, &del); err != nil {
+			return nil, err
+		}
+		if refSchema != schema {
+			refTable = refSchema + "." + refTable
+		}
+		fk := ForeignKey{
+			Name:     name,
+			RefTable: refTable,
+			OnUpdate: pgReferentialActions[upd],
+			OnDelete: pgReferentialActions[del],
+		}
+		fks = appendFKColumn(fks, fk, col, refCol)
+	}
+	return fks, rows.Err()
 }
 
 func (d postgresDialect) tableIndexes(ctx context.Context, q querier, database, table string) ([]Index, error) {
@@ -121,7 +196,9 @@ func (d postgresDialect) tableIndexes(ctx context.Context, q querier, database, 
 }
 
 // PostgreSQL does not keep the original CREATE TABLE text, so the DDL
-// is synthesized from the introspected columns.
+// is synthesized from the introspected columns, indexes and foreign
+// keys. It is a faithful description, not a byte-identical replay of
+// what the table was created with.
 func (d postgresDialect) tableDDL(ctx context.Context, q querier, database, table string) (string, error) {
 	cols, err := d.tableColumns(ctx, q, database, table)
 	if err != nil {
@@ -130,5 +207,13 @@ func (d postgresDialect) tableDDL(ctx context.Context, q querier, database, tabl
 	if len(cols) == 0 {
 		return "", fmt.Errorf("db: no DDL for table %q", table)
 	}
-	return synthesizeDDL(d, pgSchema(database), table, cols), nil
+	idx, err := d.tableIndexes(ctx, q, database, table)
+	if err != nil {
+		return "", err
+	}
+	fks, err := d.tableForeignKeys(ctx, q, database, table)
+	if err != nil {
+		return "", err
+	}
+	return synthesizeDDL(d, pgSchema(database), table, cols, idx, fks), nil
 }

--- a/internal/db/dialect_sqlite.go
+++ b/internal/db/dialect_sqlite.go
@@ -91,7 +91,62 @@ func (d sqliteDialect) tableColumns(ctx context.Context, q querier, database, ta
 			PrimaryKey: pk > 0,
 		})
 	}
-	return cols, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	markSQLiteAutoincrement(ctx, d, q, database, table, cols)
+	return cols, nil
+}
+
+// markSQLiteAutoincrement fills in the Extra note for an AUTOINCREMENT
+// primary key. PRAGMA table_info does not report the keyword at all —
+// it exists only in the stored CREATE TABLE text — so the DDL is read
+// back to find it. A failure here costs a display detail and nothing
+// else, so the error is dropped rather than failing the whole listing.
+func markSQLiteAutoincrement(ctx context.Context, d sqliteDialect, q querier, database, table string, cols []Column) {
+	ddl, err := d.tableDDL(ctx, q, database, table)
+	if err != nil || !strings.Contains(strings.ToUpper(ddl), "AUTOINCREMENT") {
+		return
+	}
+	// AUTOINCREMENT is only legal on a single INTEGER PRIMARY KEY.
+	for i := range cols {
+		if cols[i].PrimaryKey && strings.EqualFold(cols[i].DataType, "INTEGER") {
+			cols[i].Extra = "autoincrement"
+			return
+		}
+	}
+}
+
+func (d sqliteDialect) tableForeignKeys(ctx context.Context, q querier, database, table string) ([]ForeignKey, error) {
+	rows, err := q.QueryContext(ctx,
+		fmt.Sprintf(`PRAGMA %s.foreign_key_list(%s)`, sqliteSchema(d, database), d.QuoteIdent(table)))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var fks []ForeignKey
+	for rows.Next() {
+		// id groups the columns of one constraint; seq is their order.
+		var id, seq int64
+		var refTable, from, onUpdate, onDelete, match string
+		var to *string
+		if err := rows.Scan(&id, &seq, &refTable, &from, &to, &onUpdate, &onDelete, &match); err != nil {
+			return nil, err
+		}
+		// PRAGMA foreign_key_list never reports a constraint name, so
+		// the id doubles as one and as the grouping key.
+		fk := ForeignKey{
+			Name:     fmt.Sprintf("fk_%d", id),
+			RefTable: refTable,
+			OnUpdate: onUpdate,
+			OnDelete: onDelete,
+		}
+		// A NULL "to" means the reference targets the referenced
+		// table's primary key implicitly.
+		fks = appendFKColumn(fks, fk, from, derefOr(to, ""))
+	}
+	return fks, rows.Err()
 }
 
 func (d sqliteDialect) tableIndexes(ctx context.Context, q querier, database, table string) ([]Index, error) {

--- a/internal/db/dialect_test.go
+++ b/internal/db/dialect_test.go
@@ -1,6 +1,10 @@
 package db
 
-import "testing"
+import (
+	"context"
+	"strings"
+	"testing"
+)
 
 func TestQuoteIdent(t *testing.T) {
 	tests := []struct {
@@ -77,5 +81,75 @@ func TestFormatValue(t *testing.T) {
 	}
 	if got := FormatValue("x", ""); got != "x" {
 		t.Errorf("string = %q", got)
+	}
+}
+
+// synthesizeDDL is what PostgreSQL's TableDDL renders, so the shape is
+// asserted here rather than behind a server the test suite has no
+// access to.
+func TestSynthesizeDDL(t *testing.T) {
+	d, _ := DialectFor(EnginePostgres)
+	def := "nextval('users_id_seq'::regclass)"
+	cols := []Column{
+		{Name: "id", DataType: "integer", Default: &def, PrimaryKey: true, Extra: "serial"},
+		{Name: "email", DataType: "text", Nullable: true},
+		{Name: "org_id", DataType: "integer"},
+	}
+	idx := []Index{
+		{Name: "users_pkey", Columns: []string{"id"}, Unique: true, Primary: true},
+		{Name: "users_email_key", Columns: []string{"email"}, Unique: true},
+		{Name: "idx_users_org", Columns: []string{"org_id"}},
+	}
+	fks := []ForeignKey{{
+		Name:       "users_org_id_fkey",
+		Columns:    []string{"org_id"},
+		RefTable:   "other.orgs",
+		RefColumns: []string{"id"},
+		OnDelete:   "CASCADE",
+		OnUpdate:   "NO ACTION",
+	}}
+
+	ddl := synthesizeDDL(d, "public", "users", cols, idx, fks)
+	for _, want := range []string{
+		`CREATE TABLE "public"."users"`,
+		`"id" integer NOT NULL DEFAULT nextval('users_id_seq'::regclass)`,
+		`"email" text`,
+		`PRIMARY KEY ("id")`,
+		`CONSTRAINT "users_org_id_fkey" FOREIGN KEY ("org_id") REFERENCES "other"."orgs" ("id") ON DELETE CASCADE`,
+		`CREATE UNIQUE INDEX "users_email_key" ON "public"."users" ("email");`,
+		`CREATE INDEX "idx_users_org" ON "public"."users" ("org_id");`,
+	} {
+		if !strings.Contains(ddl, want) {
+			t.Errorf("DDL is missing %q:\n%s", want, ddl)
+		}
+	}
+	// The default rule contributes no clause, and the primary key index
+	// is already covered by the PRIMARY KEY clause.
+	if strings.Contains(ddl, "ON UPDATE") {
+		t.Errorf("NO ACTION should not be spelled out:\n%s", ddl)
+	}
+	if strings.Contains(ddl, "users_pkey") {
+		t.Errorf("primary key index restated as CREATE INDEX:\n%s", ddl)
+	}
+}
+
+// SQLite keeps AUTOINCREMENT only in the stored DDL, so the column
+// listing has to read it back to report it.
+func TestSQLiteAutoincrementExtra(t *testing.T) {
+	ctx := context.Background()
+	drv := openTest(t, EngineSQLite, "")
+	if _, err := drv.Exec(ctx,
+		`CREATE TABLE seq (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	cols, err := drv.TableColumns(ctx, "", "seq")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cols[0].Extra != "autoincrement" {
+		t.Errorf("id Extra = %q, want autoincrement", cols[0].Extra)
+	}
+	if cols[1].Extra != "" {
+		t.Errorf("name Extra = %q, want empty", cols[1].Extra)
 	}
 }

--- a/internal/ui/clipboard.go
+++ b/internal/ui/clipboard.go
@@ -1,0 +1,21 @@
+package ui
+
+import (
+	"errors"
+
+	"github.com/atotto/clipboard"
+)
+
+// clipboardWrite is the one place lazysql talks to the system
+// clipboard. It is a variable so tests can replace it: a test run must
+// never overwrite the developer's real clipboard. The copy/export flows
+// will grow around this seam rather than call the library directly.
+var clipboardWrite = writeClipboard
+
+func writeClipboard(text string) error {
+	// Headless sessions have no pbcopy/xclip to hand the text to.
+	if clipboard.Unsupported {
+		return errors.New("no clipboard available in this environment")
+	}
+	return clipboard.WriteAll(text)
+}

--- a/internal/ui/data.go
+++ b/internal/ui/data.go
@@ -166,6 +166,10 @@ func countRowsCmd(drv db.Driver, d dataView, req int) tea.Cmd {
 // sort belong to the relation that was open, so they do not carry over.
 func (m *Model) openTable(name string) tea.Cmd {
 	m.table = name
+	// The metadata described the relation being closed. The selected
+	// tab survives — walking a table list with Structure open is the
+	// point of the tabs — but its contents and scroll positions do not.
+	m.resetMeta()
 	if m.driver == nil {
 		m.data = dataView{}
 		return logCmd("-- open %s skipped: not connected", name)
@@ -176,7 +180,9 @@ func (m *Model) openTable(name string) tea.Cmd {
 		table:    name,
 		req:      m.data.req,
 	}
-	return m.reloadPage()
+	// The Data tab always loads: it backs the row count in the status
+	// line and is where `esc`-and-back lands.
+	return tea.Batch(m.reloadPage(), m.ensureMeta())
 }
 
 // reloadPage re-runs the page query and the count for the current
@@ -290,10 +296,16 @@ func (m Model) updateData(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	k := m.keys
 	switch {
 	case key.Matches(msg, k.Down):
+		if m.tab.metadata() {
+			return m.updateMetaKeys(1)
+		}
 		m.data.row++
 		m.data.clampCursor()
 		return m, nil
 	case key.Matches(msg, k.Up):
+		if m.tab.metadata() {
+			return m.updateMetaKeys(-1)
+		}
 		m.data.row--
 		m.data.clampCursor()
 		return m, nil
@@ -301,8 +313,13 @@ func (m Model) updateData(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.focusBack()
 		return m, nil
 	case key.Matches(msg, k.Enter):
-		// enter re-runs the page: the relation is already open, so the
-		// only thing left to drill into is fresh data.
+		// enter re-runs whatever the visible tab shows: the relation is
+		// already open, so the only thing left to drill into is fresh
+		// data.
+		if m.tab.metadata() {
+			cmd := m.reloadMeta()
+			return m, cmd
+		}
 		cmd := m.reloadPage()
 		return m, cmd
 	case key.Matches(msg, k.Actions):

--- a/internal/ui/datagrid.go
+++ b/internal/ui/datagrid.go
@@ -138,7 +138,7 @@ func rowWindow(n, cursor, rows int) (start, end int) {
 // dataContent renders the main view's Data tab into a w x h content box.
 func (m Model) dataContent(w, h int) string {
 	d := m.data
-	lines := []string{m.dataTitle(w)}
+	lines := []string{m.mainTabBar(w)}
 
 	// header (2 lines) + status (1 line) + the title already written
 	bodyRows := h - 4
@@ -178,20 +178,6 @@ func (m Model) dataContent(w, h int) string {
 		body += strings.Repeat("\n", pad)
 	}
 	return body + "\n" + truncate(m.dataStatus(), w)
-}
-
-// dataTitle is the tab strip of the main view plus the relation and its
-// load state.
-func (m Model) dataTitle(w int) string {
-	title := m.style.titleFocused.Render("Data")
-	if m.focus != panelMain {
-		title = m.style.title.Render("Data")
-	}
-	line := title + m.style.muted.Render(" — "+displayDatabase(m.data.database)+".") + m.data.table
-	if m.data.loading {
-		line += " " + m.style.pending.Render("loading…")
-	}
-	return truncate(line, w)
 }
 
 // gridHeader renders the column names and, under them, their types.

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -44,6 +44,11 @@ type keyMap struct {
 	SortColumn  key.Binding
 	WhereFilter key.Binding
 	ViewCell    key.Binding
+
+	// Main-view tabs (Data | Structure | Indexes | DDL).
+	PrevMainTab key.Binding
+	NextMainTab key.Binding
+	CopyDDL     key.Binding
 }
 
 func newKeyMap() keyMap {
@@ -81,6 +86,10 @@ func newKeyMap() keyMap {
 		SortColumn:  key.NewBinding(key.WithKeys("s"), key.WithHelp("s", "sort column")),
 		WhereFilter: key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "where filter")),
 		ViewCell:    key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "view cell")),
+
+		PrevMainTab: key.NewBinding(key.WithKeys("["), key.WithHelp("[", "prev tab")),
+		NextMainTab: key.NewBinding(key.WithKeys("]"), key.WithHelp("]", "next tab")),
+		CopyDDL:     key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy DDL")),
 	}
 }
 
@@ -116,6 +125,9 @@ const (
 	actSortColumn
 	actWhereFilter
 	actViewCell
+	actPrevMainTab
+	actNextMainTab
+	actCopyDDL
 )
 
 // action pairs a dispatchable action with the binding that documents it.
@@ -154,6 +166,8 @@ func (k keyMap) panelActions(id panelID) []action {
 		}
 	case panelMain:
 		return []action{
+			{actPrevMainTab, k.PrevMainTab},
+			{actNextMainTab, k.NextMainTab},
 			{actColLeft, k.ColLeft},
 			{actColRight, k.ColRight},
 			{actNextPage, k.NextPage},
@@ -161,6 +175,7 @@ func (k keyMap) panelActions(id panelID) []action {
 			{actSortColumn, k.SortColumn},
 			{actWhereFilter, k.WhereFilter},
 			{actViewCell, k.ViewCell},
+			{actCopyDDL, k.CopyDDL},
 			{actRefresh, k.Refresh},
 		}
 	}

--- a/internal/ui/meta.go
+++ b/internal/ui/meta.go
@@ -1,0 +1,270 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/db"
+)
+
+// mainTab is one view of the open relation. The Data tab is the paged
+// grid; the other three are introspection views that share a single
+// metadata fetch.
+type mainTab int
+
+const (
+	mainTabData mainTab = iota
+	mainTabStructure
+	mainTabIndexes
+	mainTabDDL
+	mainTabCount
+)
+
+var mainTabNames = [mainTabCount]string{"Data", "Structure", "Indexes", "DDL"}
+
+// metadata reports whether the tab is served by the metadata fetch
+// rather than by the paged data query.
+func (t mainTab) metadata() bool { return t != mainTabData }
+
+// metaView is the state behind the Structure, Indexes and DDL tabs.
+// All three come from one round trip: a table's columns, indexes,
+// foreign keys and DDL are read together the first time any of those
+// tabs is opened, and reused until the relation changes or the user
+// asks for a reload.
+type metaView struct {
+	// Identity of the metadata on screen; replies that do not match
+	// belong to a relation the user has already moved past.
+	conn     string
+	database string
+	table    string
+
+	cols    []db.Column
+	indexes []db.Index
+	fks     []db.ForeignKey
+	ddl     string
+
+	// ddlErr is kept apart from err: an engine can describe a relation
+	// perfectly well and still refuse to produce a CREATE statement for
+	// it, which costs the DDL tab and nothing else.
+	ddlErr string
+
+	loaded  bool
+	loading bool
+	err     string
+
+	// row is the cursor (Structure) or the scroll offset (Indexes, DDL)
+	// of each tab, so switching tabs back and forth keeps the position.
+	row [mainTabCount]int
+
+	// copyAfterLoad makes `y` work on a tab that has not been opened
+	// yet: the copy runs when the metadata lands.
+	copyAfterLoad bool
+
+	req int
+}
+
+// ---------- messages ----------
+
+// metaLoadedMsg carries one metadata fetch: everything the three
+// introspection tabs render.
+type metaLoadedMsg struct {
+	req      int
+	conn     string
+	database string
+	table    string
+
+	cols    []db.Column
+	indexes []db.Index
+	fks     []db.ForeignKey
+	ddl     string
+	ddlErr  error
+	err     error
+}
+
+// ---------- commands ----------
+
+// loadMetaCmd reads the columns, indexes, foreign keys and DDL of one
+// relation. The three introspection tabs are cheap enough to fetch
+// together that splitting them into separate round trips would only buy
+// a more complicated loading state.
+func loadMetaCmd(drv db.Driver, v metaView, req int) tea.Cmd {
+	if drv == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), browseTimeout)
+		defer cancel()
+
+		out := metaLoadedMsg{req: req, conn: v.conn, database: v.database, table: v.table}
+		if out.cols, out.err = drv.TableColumns(ctx, v.database, v.table); out.err != nil {
+			return out
+		}
+		if out.indexes, out.err = drv.TableIndexes(ctx, v.database, v.table); out.err != nil {
+			return out
+		}
+		if out.fks, out.err = drv.TableForeignKeys(ctx, v.database, v.table); out.err != nil {
+			return out
+		}
+		out.ddl, out.ddlErr = drv.TableDDL(ctx, v.database, v.table)
+		return out
+	}
+}
+
+// copyDDLCmd puts a DDL statement on the system clipboard and reports
+// the outcome in the command log.
+func copyDDLCmd(table, ddl string) tea.Cmd {
+	return func() tea.Msg {
+		if err := clipboardWrite(ddl); err != nil {
+			return commandLogMsg{line: fmt.Sprintf("-- copy DDL of %s FAILED: %v", table, err)}
+		}
+		return commandLogMsg{
+			line: fmt.Sprintf("-- copy DDL of %s to clipboard (%d bytes)", table, len(ddl)),
+		}
+	}
+}
+
+// ---------- model wiring ----------
+
+// resetMeta drops the cached metadata because the relation under it
+// changed. The selected tab survives — walking down a table list with
+// the Structure tab open is the point of having tabs — but everything
+// that described the previous relation, scroll positions included, goes.
+func (m *Model) resetMeta() {
+	m.meta = metaView{req: m.meta.req}
+}
+
+// ensureMeta starts the metadata fetch when the selected tab needs it
+// and nothing has loaded it yet. It is a no-op on the Data tab, on an
+// in-flight load and on already-loaded metadata.
+func (m *Model) ensureMeta() tea.Cmd {
+	if !m.tab.metadata() || m.driver == nil || !m.data.open() {
+		return nil
+	}
+	if m.meta.loaded || m.meta.loading {
+		return nil
+	}
+	return m.startMetaLoad()
+}
+
+// startMetaLoad fires the fetch unconditionally. Callers decide whether
+// the cache made it unnecessary.
+func (m *Model) startMetaLoad() tea.Cmd {
+	if m.driver == nil || !m.data.open() {
+		return nil
+	}
+	m.meta.req++
+	m.meta.conn, m.meta.database, m.meta.table = m.active, m.data.database, m.data.table
+	m.meta.loaded, m.meta.loading = false, true
+	m.meta.err = ""
+	return tea.Batch(
+		logCmd("-- introspect %s.%s (columns, indexes, foreign keys, DDL)",
+			displayDatabase(m.meta.database), m.meta.table),
+		loadMetaCmd(m.driver, m.meta, m.meta.req),
+	)
+}
+
+// reloadMeta forces a fresh fetch; it is what `R` does on the three
+// introspection tabs.
+func (m *Model) reloadMeta() tea.Cmd {
+	m.meta.loaded = false
+	m.meta.loading = false
+	return m.ensureMeta()
+}
+
+// freshMeta reports whether a reply still belongs to the relation on
+// screen.
+func (m Model) freshMeta(msg metaLoadedMsg) bool {
+	return msg.req == m.meta.req && msg.conn == m.active && msg.table == m.data.table
+}
+
+// setMainTab switches tabs and loads the metadata the new one needs.
+func (m *Model) setMainTab(t mainTab) tea.Cmd {
+	m.tab = (t + mainTabCount) % mainTabCount
+	return m.ensureMeta()
+}
+
+// metaActions handles the main view's tab actions. It runs before the
+// data grid's own actions so a key means the same thing on every tab.
+func (m Model) metaActions(id actionID) (Model, tea.Cmd, bool) {
+	switch id {
+	case actPrevMainTab:
+		cmd := m.setMainTab(m.tab - 1)
+		return m, cmd, true
+	case actNextMainTab:
+		cmd := m.setMainTab(m.tab + 1)
+		return m, cmd, true
+	case actCopyDDL:
+		cmd := m.copyDDL()
+		return m, cmd, true
+	}
+	return m, nil, false
+}
+
+// copyDDL copies the open relation's DDL, fetching it first when no tab
+// has needed it yet.
+func (m *Model) copyDDL() tea.Cmd {
+	if !m.data.open() {
+		return logCmd("-- copy DDL skipped: no relation open")
+	}
+	if m.meta.loaded {
+		if m.meta.ddl == "" {
+			return logCmd("-- copy DDL of %s skipped: %s", m.data.table, m.ddlProblem())
+		}
+		return copyDDLCmd(m.data.table, m.meta.ddl)
+	}
+	if m.driver == nil {
+		return logCmd("-- copy DDL skipped: not connected")
+	}
+	// Nothing cached yet: fetch, then copy when the reply lands. `y`
+	// works from the Data tab too, where ensureMeta would not fetch, so
+	// the load is started directly.
+	m.meta.copyAfterLoad = true
+	if m.meta.loading {
+		return nil
+	}
+	return m.startMetaLoad()
+}
+
+// ddlProblem names why the DDL tab has nothing to show.
+func (m Model) ddlProblem() string {
+	switch {
+	case m.meta.ddlErr != "":
+		return m.meta.ddlErr
+	case m.meta.err != "":
+		return m.meta.err
+	default:
+		return "the engine reported no CREATE statement"
+	}
+}
+
+// updateMetaKeys is the key handler of the focused main view on the
+// three introspection tabs: j/k walks the rows of Structure and scrolls
+// Indexes and DDL.
+func (m Model) updateMetaKeys(delta int) (Model, tea.Cmd) {
+	n := m.metaRowCount()
+	row := m.meta.row[m.tab] + delta
+	if row >= n {
+		row = n - 1
+	}
+	if row < 0 {
+		row = 0
+	}
+	m.meta.row[m.tab] = row
+	return m, nil
+}
+
+// metaRowCount is how far the current tab can be scrolled.
+func (m Model) metaRowCount() int {
+	switch m.tab {
+	case mainTabStructure:
+		return len(m.meta.cols)
+	case mainTabIndexes:
+		return len(m.meta.indexes) + len(m.meta.fks)
+	case mainTabDDL:
+		return len(strings.Split(m.meta.ddl, "\n"))
+	}
+	return 0
+}

--- a/internal/ui/meta_test.go
+++ b/internal/ui/meta_test.go
@@ -1,0 +1,309 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/db"
+)
+
+// metaBrowsing opens a fixture relation that has everything the three
+// introspection tabs render: a primary key, a nullable column, a
+// default, a unique and a plain index, and a foreign key.
+func metaBrowsing(t *testing.T) Model {
+	t.Helper()
+	m := browsing(t)
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`DROP TABLE IF EXISTS orders`,
+		`DROP TABLE IF EXISTS people`,
+		`CREATE TABLE people (id INTEGER PRIMARY KEY AUTOINCREMENT, email TEXT NOT NULL)`,
+		`CREATE UNIQUE INDEX idx_people_email ON people (email)`,
+		`CREATE TABLE orders (
+			id INTEGER PRIMARY KEY,
+			person_id INTEGER NOT NULL REFERENCES people (id) ON DELETE CASCADE,
+			status TEXT DEFAULT 'new'
+		)`,
+		`CREATE INDEX idx_orders_status ON orders (status)`,
+		`INSERT INTO people (email) VALUES ('a@example.com')`,
+		`INSERT INTO orders (id, person_id, status) VALUES (1, 1, 'new')`,
+	} {
+		if _, err := m.driver.Exec(ctx, stmt); err != nil {
+			t.Fatalf("fixture %q: %v", stmt, err)
+		}
+	}
+	m = send(t, m, press('3'), press('R'))
+	if !m.panels[panelTables].selectByName("orders") {
+		t.Fatalf("fixture table not listed: %v", m.panels[panelTables].items)
+	}
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if m.focus != panelMain {
+		t.Fatalf("focus = %v, want the main view", m.focus)
+	}
+	return m
+}
+
+// fakeClipboard replaces the real clipboard for the duration of a test,
+// so a test run can never overwrite the developer's own.
+func fakeClipboard(t *testing.T) *string {
+	t.Helper()
+	var got string
+	prev := clipboardWrite
+	clipboardWrite = func(text string) error {
+		got = text
+		return nil
+	}
+	t.Cleanup(func() { clipboardWrite = prev })
+	return &got
+}
+
+// `]` walks Data → Structure → Indexes → DDL and wraps; `[` walks back.
+func TestMainTabCycling(t *testing.T) {
+	m := metaBrowsing(t)
+	if m.tab != mainTabData {
+		t.Fatalf("initial tab = %v, want Data", m.tab)
+	}
+	for _, want := range []mainTab{mainTabStructure, mainTabIndexes, mainTabDDL, mainTabData} {
+		m = send(t, m, press(']'))
+		if m.tab != want {
+			t.Fatalf("after ] tab = %v, want %v", m.tab, want)
+		}
+	}
+	m = send(t, m, press('['))
+	if m.tab != mainTabDDL {
+		t.Fatalf("after [ tab = %v, want DDL", m.tab)
+	}
+}
+
+// The tab bar names all four tabs whatever the selected one is.
+func TestTabBarRendersEveryTab(t *testing.T) {
+	m := metaBrowsing(t)
+	for range int(mainTabCount) {
+		out := m.View().Content
+		for _, name := range mainTabNames {
+			if !strings.Contains(out, name) {
+				t.Errorf("tab %v: view is missing the %q tab", m.tab, name)
+			}
+		}
+		m = send(t, m, press(']'))
+	}
+}
+
+// The Structure tab lists every column with its type, nullability,
+// default, key info and extra.
+func TestStructureTabRendersColumns(t *testing.T) {
+	m := send(t, metaBrowsing(t), press(']'))
+	if m.tab != mainTabStructure {
+		t.Fatalf("tab = %v, want Structure", m.tab)
+	}
+	if !m.meta.loaded {
+		t.Fatalf("metadata not loaded: %+v", m.meta)
+	}
+	if len(m.meta.cols) != 3 {
+		t.Fatalf("columns = %d, want 3", len(m.meta.cols))
+	}
+	out := m.View().Content
+	for _, want := range []string{"name", "type", "null", "default", "key", "extra",
+		"person_id", "status", "'new'", "PK", "FK"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Structure tab is missing %q", want)
+		}
+	}
+	if !logContains(m, "-- introspect") {
+		t.Errorf("command log = %v", m.commandLog)
+	}
+}
+
+// The Indexes tab lists the indexes and, under them, the foreign keys
+// with the table and columns they reference.
+func TestIndexesTabRendersIndexesAndForeignKeys(t *testing.T) {
+	m := send(t, metaBrowsing(t), press(']'), press(']'))
+	if m.tab != mainTabIndexes {
+		t.Fatalf("tab = %v, want Indexes", m.tab)
+	}
+	out := m.View().Content
+	for _, want := range []string{"idx_orders_status", "Foreign keys", "people (id)", "CASCADE"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("Indexes tab is missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// The DDL tab shows the CREATE statement the engine reports.
+func TestDDLTabRendersStatement(t *testing.T) {
+	m := send(t, metaBrowsing(t), press(']'), press(']'), press(']'))
+	if m.tab != mainTabDDL {
+		t.Fatalf("tab = %v, want DDL", m.tab)
+	}
+	if !strings.Contains(m.meta.ddl, "CREATE TABLE") {
+		t.Fatalf("DDL = %q", m.meta.ddl)
+	}
+	out := m.View().Content
+	for _, want := range []string{"CREATE TABLE", "person_id", "y copies the statement"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("DDL tab is missing %q", want)
+		}
+	}
+}
+
+// A long DDL scrolls a line at a time and never runs past its end.
+func TestDDLTabScrolls(t *testing.T) {
+	m := send(t, metaBrowsing(t), press(']'), press(']'), press(']'))
+	m = send(t, m, press('j'))
+	if m.meta.row[mainTabDDL] != 1 {
+		t.Fatalf("offset after j = %d, want 1", m.meta.row[mainTabDDL])
+	}
+	for range 50 {
+		m = send(t, m, press('j'))
+	}
+	if got, max := m.meta.row[mainTabDDL], m.metaRowCount()-1; got != max {
+		t.Fatalf("offset = %d, want it clamped to %d", got, max)
+	}
+	m = send(t, m, press('k'), press('k'), press('k'), press('k'), press('k'), press('k'))
+	if m.meta.row[mainTabDDL] < 0 {
+		t.Fatalf("offset = %d, want it clamped at 0", m.meta.row[mainTabDDL])
+	}
+}
+
+// `y` copies the DDL, from the DDL tab and from the Data tab alike —
+// on the Data tab it fetches the metadata first.
+func TestCopyDDLToClipboard(t *testing.T) {
+	got := fakeClipboard(t)
+
+	m := send(t, metaBrowsing(t), press(']'), press(']'), press(']'), press('y'))
+	if !strings.Contains(*got, "CREATE TABLE") {
+		t.Fatalf("clipboard = %q", *got)
+	}
+	if !logContains(m, "-- copy DDL of orders to clipboard") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+
+	*got = ""
+	m = send(t, metaBrowsing(t), press('y'))
+	if m.tab != mainTabData {
+		t.Fatalf("y changed the tab to %v", m.tab)
+	}
+	if !strings.Contains(*got, "CREATE TABLE") {
+		t.Fatalf("clipboard after a Data-tab copy = %q", *got)
+	}
+}
+
+// A clipboard the environment does not support fails loudly in the log
+// rather than silently doing nothing.
+func TestCopyDDLFailureIsLogged(t *testing.T) {
+	prev := clipboardWrite
+	clipboardWrite = func(string) error { return context.Canceled }
+	t.Cleanup(func() { clipboardWrite = prev })
+
+	m := send(t, metaBrowsing(t), press(']'), press(']'), press(']'), press('y'))
+	if !logContains(m, "-- copy DDL of orders FAILED") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+}
+
+// Opening another relation keeps the selected tab but drops the
+// metadata and the scroll positions of the one that was open.
+func TestSelectingAnotherTableResetsTabState(t *testing.T) {
+	m := send(t, metaBrowsing(t), press(']'))
+	m = send(t, m, press('j'), press('j'))
+	if m.meta.row[mainTabStructure] == 0 {
+		t.Fatal("cursor did not move in the Structure tab")
+	}
+
+	m = send(t, m, press('3'))
+	if !m.panels[panelTables].selectByName("people") {
+		t.Fatalf("people not listed: %v", m.panels[panelTables].items)
+	}
+	m = send(t, m, special(tea.KeyEnter, 0))
+
+	if m.tab != mainTabStructure {
+		t.Errorf("tab = %v, want the Structure tab to survive", m.tab)
+	}
+	if m.meta.row[mainTabStructure] != 0 {
+		t.Errorf("cursor = %d, want it reset for the new relation", m.meta.row[mainTabStructure])
+	}
+	if m.meta.table != "people" {
+		t.Errorf("metadata table = %q, want people", m.meta.table)
+	}
+	names := make([]string, 0, len(m.meta.cols))
+	for _, c := range m.meta.cols {
+		names = append(names, c.Name)
+	}
+	if strings.Join(names, ",") != "id,email" {
+		t.Errorf("columns = %v, want [id email]", names)
+	}
+}
+
+// A stale reply — one for a relation the user has already left — is
+// dropped instead of overwriting the metadata on screen.
+func TestStaleMetadataReplyIsDropped(t *testing.T) {
+	m := send(t, metaBrowsing(t), press(']'))
+	stale := metaLoadedMsg{
+		req:   m.meta.req - 1,
+		conn:  m.active,
+		table: m.data.table,
+		cols:  []db.Column{{Name: "ghost"}},
+	}
+	next, _ := m.Update(stale)
+	m = next.(Model)
+	for _, c := range m.meta.cols {
+		if c.Name == "ghost" {
+			t.Fatal("a stale reply overwrote the metadata on screen")
+		}
+	}
+}
+
+// Introspection failures land in the log and in the tab, and never
+// clear the relation.
+func TestMetadataErrorIsShown(t *testing.T) {
+	m := send(t, metaBrowsing(t), press(']'))
+	next, _ := m.Update(metaLoadedMsg{
+		req:   m.meta.req,
+		conn:  m.active,
+		table: m.data.table,
+		err:   context.DeadlineExceeded,
+	})
+	m = next.(Model)
+	if !strings.Contains(m.View().Content, context.DeadlineExceeded.Error()) {
+		t.Errorf("the Structure tab does not show the failure")
+	}
+}
+
+// R on an introspection tab re-reads the metadata rather than the page.
+func TestRefreshReloadsMetadata(t *testing.T) {
+	m := send(t, metaBrowsing(t), press(']'))
+	before := m.meta.req
+	m = send(t, m, press('R'))
+	if m.meta.req == before {
+		t.Fatalf("R did not re-read the metadata (req still %d)", before)
+	}
+	if !m.meta.loaded {
+		t.Fatal("metadata not reloaded")
+	}
+}
+
+func TestColumnKeyInfo(t *testing.T) {
+	idx := []db.Index{
+		{Name: "pk", Columns: []string{"id"}, Unique: true, Primary: true},
+		{Name: "uq", Columns: []string{"email"}, Unique: true},
+		{Name: "ix", Columns: []string{"org_id"}},
+	}
+	fks := []db.ForeignKey{{Columns: []string{"org_id"}, RefTable: "orgs"}}
+	cases := []struct {
+		col  db.Column
+		want string
+	}{
+		{db.Column{Name: "id", PrimaryKey: true}, "PK"},
+		{db.Column{Name: "email"}, "UNI"},
+		{db.Column{Name: "org_id"}, "IDX,FK"},
+		{db.Column{Name: "note"}, ""},
+	}
+	for _, c := range cases {
+		if got := columnKeyInfo(c.col, idx, fks); got != c.want {
+			t.Errorf("columnKeyInfo(%s) = %q, want %q", c.col.Name, got, c.want)
+		}
+	}
+}

--- a/internal/ui/metaview.go
+++ b/internal/ui/metaview.go
@@ -1,0 +1,311 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"lazysql/internal/db"
+)
+
+// metaColGap separates the columns of the Structure and Indexes tables.
+const metaColGap = 2
+
+// mainTabBar is the first line of the main view: the four tabs with the
+// selected one highlighted, then the relation the tabs describe.
+func (m Model) mainTabBar(w int) string {
+	parts := make([]string, 0, mainTabCount)
+	for t := mainTab(0); t < mainTabCount; t++ {
+		style := m.style.muted
+		switch {
+		case t != m.tab:
+		case m.focus == panelMain:
+			style = m.style.titleFocused
+		default:
+			style = m.style.title
+		}
+		parts = append(parts, style.Render(mainTabNames[t]))
+	}
+	line := m.style.muted.Render("‹") +
+		strings.Join(parts, m.style.muted.Render("|")) +
+		m.style.muted.Render("›")
+	line += m.style.muted.Render(" "+displayDatabase(m.data.database)+".") + m.data.table
+	if m.tab == mainTabData && m.data.loading || m.tab.metadata() && m.meta.loading {
+		line += " " + m.style.pending.Render("loading…")
+	}
+	return truncate(line, w)
+}
+
+// metaContent renders the Structure, Indexes or DDL tab into a w x h
+// content box. Their shared loading and error states live here so the
+// three renderers only ever see data.
+func (m Model) metaContent(w, h int) string {
+	lines := []string{m.mainTabBar(w)}
+	body := maxInt(h-len(lines), 0)
+
+	switch {
+	case m.meta.err != "":
+		lines = append(lines, "", m.style.danger.Render(truncate(m.meta.err, w)))
+	case !m.meta.loaded && m.meta.loading:
+		lines = append(lines, "", m.style.pending.Render("reading table metadata…"))
+	case !m.meta.loaded:
+		lines = append(lines, "", m.style.muted.Render("no metadata yet"))
+	default:
+		switch m.tab {
+		case mainTabStructure:
+			lines = append(lines, m.structureLines(w, body)...)
+		case mainTabIndexes:
+			lines = append(lines, m.indexLines(w, body)...)
+		case mainTabDDL:
+			lines = append(lines, m.ddlLines(w, body)...)
+		}
+	}
+	return joinTruncated(lines, w, h)
+}
+
+// structureLines is the Structure tab: one row per column, with the key
+// and extra notes the engine reports.
+func (m Model) structureLines(w, h int) []string {
+	if len(m.meta.cols) == 0 {
+		return []string{"", m.style.muted.Render("no columns")}
+	}
+	rows := make([][]string, 0, len(m.meta.cols))
+	for i, c := range m.meta.cols {
+		null := "no"
+		if c.Nullable {
+			null = "yes"
+		}
+		def := ""
+		if c.Default != nil {
+			def = flatten(*c.Default)
+		}
+		rows = append(rows, []string{
+			fmt.Sprintf("%d", i+1),
+			c.Name,
+			c.DataType,
+			null,
+			def,
+			columnKeyInfo(c, m.meta.indexes, m.meta.fks),
+			c.Extra,
+		})
+	}
+	return m.metaTable([]string{"#", "name", "type", "null", "default", "key", "extra"},
+		rows, m.meta.row[mainTabStructure], true, w, h)
+}
+
+// columnKeyInfo summarizes how a column participates in the table's
+// keys: PK for the primary key, UNI/IDX for the indexes covering it and
+// FK when a foreign key constrains it.
+func columnKeyInfo(c db.Column, idx []db.Index, fks []db.ForeignKey) string {
+	var marks []string
+	add := func(mark string) {
+		for _, m := range marks {
+			if m == mark {
+				return
+			}
+		}
+		marks = append(marks, mark)
+	}
+	if c.PrimaryKey {
+		add("PK")
+	}
+	for _, ix := range idx {
+		if !containsName(ix.Columns, c.Name) {
+			continue
+		}
+		switch {
+		case ix.Primary:
+			add("PK")
+		case ix.Unique:
+			add("UNI")
+		default:
+			add("IDX")
+		}
+	}
+	for _, fk := range fks {
+		if containsName(fk.Columns, c.Name) {
+			add("FK")
+		}
+	}
+	return strings.Join(marks, ",")
+}
+
+func containsName(names []string, name string) bool {
+	for _, n := range names {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+// indexLines is the Indexes tab: the indexes first, then the foreign
+// keys with the table and columns they point at. Both are scrolled by
+// the same offset, so a long index list can be walked past to reach the
+// constraints under it.
+func (m Model) indexLines(w, h int) []string {
+	var lines []string
+
+	if len(m.meta.indexes) == 0 {
+		lines = append(lines, m.style.muted.Render("no indexes"))
+	} else {
+		rows := make([][]string, 0, len(m.meta.indexes))
+		for _, ix := range m.meta.indexes {
+			kind := "index"
+			switch {
+			case ix.Primary:
+				kind = "primary"
+			case ix.Unique:
+				kind = "unique"
+			}
+			rows = append(rows, []string{
+				ix.Name,
+				kind,
+				yesNo(ix.Unique),
+				strings.Join(ix.Columns, ", "),
+			})
+		}
+		lines = append(lines, m.metaTable(
+			[]string{"index", "type", "unique", "columns"}, rows, -1, false, w, 0)...)
+	}
+
+	lines = append(lines, "", m.style.title.Render("Foreign keys"))
+	if len(m.meta.fks) == 0 {
+		lines = append(lines, m.style.muted.Render("none"))
+	} else {
+		rows := make([][]string, 0, len(m.meta.fks))
+		for _, fk := range m.meta.fks {
+			ref := fk.RefTable
+			if len(fk.RefColumns) > 0 {
+				ref += " (" + strings.Join(fk.RefColumns, ", ") + ")"
+			}
+			rows = append(rows, []string{
+				fk.Name,
+				strings.Join(fk.Columns, ", "),
+				ref,
+				orDash(fk.OnUpdate),
+				orDash(fk.OnDelete),
+			})
+		}
+		lines = append(lines, m.metaTable(
+			[]string{"constraint", "columns", "references", "on update", "on delete"},
+			rows, -1, false, w, 0)...)
+	}
+	return scrollLines(lines, m.meta.row[mainTabIndexes], w, h)
+}
+
+// ddlLines is the DDL tab: the statement as the engine reports it (or,
+// where the engine keeps none, as lazysql synthesizes it), scrolled a
+// line at a time.
+func (m Model) ddlLines(w, h int) []string {
+	if m.meta.ddl == "" {
+		return []string{"", m.style.danger.Render(truncate("no DDL: "+m.ddlProblem(), w))}
+	}
+	var lines []string
+	for _, l := range strings.Split(strings.TrimRight(m.meta.ddl, "\n"), "\n") {
+		lines = append(lines, strings.ReplaceAll(l, "\t", "    "))
+	}
+	out := scrollLines(lines, m.meta.row[mainTabDDL], w, maxInt(h-1, 0))
+	hint := fmt.Sprintf("%d lines — y copies the statement", len(lines))
+	return append(out, m.style.keyHint.Render(truncate(hint, w)))
+}
+
+// scrollLines takes the window of a rendered block that starts at
+// offset, padding the offset back into range when the block shrank.
+func scrollLines(lines []string, offset, w, h int) []string {
+	if h <= 0 || len(lines) == 0 {
+		return nil
+	}
+	if max := len(lines) - h; offset > max {
+		offset = max
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	end := offset + h
+	if end > len(lines) {
+		end = len(lines)
+	}
+	out := make([]string, 0, end-offset)
+	for _, l := range lines[offset:end] {
+		out = append(out, truncate(l, w))
+	}
+	return out
+}
+
+// metaTable renders a header row plus rows, every column padded to its
+// widest cell. With cursor >= 0 the matching row is highlighted and the
+// window follows it; with h == 0 the whole table is returned and the
+// caller scrolls it.
+func (m Model) metaTable(headers []string, rows [][]string, cursor int, follow bool, w, h int) []string {
+	widths := make([]int, len(headers))
+	for i, hd := range headers {
+		widths[i] = lipgloss.Width(hd)
+	}
+	for _, r := range rows {
+		for i, cell := range r {
+			if i < len(widths) {
+				if n := lipgloss.Width(cell); n > widths[i] {
+					widths[i] = n
+				}
+			}
+		}
+	}
+	for i := range widths {
+		if widths[i] > maxColWidth {
+			widths[i] = maxColWidth
+		}
+	}
+
+	render := func(cells []string, style lipgloss.Style) string {
+		var b strings.Builder
+		for i, cell := range cells {
+			if i > 0 {
+				b.WriteString(strings.Repeat(" ", metaColGap))
+			}
+			width := widths[i]
+			// The last column takes the space it needs instead of
+			// padding out to the right edge.
+			text := truncate(flatten(cell), width)
+			if i < len(cells)-1 {
+				text = pad(text, width)
+			}
+			b.WriteString(text)
+		}
+		return style.Render(truncate(b.String(), w))
+	}
+
+	out := []string{render(headers, m.style.gridHeader)}
+	body := rows
+	first := 0
+	if follow && h > 1 {
+		// One line went to the header.
+		start, end := rowWindow(len(rows), cursor, h-1)
+		body, first = rows[start:end], start
+	}
+	for i, r := range body {
+		style := lipgloss.NewStyle()
+		if first+i == cursor && m.focus == panelMain {
+			style = m.style.rowCursor
+		}
+		out = append(out, render(r, style))
+	}
+	return out
+}
+
+func yesNo(b bool) string {
+	if b {
+		return "yes"
+	}
+	return "no"
+}
+
+// orDash renders a referential action, or a dash when the engine leaves
+// it at its default.
+func orDash(s string) string {
+	if s = strings.TrimSpace(s); s == "" || strings.EqualFold(s, "NO ACTION") {
+		return "—"
+	}
+	return s
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -90,6 +90,11 @@ type Model struct {
 	// data is the main view's Data tab: one page of m.table.
 	data dataView
 
+	// tab is the main view's selected tab and meta is the metadata the
+	// three introspection tabs render.
+	tab  mainTab
+	meta metaView
+
 	startupErr string
 
 	keys  keyMap
@@ -178,6 +183,8 @@ func (m *Model) resetBrowse() {
 	m.database = ""
 	m.table = ""
 	m.data = dataView{}
+	m.tab = mainTabData
+	m.resetMeta()
 	m.relations = nil
 	m.tableTab = tabTables
 	if m.focus == panelMain {
@@ -199,6 +206,7 @@ func (m *Model) openDatabase(name string) tea.Cmd {
 	// The open page belongs to the namespace we are leaving.
 	m.table = ""
 	m.data = dataView{}
+	m.resetMeta()
 	if m.focus == panelMain {
 		m.focus = panelTables
 	}
@@ -239,6 +247,9 @@ func (m *Model) reloadFocused() tea.Cmd {
 			loadRelationsCmd(m.active, m.driver, m.database),
 		)
 	case panelMain:
+		if m.tab.metadata() {
+			return m.reloadMeta()
+		}
 		return m.reloadPage()
 	}
 	return logCmd("-- refresh %s", panelTitles[m.focus])
@@ -370,6 +381,29 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.data.cols = msg.result.Columns
 		m.data.rows = msg.result.Rows
 		m.data.clampCursor()
+		return m, nil
+
+	case metaLoadedMsg:
+		if !m.freshMeta(msg) {
+			return m, nil
+		}
+		m.meta.loading = false
+		m.meta.loaded = true
+		if msg.err != nil {
+			m.meta.err = msg.err.Error()
+			m.meta.copyAfterLoad = false
+			return m, logCmd("-- introspect %s FAILED: %v", msg.table, msg.err)
+		}
+		m.meta.cols, m.meta.indexes, m.meta.fks = msg.cols, msg.indexes, msg.fks
+		m.meta.ddl, m.meta.ddlErr = msg.ddl, ""
+		if msg.ddlErr != nil {
+			m.meta.ddlErr = msg.ddlErr.Error()
+		}
+		if m.meta.copyAfterLoad {
+			m.meta.copyAfterLoad = false
+			cmd := m.copyDDL()
+			return m, cmd
+		}
 		return m, nil
 
 	case rowCountMsg:
@@ -541,7 +575,11 @@ func (m Model) updateFilter(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 // runAction performs a context action. Both a key press and an entry in the
 // `a` actions menu reach the panel behaviour through here.
 func (m Model) runAction(id actionID) (Model, tea.Cmd) {
-	// The data grid's actions live with the grid.
+	// The main view's tab actions run first: they mean the same thing
+	// on every tab. The data grid's own actions live with the grid.
+	if mm, cmd, handled := m.metaActions(id); handled {
+		return mm, cmd
+	}
 	if mm, cmd, handled := m.dataActions(id); handled {
 		return mm, cmd
 	}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -153,6 +153,9 @@ func (m Model) mainContent(w, h int) string {
 		return m.connectionDetail(w, h)
 	}
 	if m.data.open() {
+		if m.tab.metadata() {
+			return m.metaContent(w, h)
+		}
 		return m.dataContent(w, h)
 	}
 	if m.focus >= panelCount {

--- a/wiki/design/main-view-tabs.md
+++ b/wiki/design/main-view-tabs.md
@@ -1,0 +1,100 @@
+---
+type: Design Decision
+title: Main-view tabs — Data, Structure, Indexes, DDL
+description: Why the main view has four tabs behind one metadata fetch, why they cycle with [ and ] rather than digits, and what survives when the selected relation changes.
+tags: [ui, main-view, tabs, introspection, ddl, clipboard]
+generated:
+  by: claude-code/opus-5
+  at: 2026-08-09T00:00:00Z
+---
+
+# Main-view tabs — Data, Structure, Indexes, DDL
+
+The main view shows one open relation through four tabs. `Data` is the
+paged grid from [design/data-grid](data-grid.md); the other three render
+introspection results:
+
+| Tab | Contents |
+| --- | --- |
+| `Structure` | one row per column: position, name, type, nullability, default, key info, extra |
+| `Indexes` | the indexes (name, type, unique, columns), then the foreign keys with their referenced table and columns |
+| `DDL` | the `CREATE` statement, scrollable, `y` copies it |
+
+## One fetch behind three tabs
+
+`Structure`, `Indexes` and `DDL` share a single `metaView` filled by one
+`loadMetaCmd`, which calls `TableColumns`, `TableIndexes`,
+`TableForeignKeys` and `TableDDL` in one command. Splitting them into
+three commands would buy three independent loading states and three sets
+of staleness checks for four catalog queries that together cost less
+than one page read.
+
+The fetch is lazy: opening a relation loads the Data page, and the
+metadata only when a tab that needs it is selected (or `y` is pressed).
+Browsing a table list with only the Data tab open never issues an
+introspection query.
+
+Two error slots, not one:
+
+- `metaView.err` is fatal for all three tabs — the columns could not be
+  read at all.
+- `metaView.ddlErr` costs only the DDL tab. An engine can describe a
+  relation perfectly well and still refuse to produce a `CREATE`
+  statement for it (a view on some engines, a table the user cannot
+  `SHOW CREATE`), and that must not blank out `Structure`.
+
+## `[` / `]`, not `1` / `2` / `3`
+
+The issue offered digit sub-shortcuts as an alternative to bracket
+cycling. Digits are not available: `1`–`4` are **global** panel jumps,
+handled in `updateGlobal` before the focused view ever sees the key, and
+that ordering is the shell's contract
+([design/tui-shell-architecture](tui-shell-architecture.md)). Stealing
+them inside the main view would make the same key mean two different
+things depending on focus — exactly what the numbered-panel convention
+exists to prevent.
+
+So the tabs cycle with `[` (previous) and `]` (next), as two separate
+bindings rather than one two-key binding: with four tabs, walking
+backwards matters, and every key in the options bar must be individually
+bound and documented
+([design/keybindings-single-source](keybindings-single-source.md)). The
+tab bar at the top of the main view is the discoverability half —
+`‹Data|Structure|Indexes|DDL›` with the selected tab highlighted, in the
+same idiom as the `[3]` panel's Tables/Views sub-tabs.
+
+## What resets when the relation changes
+
+Selecting another table keeps the **selected tab** and drops
+**everything else**: cached columns/indexes/foreign keys/DDL, the
+per-tab cursor and scroll offsets, and any error. Walking down a table
+list with `Structure` open and watching each table's columns is the
+reason to have tabs at all, so the tab is the one piece of state worth
+carrying across relations. Switching connection or namespace resets the
+tab to `Data` too, because there is no longer a relation the tab could
+describe.
+
+Stale replies are dropped the same way the data grid drops them: a
+`metaLoadedMsg` is applied only when its `req`, connection and table all
+still match.
+
+## `j`/`k` mean different things per tab
+
+- `Structure` has a row cursor; the window follows it.
+- `Indexes` and `DDL` scroll by offset — their rows are not selectable
+  targets, and the DDL is free text.
+
+`R` (and `enter`) re-read whatever the visible tab shows: the metadata
+on the three introspection tabs, the page on `Data`.
+
+## Copying the DDL
+
+`y` copies through `clipboardWrite` in `internal/ui/clipboard.go` — a
+package-level variable wrapping `atotto/clipboard`, so the copy/export
+work has one seam to grow from and tests can replace it (a test run must
+never overwrite the developer's real clipboard).
+
+`y` works from any tab, including `Data`. When no metadata is cached
+yet, it sets `copyAfterLoad`, starts the fetch and copies when the reply
+lands, rather than telling the user to visit the DDL tab first. Success
+and failure both land in the command log.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -14,6 +14,7 @@ concept with YAML frontmatter. Concept IDs are bundle-relative paths without
 - [design/connection-form-modal](design/connection-form-modal.md) — Design Decision — one reusable multi-field modal with engine-driven field visibility.
 - [design/catalog-browsing](design/catalog-browsing.md) — Design Decision — async catalog loads, inline fuzzy filter, tables/views sub-tabs, pseudo-database for single-namespace engines.
 - [design/data-grid](design/data-grid.md) — Design Decision — one-page-at-a-time main view, derived scroll windows, the `panelMain` focus target, and the parse-first quick filter.
+- [design/main-view-tabs](design/main-view-tabs.md) — Design Decision — Data/Structure/Indexes/DDL tabs behind one metadata fetch, `[`/`]` cycling instead of digits, and what survives a relation change.
 
 ## reference
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -65,3 +65,24 @@ Chronological history of wiki changes, newest last.
   matches no column as a string literal, so `"typo" = 1` quietly matches nothing
   instead of erroring. Safety is unaffected (the value is still bound), but a
   missing column is not a way to provoke a query failure there.
+- Added [design/main-view-tabs](design/main-view-tabs.md) with the
+  `Data | Structure | Indexes | DDL` main view (issue #6): the three
+  introspection tabs share one lazy metadata fetch and one staleness
+  check, `metaView.ddlErr` is kept apart from `metaView.err` so a
+  missing `CREATE` statement costs only the DDL tab, and the tabs cycle
+  with `[`/`]` because `1`–`4` are global panel jumps that the main
+  view must not redefine. Selecting another relation keeps the tab and
+  drops everything else.
+- Extended the driver for those tabs: `Column.Extra`, a `ForeignKey`
+  type and `Driver.TableForeignKeys` across all five engines, and
+  `synthesizeDDL` now emits foreign key constraints and secondary
+  `CREATE INDEX` statements — so PostgreSQL's synthesized DDL says as
+  much as MySQL's `SHOW CREATE TABLE`.
+- Updated
+  [reference/dialect-introspection-quirks](reference/dialect-introspection-quirks.md)
+  with what that cost per engine: SQLite hides `AUTOINCREMENT` in the
+  stored DDL text and names no foreign key constraint, DuckDB spells
+  the referenced table only inside `constraint_text`, PostgreSQL needs
+  `conkey`/`confkey` unnested *together* and its action codes cast
+  `::text` for pgx, and MySQL splits foreign keys across
+  `key_column_usage` and `referential_constraints`.

--- a/wiki/reference/dialect-introspection-quirks.md
+++ b/wiki/reference/dialect-introspection-quirks.md
@@ -26,6 +26,16 @@ sources:
   relation-kind column costs nothing.
 - Original DDL comes from `sqlite_master.sql` (NULL for auto-created
   indexes — filter `sql IS NOT NULL`).
+- `AUTOINCREMENT` is reported by **nothing**: not `table_info`, not
+  `index_list`. It exists only in the stored `sqlite_master.sql` text,
+  so `tableColumns` reads the DDL back and marks the single
+  `INTEGER PRIMARY KEY` column when the keyword appears. A failure
+  there is dropped — it costs a display note, not the column list.
+- `PRAGMA foreign_key_list` names no constraint: the columns are
+  `(id, seq, table, from, to, on_update, on_delete, match)`, `id`
+  groups the columns of one constraint and doubles as its display name.
+  `to` is NULL when the reference targets the referenced table's
+  primary key implicitly.
 - In-memory DSN: `:memory:`.
 
 ## DuckDB (`marcboeker/go-duckdb/v2`, driver name `duckdb`)
@@ -48,6 +58,12 @@ sources:
   — there is no catalog column to read the kind from. Each branch needs
   its own copy of the `database_name` argument.
 - `duckdb_tables().sql` / `duckdb_views().sql` hold reconstructed DDL.
+- Foreign keys come from `duckdb_constraints()` with
+  `constraint_type = 'FOREIGN KEY'`, but the **referenced** table and
+  columns are only spelled inside `constraint_text`
+  (`FOREIGN KEY (user_id) REFERENCES users(id)`) — and the catalog's
+  own reference columns have changed names between DuckDB versions, so
+  parsing that text is the version-independent route.
 
 ## PostgreSQL (`jackc/pgx/v5/stdlib`, driver name `pgx`)
 
@@ -57,7 +73,20 @@ sources:
   `VIEW`, `FOREIGN`, `LOCAL TEMPORARY` — match on "contains view"
   rather than equality.
 - No stored CREATE TABLE text; DDL is synthesized from
-  `information_schema.columns`.
+  `information_schema.columns` plus the introspected indexes and
+  foreign keys. It is a faithful description, not a byte-identical
+  replay of the original statement.
+- Foreign keys: `pg_constraint` with `contype = 'f'`. `conkey` and
+  `confkey` are positionally paired arrays, so unnest them **together**
+  — `JOIN LATERAL unnest(c.conkey, c.confkey) WITH ORDINALITY` — or the
+  column pairing is lost.
+- `confupdtype`/`confdeltype` are single chars (`a` no action,
+  `r` restrict, `c` cascade, `n` set null, `d` set default) of the
+  internal `"char"` type; cast them `::text` so the pgx decoder stays
+  on the plain-string path.
+- Column "extra": `is_identity` + `identity_generation` (PG 10+),
+  `is_generated` (PG 12+), and the older `serial` types, which show up
+  only as a `nextval(...)` column default.
 - Primary key / index columns via `pg_index` with
   `to_regclass($1)` on the quoted `schema.table` string — pass the
   qualified name as a **value**, quoting each part with `QuoteIdent`.
@@ -73,3 +102,15 @@ sources:
   different column set for views; scan positionally.
 - Primary key detection: `columns.column_key = 'PRI'`; the PK index in
   `statistics` is always named `PRIMARY`.
+- `information_schema.columns.extra` is where `auto_increment`,
+  `DEFAULT_GENERATED` and `STORED GENERATED` live.
+- Foreign keys need **two** tables: `key_column_usage` for the column
+  pairs in key order (`referenced_table_name IS NOT NULL` filters out
+  plain unique/primary rows) and `referential_constraints` for the
+  `update_rule`/`delete_rule`. Join on schema **and** constraint name;
+  the extra `table_name` predicate is defensive — InnoDB keeps foreign
+  key names unique per schema, but the join costs nothing and pins the
+  row to the table being introspected.
+- `key_column_usage.referenced_table_schema` is worth selecting: a
+  constraint may point at a table in another schema, and the UI shows
+  the qualified name only then.


### PR DESCRIPTION
Adds a tab bar to the main view with Structure (columns + key info), Indexes (incl. foreign keys), and scrollable DDL with clipboard copy. Driver layer gains per-dialect FK introspection. SQLite and DuckDB paths exercised by tests; MySQL/Postgres SQL reviewed but not run against live servers.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139rhNA79AoksWw97zoxwWA