### PR TITLE
Stage inline cell edits with commit/rollback changeset

### DIFF
--- a/internal/db/changeset.go
+++ b/internal/db/changeset.go
@@ -1,0 +1,154 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Staged mutations. lazysql never executes destructive SQL as a side
+// effect of editing: a cell edit only records a CellChange here, and the
+// SQL runs when the user explicitly commits the whole changeset — in one
+// transaction, so a failure applies nothing.
+
+// CellChange is one staged single-cell UPDATE. The row is identified by
+// the table's primary key, never by heuristics: PKCols and PKVals are
+// positionally paired and always cover the full (possibly composite)
+// key. NewValue nil means SQL NULL.
+type CellChange struct {
+	Database string
+	Table    string
+	PKCols   []string
+	PKVals   []any
+	Column   string
+	OldValue any
+	NewValue any
+}
+
+// key identifies the cell a change targets: same key = same cell, so a
+// second edit of a cell replaces the first instead of stacking on it.
+// Values are keyed with their type so int64(1) and "1" stay distinct.
+func (c CellChange) key() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\x00%s\x00%s", c.Database, c.Table, c.Column)
+	for _, v := range c.PKVals {
+		fmt.Fprintf(&b, "\x00%T:%v", v, v)
+	}
+	return b.String()
+}
+
+// Changeset accumulates staged changes in the order they were first
+// staged, which is also the order they execute in on commit.
+type Changeset struct {
+	changes []CellChange
+	index   map[string]int
+}
+
+// NewChangeset returns an empty changeset.
+func NewChangeset() *Changeset {
+	return &Changeset{index: map[string]int{}}
+}
+
+// Stage records a change, replacing an earlier change of the same cell.
+// A replacement keeps the original OldValue so unstaging or displaying
+// the change still refers to what the database holds.
+func (cs *Changeset) Stage(c CellChange) {
+	k := c.key()
+	if i, ok := cs.index[k]; ok {
+		c.OldValue = cs.changes[i].OldValue
+		cs.changes[i] = c
+		return
+	}
+	cs.index[k] = len(cs.changes)
+	cs.changes = append(cs.changes, c)
+}
+
+// Unstage drops the staged change of one cell and reports whether there
+// was one.
+func (cs *Changeset) Unstage(database, table string, pkVals []any, column string) bool {
+	k := CellChange{Database: database, Table: table, PKVals: pkVals, Column: column}.key()
+	i, ok := cs.index[k]
+	if !ok {
+		return false
+	}
+	cs.changes = append(cs.changes[:i], cs.changes[i+1:]...)
+	delete(cs.index, k)
+	for j := i; j < len(cs.changes); j++ {
+		cs.index[cs.changes[j].key()] = j
+	}
+	return true
+}
+
+// Lookup returns the staged change of one cell, if any.
+func (cs *Changeset) Lookup(database, table string, pkVals []any, column string) (CellChange, bool) {
+	k := CellChange{Database: database, Table: table, PKVals: pkVals, Column: column}.key()
+	if i, ok := cs.index[k]; ok {
+		return cs.changes[i], true
+	}
+	return CellChange{}, false
+}
+
+// PKColsFor returns the primary key columns recorded for a table, taken
+// from any staged change of it. It lets the grid find the key columns of
+// rendered rows without re-introspecting the table.
+func (cs *Changeset) PKColsFor(database, table string) []string {
+	for _, c := range cs.changes {
+		if c.Database == database && c.Table == table {
+			return c.PKCols
+		}
+	}
+	return nil
+}
+
+// Len is how many changes are staged.
+func (cs *Changeset) Len() int { return len(cs.changes) }
+
+// All returns the staged changes in commit order. Callers must not
+// mutate the slice.
+func (cs *Changeset) All() []CellChange { return cs.changes }
+
+// Clear discards every staged change.
+func (cs *Changeset) Clear() {
+	cs.changes = nil
+	cs.index = map[string]int{}
+}
+
+// Statement is one parameterized SQL statement ready to execute.
+type Statement struct {
+	SQL  string
+	Args []any
+}
+
+// UpdateSQL renders one staged change as a parameterized UPDATE: the new
+// value and every key value travel as parameters, identifiers get the
+// dialect's quoting. Nothing user-supplied reaches the statement text.
+func UpdateSQL(d Dialect, c CellChange) Statement {
+	var b strings.Builder
+	args := make([]any, 0, 1+len(c.PKVals))
+	b.WriteString("UPDATE ")
+	b.WriteString(qualifiedTable(d, c.Database, c.Table))
+	b.WriteString(" SET ")
+	b.WriteString(d.QuoteIdent(c.Column))
+	b.WriteString(" = ")
+	b.WriteString(d.Placeholder(1))
+	args = append(args, c.NewValue)
+	b.WriteString(" WHERE ")
+	for i, pk := range c.PKCols {
+		if i > 0 {
+			b.WriteString(" AND ")
+		}
+		b.WriteString(d.QuoteIdent(pk))
+		b.WriteString(" = ")
+		b.WriteString(d.Placeholder(len(args) + 1))
+		args = append(args, c.PKVals[i])
+	}
+	return Statement{SQL: b.String(), Args: args}
+}
+
+// Statements renders the whole changeset in commit order.
+func (cs *Changeset) Statements(d Dialect) []Statement {
+	out := make([]Statement, 0, len(cs.changes))
+	for _, c := range cs.changes {
+		out = append(out, UpdateSQL(d, c))
+	}
+	return out
+}

--- a/internal/db/changeset_test.go
+++ b/internal/db/changeset_test.go
@@ -1,0 +1,160 @@
+package db
+
+import (
+	"context"
+	"slices"
+	"testing"
+)
+
+func dialect(t *testing.T, e Engine) Dialect {
+	t.Helper()
+	d, err := DialectFor(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// Every engine gets its own quoting and placeholder style, and both the
+// new value and the key values travel as parameters.
+func TestUpdateSQLPerDialect(t *testing.T) {
+	c := CellChange{
+		Table:    "users",
+		PKCols:   []string{"id"},
+		PKVals:   []any{int64(3)},
+		Column:   "email",
+		NewValue: "x@example.com",
+	}
+	cases := []struct {
+		engine Engine
+		want   string
+	}{
+		{EngineSQLite, `UPDATE "users" SET "email" = ? WHERE "id" = ?`},
+		{EnginePostgres, `UPDATE "users" SET "email" = $1 WHERE "id" = $2`},
+		{EngineMySQL, "UPDATE `users` SET `email` = ? WHERE `id` = ?"},
+	}
+	for _, tc := range cases {
+		st := UpdateSQL(dialect(t, tc.engine), c)
+		if st.SQL != tc.want {
+			t.Errorf("%s: SQL = %q, want %q", tc.engine, st.SQL, tc.want)
+		}
+		if !slices.Equal(st.Args, []any{any("x@example.com"), any(int64(3))}) {
+			t.Errorf("%s: args = %v", tc.engine, st.Args)
+		}
+	}
+}
+
+// A composite key contributes one predicate per column, a qualified
+// table keeps the database part, and NULL is a bound nil parameter.
+func TestUpdateSQLCompositeKeyAndNull(t *testing.T) {
+	c := CellChange{
+		Database: "app",
+		Table:    "grades",
+		PKCols:   []string{"student", "course"},
+		PKVals:   []any{int64(1), "math"},
+		Column:   "grade",
+		NewValue: nil,
+	}
+	st := UpdateSQL(dialect(t, EnginePostgres), c)
+	want := `UPDATE "app"."grades" SET "grade" = $1 WHERE "student" = $2 AND "course" = $3`
+	if st.SQL != want {
+		t.Fatalf("SQL = %q, want %q", st.SQL, want)
+	}
+	if len(st.Args) != 3 || st.Args[0] != nil {
+		t.Fatalf("args = %v, want a leading nil", st.Args)
+	}
+}
+
+// Staging the same cell twice replaces the change and keeps the original
+// OldValue; unstaging removes exactly one cell.
+func TestChangesetStageReplaceUnstage(t *testing.T) {
+	cs := NewChangeset()
+	base := CellChange{Table: "t", PKCols: []string{"id"}, PKVals: []any{int64(1)}, Column: "c"}
+
+	first := base
+	first.OldValue, first.NewValue = "orig", "v1"
+	cs.Stage(first)
+	second := base
+	second.OldValue, second.NewValue = "v1", "v2"
+	cs.Stage(second)
+
+	if cs.Len() != 1 {
+		t.Fatalf("Len = %d, want the second edit to replace the first", cs.Len())
+	}
+	got, ok := cs.Lookup("", "t", []any{int64(1)}, "c")
+	if !ok || got.NewValue != "v2" || got.OldValue != "orig" {
+		t.Fatalf("Lookup = %+v, want NewValue v2 with the original OldValue", got)
+	}
+
+	other := base
+	other.PKVals = []any{int64(2)}
+	other.NewValue = "x"
+	cs.Stage(other)
+	if !cs.Unstage("", "t", []any{int64(1)}, "c") {
+		t.Fatal("Unstage missed a staged cell")
+	}
+	if cs.Len() != 1 {
+		t.Fatalf("Len = %d after unstage, want 1", cs.Len())
+	}
+	if _, ok := cs.Lookup("", "t", []any{int64(2)}, "c"); !ok {
+		t.Fatal("unstaging one cell dropped another")
+	}
+	cs.Clear()
+	if cs.Len() != 0 {
+		t.Fatal("Clear left changes behind")
+	}
+}
+
+// Key values are compared with their type, so row "1" and row 1 are
+// different cells.
+func TestChangesetKeysAreTyped(t *testing.T) {
+	cs := NewChangeset()
+	cs.Stage(CellChange{Table: "t", PKCols: []string{"id"}, PKVals: []any{int64(1)}, Column: "c", NewValue: "a"})
+	cs.Stage(CellChange{Table: "t", PKCols: []string{"id"}, PKVals: []any{"1"}, Column: "c", NewValue: "b"})
+	if cs.Len() != 2 {
+		t.Fatalf("Len = %d, want int64(1) and \"1\" kept apart", cs.Len())
+	}
+}
+
+// The whole commit is one transaction: a failing statement rolls back
+// the ones before it.
+func TestExecTxRollsBackOnError(t *testing.T) {
+	ctx := context.Background()
+	drv := openTest(t, EngineSQLite, ":memory:")
+	seed(t, drv)
+	d := drv.Dialect()
+
+	stmts := []Statement{
+		UpdateSQL(d, CellChange{Table: "users", PKCols: []string{"id"}, PKVals: []any{int64(1)},
+			Column: "email", NewValue: "changed@example.com"}),
+		// name is NOT NULL, so this one fails.
+		UpdateSQL(d, CellChange{Table: "users", PKCols: []string{"id"}, PKVals: []any{int64(2)},
+			Column: "name", NewValue: nil}),
+	}
+	if _, err := drv.ExecTx(ctx, stmts); err == nil {
+		t.Fatal("ExecTx succeeded, want the NOT NULL violation to fail it")
+	}
+	rs, err := drv.Query(ctx, "SELECT email FROM users WHERE id = "+d.Placeholder(1), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := rs.Rows[0][0]; got != "alice@example.com" {
+		t.Fatalf("email = %v, want the first UPDATE rolled back", got)
+	}
+
+	// The same first statement alone commits fine.
+	results, err := drv.ExecTx(ctx, stmts[:1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].RowsAffected != 1 {
+		t.Fatalf("results = %+v, want one row affected", results)
+	}
+	rs, err = drv.Query(ctx, "SELECT email FROM users WHERE id = "+d.Placeholder(1), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := rs.Rows[0][0]; got != "changed@example.com" {
+		t.Fatalf("email = %v, want the committed value", got)
+	}
+}

--- a/internal/db/conn.go
+++ b/internal/db/conn.go
@@ -218,6 +218,36 @@ func (c *conn) Exec(ctx context.Context, query string, args ...any) (ExecResult,
 	return out, nil
 }
 
+func (c *conn) ExecTx(ctx context.Context, stmts []Statement) ([]ExecResult, error) {
+	if c.db == nil {
+		return nil, errNotConnected
+	}
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]ExecResult, 0, len(stmts))
+	for i, s := range stmts {
+		res, err := tx.ExecContext(ctx, s.SQL, s.Args...)
+		if err != nil {
+			tx.Rollback()
+			return nil, fmt.Errorf("statement %d of %d: %w", i+1, len(stmts), err)
+		}
+		r := ExecResult{}
+		if n, err := res.RowsAffected(); err == nil {
+			r.RowsAffected = n
+		}
+		if id, err := res.LastInsertId(); err == nil {
+			r.LastInsertID = id
+		}
+		out = append(out, r)
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *conn) Query(ctx context.Context, query string, args ...any) (*ResultSet, error) {
 	if c.db == nil {
 		return nil, errNotConnected

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -183,6 +183,9 @@ type Driver interface {
 
 	// Exec runs a statement with parameters (dialect placeholder style).
 	Exec(ctx context.Context, query string, args ...any) (ExecResult, error)
+	// ExecTx runs the statements in one transaction: the first error
+	// rolls everything back, so either all of them applied or none did.
+	ExecTx(ctx context.Context, stmts []Statement) ([]ExecResult, error)
 	// Query runs an arbitrary SQL query with parameters.
 	Query(ctx context.Context, query string, args ...any) (*ResultSet, error)
 }

--- a/internal/ui/data.go
+++ b/internal/ui/data.go
@@ -385,6 +385,18 @@ func (m Model) dataActions(id actionID) (Model, tea.Cmd, bool) {
 			name = m.data.cols[m.data.col].Name
 		}
 		m.modal = newCellModal(name, v)
+	case actEditCell:
+		cmd := m.startEdit()
+		return m, cmd, true
+	case actCommitChanges:
+		cmd := m.openCommitModal()
+		return m, cmd, true
+	case actUnstageCell:
+		cmd := m.unstageAtCursor()
+		return m, cmd, true
+	case actDiscardChanges:
+		cmd := m.confirmDiscard()
+		return m, cmd, true
 	default:
 		return m, nil, false
 	}

--- a/internal/ui/datagrid.go
+++ b/internal/ui/datagrid.go
@@ -30,12 +30,14 @@ type gridColumn struct {
 	width  int
 	cells  []string
 	nulls  []bool
+	staged []bool
 }
 
 // buildGrid formats the whole page once so column widths, the header
 // and every row agree on the same strings.
 func (m Model) buildGrid() []gridColumn {
 	d := m.data
+	rowKeys := m.stagedRowKeys()
 	cols := make([]gridColumn, len(d.cols))
 	for i, c := range d.cols {
 		header := c.Name
@@ -51,12 +53,21 @@ func (m Model) buildGrid() []gridColumn {
 			typ:    strings.ToLower(c.DataType),
 			cells:  make([]string, len(d.rows)),
 			nulls:  make([]bool, len(d.rows)),
+			staged: make([]bool, len(d.rows)),
 			width:  maxInt(lipgloss.Width(header), lipgloss.Width(c.DataType)),
 		}
 		for r, row := range d.rows {
 			var v any
 			if i < len(row) {
 				v = row[i]
+			}
+			// A staged cell shows its staged value — seeing the pending
+			// edit in place is the point of staging.
+			if rowKeys != nil && rowKeys[r] != nil {
+				if ch, ok := m.changes.Lookup(d.database, d.table, rowKeys[r], c.Name); ok {
+					v = ch.NewValue
+					g.staged[r] = true
+				}
 			}
 			g.nulls[r] = v == nil
 			g.cells[r] = flatten(db.FormatValue(v, nullText))
@@ -73,6 +84,23 @@ func (m Model) buildGrid() []gridColumn {
 		cols[i] = g
 	}
 	return cols
+}
+
+// stagedRowKeys returns each page row's primary key values, or nil when
+// nothing is staged for the open table. The key columns come from the
+// changeset itself, so highlighting works without a metadata fetch.
+func (m Model) stagedRowKeys() [][]any {
+	pkCols := m.changes.PKColsFor(m.data.database, m.data.table)
+	if pkCols == nil {
+		return nil
+	}
+	keys := make([][]any, len(m.data.rows))
+	for r := range m.data.rows {
+		if vals, ok := m.rowKeyVals(pkCols, r); ok {
+			keys[r] = vals
+		}
+	}
+	return keys
 }
 
 // flatten collapses whitespace that would otherwise break the row into
@@ -212,19 +240,20 @@ func (m Model) gridRow(cols []gridColumn, first, r, w int) string {
 			b.WriteString(gap)
 		}
 		text := ""
-		isNull := false
+		isNull, isStaged := false, false
 		if r < len(c.cells) {
-			text, isNull = c.cells[r], c.nulls[r]
+			text, isNull, isStaged = c.cells[r], c.nulls[r], c.staged[r]
 		}
-		b.WriteString(m.cellStyle(onRow, first+i == m.data.col, isNull).
+		b.WriteString(m.cellStyle(onRow, first+i == m.data.col, isNull, isStaged).
 			Render(pad(truncate(text, c.width), c.width)))
 	}
 	return truncate(b.String(), w)
 }
 
-// cellStyle picks the tint of one cell from the cursor position and
-// whether the value is NULL.
-func (m Model) cellStyle(onRow, onCol, isNull bool) lipgloss.Style {
+// cellStyle picks the tint of one cell from the cursor position, whether
+// the value is NULL and whether an edit of it is staged. Staged wins
+// over NULL: yellow is the "pending" color throughout the app.
+func (m Model) cellStyle(onRow, onCol, isNull, isStaged bool) lipgloss.Style {
 	style := lipgloss.NewStyle()
 	switch {
 	case onRow && onCol && m.focus == panelMain:
@@ -232,7 +261,10 @@ func (m Model) cellStyle(onRow, onCol, isNull bool) lipgloss.Style {
 	case onRow:
 		style = m.style.rowCursor
 	}
-	if isNull {
+	switch {
+	case isStaged:
+		style = style.Foreground(colorYellow).Bold(true)
+	case isNull:
 		style = style.Foreground(colorMuted)
 	}
 	return style
@@ -263,6 +295,9 @@ func (m Model) dataStatus() string {
 	parts = append(parts, page+")")
 
 	line := m.style.muted.Render(strings.Join(parts, " "))
+	if n := m.changes.Len(); n > 0 {
+		line += m.style.pending.Render("  " + countChanges(n))
+	}
 	if d.sort != nil {
 		dir := "asc"
 		if d.sort.Desc {

--- a/internal/ui/edit.go
+++ b/internal/ui/edit.go
@@ -1,0 +1,346 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"lazysql/internal/db"
+)
+
+// Inline editing, the staged way: `e` records a CellChange in the
+// changeset instead of executing anything. The UPDATEs only run when the
+// user confirms the commit modal, all in one transaction. A table
+// without a primary key cannot be edited at all — identifying a row by
+// anything less than its declared key is guessing, and lazysql does not
+// guess what an UPDATE will hit.
+
+// ---------- messages ----------
+
+// changesCommittedMsg reports the outcome of one commit transaction.
+type changesCommittedMsg struct {
+	stmts []db.Statement
+	err   error
+}
+
+// ---------- commands ----------
+
+func commitChangesCmd(drv db.Driver, stmts []db.Statement) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
+		defer cancel()
+		_, err := drv.ExecTx(ctx, stmts)
+		return changesCommittedMsg{stmts: stmts, err: err}
+	}
+}
+
+// ---------- model wiring ----------
+
+// startEdit is `e` on the Data tab. The primary key comes from the
+// cached metadata; when no tab has fetched it yet the fetch is started
+// and the modal opens when the reply lands, like `y` does for the DDL.
+func (m *Model) startEdit() tea.Cmd {
+	if !m.data.open() || m.tab.metadata() || m.driver == nil {
+		return nil
+	}
+	if len(m.data.rows) == 0 {
+		return logCmd("-- edit skipped: no rows on this page")
+	}
+	if m.meta.loaded {
+		return m.openEditModal()
+	}
+	m.meta.editAfterLoad = true
+	if m.meta.loading {
+		return nil
+	}
+	return m.startMetaLoad()
+}
+
+// editIdentity returns the primary key columns of the open table and
+// their values in one page row. A non-empty problem means the row cannot
+// be identified and editing is off.
+func (m Model) editIdentity(row int) (pkCols []string, pkVals []any, problem string) {
+	for _, c := range m.meta.cols {
+		if c.PrimaryKey {
+			pkCols = append(pkCols, c.Name)
+		}
+	}
+	if len(pkCols) == 0 {
+		return nil, nil, "the table has no primary key, so a row cannot be identified safely.\n\nlazysql refuses to guess row identity — add a primary key to edit this table."
+	}
+	if row < 0 || row >= len(m.data.rows) {
+		return nil, nil, "no row under the cursor."
+	}
+	vals, ok := m.rowKeyVals(pkCols, row)
+	if !ok {
+		return nil, nil, "the result set does not contain every primary key column."
+	}
+	return pkCols, vals, ""
+}
+
+// rowKeyVals picks the values of the named columns out of one page row.
+func (m Model) rowKeyVals(cols []string, row int) ([]any, bool) {
+	if row < 0 || row >= len(m.data.rows) {
+		return nil, false
+	}
+	vals := make([]any, len(cols))
+	for i, name := range cols {
+		found := false
+		for j, c := range m.data.cols {
+			if c.Name == name && j < len(m.data.rows[row]) {
+				vals[i] = m.data.rows[row][j]
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, false
+		}
+	}
+	return vals, true
+}
+
+// openEditModal builds the edit modal for the cell under the cursor.
+// Editing an already-staged cell resumes from its staged value.
+func (m *Model) openEditModal() tea.Cmd {
+	pkCols, pkVals, problem := m.editIdentity(m.data.row)
+	if problem != "" {
+		m.modal = &confirmModal{title: "Editing disabled", body: problem, danger: true}
+		return nil
+	}
+	if m.data.col >= len(m.data.cols) {
+		return nil
+	}
+	colName := m.data.cols[m.data.col].Name
+	old, _ := m.data.cell()
+
+	change := db.CellChange{
+		Database: m.data.database,
+		Table:    m.data.table,
+		PKCols:   pkCols,
+		PKVals:   pkVals,
+		Column:   colName,
+		OldValue: old,
+	}
+	initial := old
+	if staged, ok := m.changes.Lookup(change.Database, change.Table, pkVals, colName); ok {
+		change.OldValue = staged.OldValue
+		initial = staged.NewValue
+	}
+
+	nullable := true
+	for _, c := range m.meta.cols {
+		if c.Name == colName {
+			nullable = c.Nullable
+			break
+		}
+	}
+	m.modal = newEditCellModal(change, initial, nullable, rowLabel(pkCols, pkVals))
+	return nil
+}
+
+// rowLabel names the row being edited, e.g. "id=3" or "a=1, b=2".
+func rowLabel(pkCols []string, pkVals []any) string {
+	parts := make([]string, len(pkCols))
+	for i, c := range pkCols {
+		parts[i] = c + "=" + db.FormatValue(pkVals[i], nullText)
+	}
+	return strings.Join(parts, ", ")
+}
+
+// stageChange records a confirmed edit. Restoring a cell to its original
+// value unstages it instead of staging a no-op UPDATE.
+func (m *Model) stageChange(c db.CellChange) tea.Cmd {
+	if valuesEqual(c.NewValue, c.OldValue) {
+		if m.changes.Unstage(c.Database, c.Table, c.PKVals, c.Column) {
+			return logCmd("-- unstage %s.%s (original value restored)", c.Table, c.Column)
+		}
+		return logCmd("-- not staged: %s.%s is unchanged", c.Table, c.Column)
+	}
+	m.changes.Stage(c)
+	st := db.UpdateSQL(m.driver.Dialect(), c)
+	return logCmd("-- stage: %s;  -- args %v", st.SQL, st.Args)
+}
+
+// unstageAtCursor is `u`: drop the staged change of the cell under the
+// cursor, if there is one.
+func (m *Model) unstageAtCursor() tea.Cmd {
+	if !m.data.open() || m.tab.metadata() {
+		return nil
+	}
+	pkCols := m.changes.PKColsFor(m.data.database, m.data.table)
+	if pkCols == nil {
+		return logCmd("-- nothing staged for %s", m.data.table)
+	}
+	pkVals, ok := m.rowKeyVals(pkCols, m.data.row)
+	if !ok || m.data.col >= len(m.data.cols) {
+		return nil
+	}
+	colName := m.data.cols[m.data.col].Name
+	if m.changes.Unstage(m.data.database, m.data.table, pkVals, colName) {
+		return logCmd("-- unstage %s.%s", m.data.table, colName)
+	}
+	return logCmd("-- no staged change under the cursor")
+}
+
+// confirmDiscard is `U`: throw the whole changeset away, after asking.
+func (m *Model) confirmDiscard() tea.Cmd {
+	n := m.changes.Len()
+	if n == 0 {
+		return logCmd("-- no staged changes to discard")
+	}
+	m.modal = &confirmModal{
+		title:  "Discard staged changes",
+		body:   fmt.Sprintf("Discard all %s without executing anything?", countChanges(n)),
+		danger: true,
+		onConfirm: func(mm *Model) tea.Cmd {
+			mm.changes.Clear()
+			return logCmd("-- discard %s", countChanges(n))
+		},
+	}
+	return nil
+}
+
+// openCommitModal is `c`: show the exact SQL the commit will run, then
+// execute it all in one transaction on confirm.
+func (m *Model) openCommitModal() tea.Cmd {
+	if m.driver == nil {
+		return nil
+	}
+	n := m.changes.Len()
+	if n == 0 {
+		return logCmd("-- no staged changes to commit")
+	}
+	stmts := m.changes.Statements(m.driver.Dialect())
+	lines := make([]string, 0, len(stmts))
+	for _, s := range stmts {
+		lines = append(lines, fmt.Sprintf("%s;  -- args %v", s.SQL, s.Args))
+	}
+	m.modal = &confirmModal{
+		title: "Commit " + countChanges(n),
+		body: strings.Join(lines, "\n") +
+			"\n\nAll statements run in one transaction: on error nothing is applied and the changeset is kept.",
+		danger:    true,
+		onConfirm: func(mm *Model) tea.Cmd { return commitChangesCmd(mm.driver, stmts) },
+	}
+	return nil
+}
+
+// countChanges spells "1 staged change" / "3 staged changes".
+func countChanges(n int) string {
+	if n == 1 {
+		return "1 staged change"
+	}
+	return fmt.Sprintf("%d staged changes", n)
+}
+
+// valuesEqual compares two normalized cell values. The normalized types
+// (nil, string, int64, float64, bool, time.Time) are all comparable.
+func valuesEqual(a, b any) bool { return a == b }
+
+// convertInput turns the modal's text back into a typed value, guided by
+// the type the cell held before. Text that does not parse stays a
+// string and the engine gets the final say on commit.
+func convertInput(text string, old any) any {
+	switch old.(type) {
+	case int64:
+		if v, err := strconv.ParseInt(text, 10, 64); err == nil {
+			return v
+		}
+	case float64:
+		if v, err := strconv.ParseFloat(text, 64); err == nil {
+			return v
+		}
+	case bool:
+		if v, err := strconv.ParseBool(text); err == nil {
+			return v
+		}
+	case time.Time:
+		if v, err := time.Parse(time.RFC3339, text); err == nil {
+			return v
+		}
+	}
+	return text
+}
+
+// ---------- edit modal ----------
+
+// editCellModal is the `e` popup: a prefilled input plus a NULL toggle.
+// Submitting stages the change; nothing here touches the database.
+type editCellModal struct {
+	change   db.CellChange
+	rowLabel string
+	input    textinput.Model
+	null     bool
+	nullable bool
+}
+
+func newEditCellModal(change db.CellChange, initial any, nullable bool, rowLabel string) *editCellModal {
+	ti := textinput.New()
+	ti.Placeholder = "value"
+	if initial != nil {
+		ti.SetValue(db.FormatValue(initial, ""))
+	}
+	ti.CursorEnd()
+	ti.Focus()
+	ti.SetWidth(40)
+	return &editCellModal{
+		change:   change,
+		rowLabel: rowLabel,
+		input:    ti,
+		null:     initial == nil,
+		nullable: nullable,
+	}
+}
+
+func (e *editCellModal) update(msg tea.KeyPressMsg, m *Model) (bool, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		return true, nil
+	case "ctrl+n":
+		e.null = !e.null
+		return false, nil
+	case "enter":
+		c := e.change
+		if e.null {
+			c.NewValue = nil
+		} else {
+			c.NewValue = convertInput(e.input.Value(), c.OldValue)
+		}
+		return true, m.stageChange(c)
+	}
+	// Typing while NULL is toggled on means the user wants a value again.
+	if msg.Text != "" {
+		e.null = false
+	}
+	var cmd tea.Cmd
+	e.input, cmd = e.input.Update(msg)
+	return false, cmd
+}
+
+func (e *editCellModal) view(s styles, maxW, maxH int) string {
+	e.input.SetWidth(min(50, maxW-8))
+	title := fmt.Sprintf("Edit %s.%s — %s", e.change.Table, e.change.Column, e.rowLabel)
+
+	value := e.input.View()
+	if e.null {
+		value = s.pending.Render(nullText) + s.muted.Render("  (ctrl+n for a value)")
+	}
+	lines := []string{
+		s.modalTitle.Render(truncate(title, min(maxW-8, 70))),
+		"",
+		s.muted.Render("current: " + truncate(flatten(db.FormatValue(e.change.OldValue, nullText)), 50)),
+		value,
+	}
+	if e.null && !e.nullable {
+		lines = append(lines, s.danger.Render("column is NOT NULL — the commit will fail"))
+	}
+	lines = append(lines, "", s.muted.Render("enter stage · ctrl+n NULL · esc cancel"))
+	return s.modal.Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+}

--- a/internal/ui/edit_test.go
+++ b/internal/ui/edit_test.go
@@ -1,0 +1,240 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// stageEdit drives `e` on the cell under the cursor and submits value
+// through the edit modal.
+func stageEdit(t *testing.T, m Model, value string) Model {
+	t.Helper()
+	m = send(t, m, press('e'))
+	e, ok := m.modal.(*editCellModal)
+	if !ok {
+		t.Fatalf("e opened %T, want the edit modal", m.modal)
+	}
+	e.input.SetValue(value)
+	e.null = false
+	return send(t, m, special(tea.KeyEnter, 0))
+}
+
+// The full round trip: edit stages, nothing executes until the commit
+// modal is confirmed, and the commit runs, logs, clears and reloads.
+func TestEditStageCommitRoundTrip(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('l')) // cursor onto `name`
+	m = stageEdit(t, m, "renamed")
+
+	if m.changes.Len() != 1 {
+		t.Fatalf("changeset = %d, want the edit staged", m.changes.Len())
+	}
+	if !logContains(m, `-- stage: UPDATE "grid" SET "name" = ? WHERE "id" = ?`) {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	// Nothing executed yet: the database still holds the old value.
+	rs, err := m.driver.Query(context.Background(), "SELECT name FROM grid WHERE id = 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rs.Rows[0][0] != "name-1" {
+		t.Fatalf("value = %v, want the edit NOT executed before commit", rs.Rows[0][0])
+	}
+	// The staged value shows in the grid, and the badge counts it.
+	out := m.View().Content
+	if !strings.Contains(out, "renamed") {
+		t.Error("staged value not rendered in the grid")
+	}
+	if !strings.Contains(out, "1 staged change") {
+		t.Error("status badge missing")
+	}
+
+	// `c` lists the parameterized SQL, enter commits in one transaction.
+	m = send(t, m, press('c'))
+	cm, ok := m.modal.(*confirmModal)
+	if !ok {
+		t.Fatalf("c opened %T, want the commit confirmation", m.modal)
+	}
+	if !strings.Contains(cm.body, `UPDATE "grid" SET "name" = ?`) {
+		t.Fatalf("commit modal body = %q, want the generated SQL", cm.body)
+	}
+	m = send(t, m, special(tea.KeyEnter, 0))
+
+	if m.changes.Len() != 0 {
+		t.Fatalf("changeset = %d after commit, want it cleared", m.changes.Len())
+	}
+	if !logContains(m, `UPDATE "grid" SET "name" = ? WHERE "id" = ?;  -- args [renamed 1]`) ||
+		!logContains(m, "COMMIT;") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	rs, err = m.driver.Query(context.Background(), "SELECT name FROM grid WHERE id = 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rs.Rows[0][0] != "renamed" {
+		t.Fatalf("value = %v, want the committed value", rs.Rows[0][0])
+	}
+	// The page was refreshed, so the grid shows the committed value too.
+	if got := m.data.rows[0][1]; got != "renamed" {
+		t.Fatalf("grid value = %v, want the refreshed page", got)
+	}
+}
+
+// ctrl+n stages NULL, and the second edit of the same cell replaces the
+// first instead of stacking.
+func TestEditNullToggleAndReplace(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('l'), press('e'))
+	e := m.modal.(*editCellModal)
+	if e.null {
+		t.Fatal("null pre-toggled on a non-NULL cell")
+	}
+	m = send(t, m, ctrl('n'))
+	if !e.null {
+		t.Fatal("ctrl+n did not toggle NULL")
+	}
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if got, _ := m.changes.Lookup("", "grid", []any{int64(1)}, "name"); got.NewValue != nil {
+		t.Fatalf("staged value = %v, want NULL", got.NewValue)
+	}
+
+	m = stageEdit(t, m, "again")
+	if m.changes.Len() != 1 {
+		t.Fatalf("changeset = %d, want the re-edit to replace", m.changes.Len())
+	}
+	got, _ := m.changes.Lookup("", "grid", []any{int64(1)}, "name")
+	if got.NewValue != "again" || got.OldValue != "name-1" {
+		t.Fatalf("change = %+v, want the new value with the original OldValue", got)
+	}
+}
+
+// Restoring the original value in the modal unstages instead of staging
+// a no-op, `u` unstages the cursor cell, and `U` discards everything
+// after a confirmation.
+func TestUnstageAndDiscard(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('l'))
+	m = stageEdit(t, m, "tmp")
+	m = stageEdit(t, m, "name-1") // original value back
+	if m.changes.Len() != 0 {
+		t.Fatalf("changeset = %d, want restoring the original to unstage", m.changes.Len())
+	}
+
+	m = stageEdit(t, m, "one")
+	m = send(t, m, press('j'))
+	m = stageEdit(t, m, "two")
+	if m.changes.Len() != 2 {
+		t.Fatalf("changeset = %d, want 2", m.changes.Len())
+	}
+	m = send(t, m, press('u'))
+	if m.changes.Len() != 1 {
+		t.Fatalf("changeset = %d after u, want 1", m.changes.Len())
+	}
+	if _, ok := m.changes.Lookup("", "grid", []any{int64(1)}, "name"); !ok {
+		t.Fatal("u removed the wrong cell")
+	}
+
+	m = send(t, m, press('U'))
+	cm, ok := m.modal.(*confirmModal)
+	if !ok {
+		t.Fatalf("U opened %T, want a confirmation", m.modal)
+	}
+	if !strings.Contains(cm.body, "1 staged change") {
+		t.Fatalf("body = %q", cm.body)
+	}
+	// esc keeps the changeset, enter discards it.
+	m = send(t, m, special(tea.KeyEscape, 0))
+	if m.changes.Len() != 1 {
+		t.Fatal("esc on the discard confirmation dropped the changeset")
+	}
+	m = send(t, m, press('U'), special(tea.KeyEnter, 0))
+	if m.changes.Len() != 0 {
+		t.Fatal("U did not discard the changeset")
+	}
+}
+
+// A table without a primary key cannot be edited: `e` explains instead
+// of opening the editor.
+func TestEditDisabledWithoutPrimaryKey(t *testing.T) {
+	m := dataBrowsing(t)
+	if _, err := m.driver.Exec(context.Background(),
+		`CREATE TABLE IF NOT EXISTS nopk (x INTEGER, y TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.driver.Exec(context.Background(),
+		`INSERT INTO nopk (x, y) VALUES (1, 'a')`); err != nil {
+		t.Fatal(err)
+	}
+	m = send(t, m, press('3'), press('R'))
+	if !m.panels[panelTables].selectByName("nopk") {
+		t.Fatalf("nopk not listed: %v", m.panels[panelTables].items)
+	}
+	m = send(t, m, special(tea.KeyEnter, 0), press('e'))
+	cm, ok := m.modal.(*confirmModal)
+	if !ok {
+		t.Fatalf("e opened %T, want the explanation", m.modal)
+	}
+	if !strings.Contains(cm.body, "no primary key") {
+		t.Fatalf("body = %q, want it to name the missing key", cm.body)
+	}
+	if m.changes.Len() != 0 {
+		t.Fatal("something got staged on a PK-less table")
+	}
+}
+
+// A failing commit applies nothing and keeps the changeset.
+func TestCommitFailureKeepsChangeset(t *testing.T) {
+	m := dataBrowsing(t)
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`CREATE TABLE IF NOT EXISTS strict (id INTEGER PRIMARY KEY, name TEXT NOT NULL)`,
+		`DELETE FROM strict`,
+		`INSERT INTO strict (id, name) VALUES (1, 'a'), (2, 'b')`,
+	} {
+		if _, err := m.driver.Exec(ctx, stmt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m = send(t, m, press('3'), press('R'))
+	m.panels[panelTables].selectByName("strict")
+	m = send(t, m, special(tea.KeyEnter, 0), press('l'))
+
+	m = stageEdit(t, m, "ok-value")
+	// Second change violates NOT NULL.
+	m = send(t, m, press('j'), press('e'))
+	m = send(t, m, ctrl('n'), special(tea.KeyEnter, 0))
+	if m.changes.Len() != 2 {
+		t.Fatalf("changeset = %d, want 2", m.changes.Len())
+	}
+
+	m = send(t, m, press('c'), special(tea.KeyEnter, 0))
+	if !logContains(m, "COMMIT FAILED") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	if m.changes.Len() != 2 {
+		t.Fatalf("changeset = %d after failed commit, want it kept", m.changes.Len())
+	}
+	rs, err := m.driver.Query(ctx, "SELECT name FROM strict WHERE id = 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rs.Rows[0][0] != "a" {
+		t.Fatalf("value = %v, want the transaction rolled back entirely", rs.Rows[0][0])
+	}
+}
+
+// The staged-editing keys appear in the help modal like every other
+// binding.
+func TestEditKeysAreDocumented(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('?'))
+	out := m.View().Content
+	for _, want := range []string{"edit cell", "commit staged changes", "unstage cell", "discard staged changes"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("help is missing %q", want)
+		}
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -45,6 +45,12 @@ type keyMap struct {
 	WhereFilter key.Binding
 	ViewCell    key.Binding
 
+	// Staged editing (Data tab).
+	EditCell       key.Binding
+	CommitChanges  key.Binding
+	UnstageCell    key.Binding
+	DiscardChanges key.Binding
+
 	// Main-view tabs (Data | Structure | Indexes | DDL).
 	PrevMainTab key.Binding
 	NextMainTab key.Binding
@@ -87,6 +93,11 @@ func newKeyMap() keyMap {
 		WhereFilter: key.NewBinding(key.WithKeys("f"), key.WithHelp("f", "where filter")),
 		ViewCell:    key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "view cell")),
 
+		EditCell:       key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit cell")),
+		CommitChanges:  key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "commit staged changes")),
+		UnstageCell:    key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "unstage cell")),
+		DiscardChanges: key.NewBinding(key.WithKeys("U"), key.WithHelp("U", "discard staged changes")),
+
 		PrevMainTab: key.NewBinding(key.WithKeys("["), key.WithHelp("[", "prev tab")),
 		NextMainTab: key.NewBinding(key.WithKeys("]"), key.WithHelp("]", "next tab")),
 		CopyDDL:     key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy DDL")),
@@ -125,6 +136,10 @@ const (
 	actSortColumn
 	actWhereFilter
 	actViewCell
+	actEditCell
+	actCommitChanges
+	actUnstageCell
+	actDiscardChanges
 	actPrevMainTab
 	actNextMainTab
 	actCopyDDL
@@ -175,6 +190,10 @@ func (k keyMap) panelActions(id panelID) []action {
 			{actSortColumn, k.SortColumn},
 			{actWhereFilter, k.WhereFilter},
 			{actViewCell, k.ViewCell},
+			{actEditCell, k.EditCell},
+			{actCommitChanges, k.CommitChanges},
+			{actUnstageCell, k.UnstageCell},
+			{actDiscardChanges, k.DiscardChanges},
 			{actCopyDDL, k.CopyDDL},
 			{actRefresh, k.Refresh},
 		}

--- a/internal/ui/meta.go
+++ b/internal/ui/meta.go
@@ -60,8 +60,10 @@ type metaView struct {
 	row [mainTabCount]int
 
 	// copyAfterLoad makes `y` work on a tab that has not been opened
-	// yet: the copy runs when the metadata lands.
+	// yet: the copy runs when the metadata lands. editAfterLoad does the
+	// same for `e`, which needs the primary key from the metadata.
 	copyAfterLoad bool
+	editAfterLoad bool
 
 	req int
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -90,6 +90,11 @@ type Model struct {
 	// data is the main view's Data tab: one page of m.table.
 	data dataView
 
+	// changes is the staged changeset: edits accumulate here and only
+	// execute on explicit commit. It is a pointer so every copied Model
+	// shares one changeset.
+	changes *db.Changeset
+
 	// tab is the main view's selected tab and meta is the metadata the
 	// three introspection tabs render.
 	tab  mainTab
@@ -112,6 +117,7 @@ func New() Model {
 		help:      help.New(),
 		style:     newStyles(),
 		connState: map[string]connState{},
+		changes:   db.NewChangeset(),
 	}
 	for id := panelID(0); id < panelCount; id++ {
 		m.panels[id] = &sidePanel{id: id}
@@ -180,6 +186,9 @@ func (m *Model) renameConnState(oldName, newName string) {
 
 // resetBrowse drops everything that belonged to the previous connection.
 func (m *Model) resetBrowse() {
+	// Staged changes reference the connection's tables; they cannot
+	// survive it. They are discarded, not committed.
+	m.changes.Clear()
 	m.database = ""
 	m.table = ""
 	m.data = dataView{}
@@ -392,6 +401,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.err != nil {
 			m.meta.err = msg.err.Error()
 			m.meta.copyAfterLoad = false
+			m.meta.editAfterLoad = false
 			return m, logCmd("-- introspect %s FAILED: %v", msg.table, msg.err)
 		}
 		m.meta.cols, m.meta.indexes, m.meta.fks = msg.cols, msg.indexes, msg.fks
@@ -402,6 +412,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.meta.copyAfterLoad {
 			m.meta.copyAfterLoad = false
 			cmd := m.copyDDL()
+			return m, cmd
+		}
+		if m.meta.editAfterLoad {
+			m.meta.editAfterLoad = false
+			cmd := m.openEditModal()
 			return m, cmd
 		}
 		return m, nil
@@ -418,6 +433,27 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.data.total, m.data.hasTotal = msg.total, true
 		return m, nil
+
+	case changesCommittedMsg:
+		if msg.err != nil {
+			// The transaction rolled back: nothing was applied, and the
+			// changeset survives so the user can fix and retry.
+			return m, logCmd("-- COMMIT FAILED — nothing applied, changeset kept: %v", msg.err)
+		}
+		cmds := []tea.Cmd{logCmd("BEGIN;")}
+		for _, s := range msg.stmts {
+			stmt := s
+			cmds = append(cmds,
+				logCmd("%s;  -- args %v", stmt.SQL, stmt.Args),
+				func() tea.Msg { return historyEntryMsg{statement: stmt.SQL + ";"} },
+			)
+		}
+		m.changes.Clear()
+		cmds = append(cmds,
+			logCmd("COMMIT;  -- %s applied", countChanges(len(msg.stmts))),
+			m.reloadPage(),
+		)
+		return m, tea.Batch(cmds...)
 
 	case connPersistedMsg:
 		if msg.err != nil {

--- a/wiki/design/staged-changeset.md
+++ b/wiki/design/staged-changeset.md
@@ -1,0 +1,71 @@
+---
+type: Design Decision
+title: Staged cell edits with an explicit commit transaction
+description: Why edits accumulate in an engine-agnostic changeset instead of executing, how a row is identified only by its declared primary key, and how the commit runs everything in one transaction.
+tags: [tui, db, editing, changeset, transactions, security]
+generated:
+  by: claude-code/fable-5
+  at: 2026-08-09T00:00:00Z
+---
+
+# Staged changeset
+
+## Decision
+
+`e` on a Data-tab cell never executes SQL. It records a
+`db.CellChange` in a `db.Changeset` (`internal/db/changeset.go`), and
+the UPDATEs only run when the user confirms the `c` commit modal —
+all of them inside one transaction via `Driver.ExecTx`. This is the
+lazygit staging model applied to mutations, and it is what the
+"never auto-execute destructive SQL" rule looks like in code.
+
+### The changeset is engine-agnostic
+
+A `CellChange` holds `(Database, Table, PKCols, PKVals, Column,
+OldValue, NewValue)` — plain normalized values, no SQL. SQL is only
+rendered by `UpdateSQL(dialect, change)`, which quotes identifiers and
+numbers placeholders per dialect; the new value and every key value
+travel as parameters. The changeset is keyed by
+`(database, table, column, typed pk values)`, so editing a cell twice
+replaces the pending change (keeping the original `OldValue`) instead
+of stacking two UPDATEs, and restoring the original value in the
+editor unstages the cell. Row insert/delete (a separate issue) will
+extend the same structure.
+
+### Rows are identified by the primary key, or not at all
+
+The key columns come from the cached metadata fetch (the same one the
+Structure tab uses; `e` triggers it lazily like `y` does for the DDL,
+via `metaView.editAfterLoad`). A table without a declared primary key
+gets an explanatory modal instead of an editor: identifying a row by
+"all columns" or a rowid heuristic can silently hit more rows than the
+one on screen, so lazysql refuses to guess. For rendering, the grid
+does *not* need metadata: `Changeset.PKColsFor` recovers the key
+columns from any staged change of the table, which is how staged cells
+stay highlighted (yellow, showing the staged value) after the metadata
+cache was reset.
+
+### Commit is one transaction, and failure keeps the changeset
+
+`ExecTx` wraps all statements in `BeginTx … Commit`; the first error
+rolls everything back and the reply keeps the changeset intact, so the
+user fixes the offending edit and retries. On success the exact
+parameterized statements are appended to the command log between
+`BEGIN;` and `COMMIT;` lines, recorded in the history panel, the
+changeset is cleared and the page reloads. `u` unstages the cursor
+cell, `U` confirms and discards everything; `resetBrowse` (connection
+switch/removal) also discards, because staged changes reference tables
+of the connection that owned them.
+
+## Consequences
+
+- Typed input is converted back toward the cell's previous type
+  (`convertInput`): text that parses as the old `int64`/`float64`/
+  `bool`/`time.Time` is bound as that type, anything else is bound as
+  a string and the engine gets the final say on commit.
+- The NULL toggle (`ctrl+n`) is the only way to stage SQL NULL — an
+  emptied input stages an empty string. Toggling NULL on a NOT NULL
+  column warns in the modal but is allowed; the commit's rollback is
+  the safety net.
+- The status line badge ("3 staged changes") counts the whole
+  changeset, not just the open table, because `c` commits all of it.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -15,6 +15,7 @@ concept with YAML frontmatter. Concept IDs are bundle-relative paths without
 - [design/catalog-browsing](design/catalog-browsing.md) — Design Decision — async catalog loads, inline fuzzy filter, tables/views sub-tabs, pseudo-database for single-namespace engines.
 - [design/data-grid](design/data-grid.md) — Design Decision — one-page-at-a-time main view, derived scroll windows, the `panelMain` focus target, and the parse-first quick filter.
 - [design/main-view-tabs](design/main-view-tabs.md) — Design Decision — Data/Structure/Indexes/DDL tabs behind one metadata fetch, `[`/`]` cycling instead of digits, and what survives a relation change.
+- [design/staged-changeset](design/staged-changeset.md) — Design Decision — cell edits stage into an engine-agnostic changeset, rows are identified only by their primary key, and the commit runs every UPDATE in one transaction.
 
 ## reference
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -86,3 +86,11 @@ Chronological history of wiki changes, newest last.
   `conkey`/`confkey` unnested *together* and its action codes cast
   `::text` for pgx, and MySQL splits foreign keys across
   `key_column_usage` and `referential_constraints`.
+- Added [design/staged-changeset](design/staged-changeset.md) with the
+  staged editing feature (issue #7): `e` records a `db.CellChange`
+  instead of executing, `db.Changeset` keys pending changes by
+  `(database, table, column, typed pk values)` so re-edits replace and
+  restoring the original unstages, `UpdateSQL` renders per-dialect
+  parameterized UPDATEs, and `Driver.ExecTx` commits everything in one
+  transaction — failure rolls back and keeps the changeset. Tables
+  without a declared primary key are not editable at all.


### PR DESCRIPTION
Edit modal with NULL toggle stages cell changes into a pending changeset; commit modal shows exact SQL + args and applies everything in one transaction via `ExecTx` (first error rolls back all). Staged cells render bold yellow with a status badge; unstage single/all supported; PK-less tables refuse editing. Live SQLite rollback test plus per-dialect UPDATE generation tests.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139rhNA79AoksWw97zoxwWA