### PR TITLE
Stage row insert, delete, and duplicate operations

### DIFF
--- a/internal/db/changeset.go
+++ b/internal/db/changeset.go
@@ -6,9 +6,24 @@ import (
 )
 
 // Staged mutations. lazysql never executes destructive SQL as a side
-// effect of editing: a cell edit only records a CellChange here, and the
-// SQL runs when the user explicitly commits the whole changeset — in one
-// transaction, so a failure applies nothing.
+// effect of editing: a cell edit only records a CellChange here, a row
+// delete a RowDelete and a row insert a RowInsert. The SQL runs when the
+// user explicitly commits the whole changeset — in one transaction, so a
+// failure applies nothing.
+
+// Change is one staged mutation. The three implementations live in this
+// file; the unexported methods keep it that way, so no UI package can
+// smuggle its own SQL into a commit.
+type Change interface {
+	// key identifies what the change targets: two changes with the same
+	// key are the same pending mutation, and the second replaces the
+	// first instead of stacking on it.
+	key() string
+	// target is the database and table the change applies to.
+	target() (database, table string)
+	// Statement renders the change as one parameterized statement.
+	Statement(d Dialect) Statement
+}
 
 // CellChange is one staged single-cell UPDATE. The row is identified by
 // the table's primary key, never by heuristics: PKCols and PKVals are
@@ -24,23 +39,77 @@ type CellChange struct {
 	NewValue any
 }
 
-// key identifies the cell a change targets: same key = same cell, so a
-// second edit of a cell replaces the first instead of stacking on it.
-// Values are keyed with their type so int64(1) and "1" stay distinct.
+// key of a cell change: same cell = same key. Values are keyed with
+// their type so int64(1) and "1" stay distinct.
 func (c CellChange) key() string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s\x00%s\x00%s", c.Database, c.Table, c.Column)
-	for _, v := range c.PKVals {
-		fmt.Fprintf(&b, "\x00%T:%v", v, v)
-	}
+	fmt.Fprintf(&b, "cell\x00%s\x00%s\x00%s", c.Database, c.Table, c.Column)
+	writeKeyVals(&b, c.PKVals)
 	return b.String()
+}
+
+func (c CellChange) target() (string, string) { return c.Database, c.Table }
+
+func (c CellChange) Statement(d Dialect) Statement { return UpdateSQL(d, c) }
+
+// RowDelete is one staged DELETE of a whole row, identified by the same
+// full primary key a cell edit uses. A table without a declared primary
+// key cannot be deleted from, for the same reason it cannot be edited.
+type RowDelete struct {
+	Database string
+	Table    string
+	PKCols   []string
+	PKVals   []any
+}
+
+func (r RowDelete) key() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "del\x00%s\x00%s", r.Database, r.Table)
+	writeKeyVals(&b, r.PKVals)
+	return b.String()
+}
+
+func (r RowDelete) target() (string, string) { return r.Database, r.Table }
+
+func (r RowDelete) Statement(d Dialect) Statement { return DeleteSQL(d, r) }
+
+// RowInsert is one staged INSERT. Columns and Values are positionally
+// paired and hold only the columns the user filled in — everything the
+// form left on "DEFAULT" is simply absent, so the engine applies its own
+// default or auto-increment. A nil value is an explicit SQL NULL.
+//
+// ID makes two identical inserts two rows: unlike an UPDATE or a DELETE,
+// an INSERT has no natural identity to key on, so the changeset assigns
+// one at staging time and `u` unstages by it.
+type RowInsert struct {
+	ID       int
+	Database string
+	Table    string
+	Columns  []string
+	Values   []any
+}
+
+func (r RowInsert) key() string {
+	return fmt.Sprintf("ins\x00%s\x00%s\x00%d", r.Database, r.Table, r.ID)
+}
+
+func (r RowInsert) target() (string, string) { return r.Database, r.Table }
+
+func (r RowInsert) Statement(d Dialect) Statement { return InsertSQL(d, r) }
+
+// writeKeyVals appends type-tagged key values to a change key.
+func writeKeyVals(b *strings.Builder, vals []any) {
+	for _, v := range vals {
+		fmt.Fprintf(b, "\x00%T:%v", v, v)
+	}
 }
 
 // Changeset accumulates staged changes in the order they were first
 // staged, which is also the order they execute in on commit.
 type Changeset struct {
-	changes []CellChange
-	index   map[string]int
+	ops    []Change
+	index  map[string]int
+	nextID int
 }
 
 // NewChangeset returns an empty changeset.
@@ -48,51 +117,160 @@ func NewChangeset() *Changeset {
 	return &Changeset{index: map[string]int{}}
 }
 
-// Stage records a change, replacing an earlier change of the same cell.
-// A replacement keeps the original OldValue so unstaging or displaying
-// the change still refers to what the database holds.
-func (cs *Changeset) Stage(c CellChange) {
+// stage appends a change, or replaces the one with the same key.
+func (cs *Changeset) stage(c Change) {
 	k := c.key()
 	if i, ok := cs.index[k]; ok {
-		c.OldValue = cs.changes[i].OldValue
-		cs.changes[i] = c
+		cs.ops[i] = c
 		return
 	}
-	cs.index[k] = len(cs.changes)
-	cs.changes = append(cs.changes, c)
+	cs.index[k] = len(cs.ops)
+	cs.ops = append(cs.ops, c)
+}
+
+// removeAt drops one change and repairs the index.
+func (cs *Changeset) removeAt(i int) {
+	delete(cs.index, cs.ops[i].key())
+	cs.ops = append(cs.ops[:i], cs.ops[i+1:]...)
+	for j := i; j < len(cs.ops); j++ {
+		cs.index[cs.ops[j].key()] = j
+	}
+}
+
+// removeKey drops the change with a key and reports whether there was one.
+func (cs *Changeset) removeKey(k string) bool {
+	i, ok := cs.index[k]
+	if !ok {
+		return false
+	}
+	cs.removeAt(i)
+	return true
+}
+
+// Stage records a confirmed cell edit, replacing an earlier edit of the
+// same cell. A replacement keeps the original OldValue so unstaging or
+// displaying the change still refers to what the database holds.
+func (cs *Changeset) Stage(c CellChange) {
+	if i, ok := cs.index[c.key()]; ok {
+		if prev, ok := cs.ops[i].(CellChange); ok {
+			c.OldValue = prev.OldValue
+		}
+	}
+	cs.stage(c)
+}
+
+// StageDelete records a row delete and reports whether it was new. It
+// also drops any staged cell edits of the same row: updating a row the
+// same commit deletes is dead work, and hiding it behind a strikethrough
+// row would be worse.
+func (cs *Changeset) StageDelete(r RowDelete) bool {
+	if _, ok := cs.index[r.key()]; ok {
+		return false
+	}
+	for i := len(cs.ops) - 1; i >= 0; i-- {
+		c, ok := cs.ops[i].(CellChange)
+		if ok && c.Database == r.Database && c.Table == r.Table && keyValsEqual(c.PKVals, r.PKVals) {
+			cs.removeAt(i)
+		}
+	}
+	cs.stage(r)
+	return true
+}
+
+// StageInsert records a row insert, assigning it the identity the UI
+// unstages it by, and returns the stored change.
+func (cs *Changeset) StageInsert(r RowInsert) RowInsert {
+	cs.nextID++
+	r.ID = cs.nextID
+	cs.stage(r)
+	return r
 }
 
 // Unstage drops the staged change of one cell and reports whether there
 // was one.
 func (cs *Changeset) Unstage(database, table string, pkVals []any, column string) bool {
-	k := CellChange{Database: database, Table: table, PKVals: pkVals, Column: column}.key()
-	i, ok := cs.index[k]
-	if !ok {
-		return false
+	return cs.removeKey(CellChange{Database: database, Table: table, PKVals: pkVals, Column: column}.key())
+}
+
+// UnstageDelete drops the staged delete of one row and reports whether
+// there was one.
+func (cs *Changeset) UnstageDelete(database, table string, pkVals []any) bool {
+	return cs.removeKey(RowDelete{Database: database, Table: table, PKVals: pkVals}.key())
+}
+
+// UnstageInsert drops one staged insert by its identity.
+func (cs *Changeset) UnstageInsert(database, table string, id int) bool {
+	return cs.removeKey(RowInsert{Database: database, Table: table, ID: id}.key())
+}
+
+// UnstageRow drops every staged change of one row — the delete and any
+// cell edits — and reports how many went.
+func (cs *Changeset) UnstageRow(database, table string, pkVals []any) int {
+	n := 0
+	for i := len(cs.ops) - 1; i >= 0; i-- {
+		var (
+			db2, t2 = cs.ops[i].target()
+			vals    []any
+		)
+		switch c := cs.ops[i].(type) {
+		case CellChange:
+			vals = c.PKVals
+		case RowDelete:
+			vals = c.PKVals
+		default:
+			continue
+		}
+		if db2 == database && t2 == table && keyValsEqual(vals, pkVals) {
+			cs.removeAt(i)
+			n++
+		}
 	}
-	cs.changes = append(cs.changes[:i], cs.changes[i+1:]...)
-	delete(cs.index, k)
-	for j := i; j < len(cs.changes); j++ {
-		cs.index[cs.changes[j].key()] = j
-	}
-	return true
+	return n
 }
 
 // Lookup returns the staged change of one cell, if any.
 func (cs *Changeset) Lookup(database, table string, pkVals []any, column string) (CellChange, bool) {
 	k := CellChange{Database: database, Table: table, PKVals: pkVals, Column: column}.key()
 	if i, ok := cs.index[k]; ok {
-		return cs.changes[i], true
+		if c, ok := cs.ops[i].(CellChange); ok {
+			return c, true
+		}
 	}
 	return CellChange{}, false
 }
 
+// DeleteStaged reports whether a row is staged for deletion.
+func (cs *Changeset) DeleteStaged(database, table string, pkVals []any) bool {
+	_, ok := cs.index[RowDelete{Database: database, Table: table, PKVals: pkVals}.key()]
+	return ok
+}
+
+// InsertsFor returns the staged inserts of one table in staging order.
+// The grid renders them as phantom rows after the last real one.
+func (cs *Changeset) InsertsFor(database, table string) []RowInsert {
+	var out []RowInsert
+	for _, op := range cs.ops {
+		if r, ok := op.(RowInsert); ok && r.Database == database && r.Table == table {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
 // PKColsFor returns the primary key columns recorded for a table, taken
-// from any staged change of it. It lets the grid find the key columns of
-// rendered rows without re-introspecting the table.
+// from any staged change of it that identifies a row. It lets the grid
+// find the key columns of rendered rows without re-introspecting the
+// table.
 func (cs *Changeset) PKColsFor(database, table string) []string {
-	for _, c := range cs.changes {
-		if c.Database == database && c.Table == table {
+	for _, op := range cs.ops {
+		d, t := op.target()
+		if d != database || t != table {
+			continue
+		}
+		switch c := op.(type) {
+		case CellChange:
+			return c.PKCols
+		case RowDelete:
 			return c.PKCols
 		}
 	}
@@ -100,16 +278,32 @@ func (cs *Changeset) PKColsFor(database, table string) []string {
 }
 
 // Len is how many changes are staged.
-func (cs *Changeset) Len() int { return len(cs.changes) }
+func (cs *Changeset) Len() int { return len(cs.ops) }
 
 // All returns the staged changes in commit order. Callers must not
 // mutate the slice.
-func (cs *Changeset) All() []CellChange { return cs.changes }
+func (cs *Changeset) All() []Change { return cs.ops }
 
-// Clear discards every staged change.
+// Clear discards every staged change. The insert counter is not reset:
+// nothing depends on the numbering, and monotonic ids keep a stale
+// reference from ever matching a fresh insert.
 func (cs *Changeset) Clear() {
-	cs.changes = nil
+	cs.ops = nil
 	cs.index = map[string]int{}
+}
+
+// keyValsEqual compares two primary key tuples. The normalized cell
+// types (nil, string, int64, float64, bool, time.Time) are comparable.
+func keyValsEqual(a, b []any) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // Statement is one parameterized SQL statement ready to execute.
@@ -131,24 +325,78 @@ func UpdateSQL(d Dialect, c CellChange) Statement {
 	b.WriteString(" = ")
 	b.WriteString(d.Placeholder(1))
 	args = append(args, c.NewValue)
+	args = writeKeyPredicates(&b, d, c.PKCols, c.PKVals, args)
+	return Statement{SQL: b.String(), Args: args}
+}
+
+// DeleteSQL renders one staged row delete as a parameterized DELETE.
+// The full primary key is in the WHERE clause, so the statement can
+// never hit more than the row the user pointed at.
+func DeleteSQL(d Dialect, r RowDelete) Statement {
+	var b strings.Builder
+	b.WriteString("DELETE FROM ")
+	b.WriteString(qualifiedTable(d, r.Database, r.Table))
+	args := writeKeyPredicates(&b, d, r.PKCols, r.PKVals, make([]any, 0, len(r.PKVals)))
+	return Statement{SQL: b.String(), Args: args}
+}
+
+// InsertSQL renders one staged row insert as a parameterized INSERT.
+// Only the columns the form filled in are named; the rest are left to
+// the engine's DEFAULT / auto-increment, which is why an insert with no
+// columns at all is still a valid statement.
+func InsertSQL(d Dialect, r RowInsert) Statement {
+	var b strings.Builder
+	b.WriteString("INSERT INTO ")
+	b.WriteString(qualifiedTable(d, r.Database, r.Table))
+	if len(r.Columns) == 0 {
+		b.WriteString(defaultValuesClause(d))
+		return Statement{SQL: b.String()}
+	}
+	args := make([]any, 0, len(r.Values))
+	b.WriteString(" (")
+	for i, c := range r.Columns {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(d.QuoteIdent(c))
+	}
+	b.WriteString(") VALUES (")
+	for i := range r.Columns {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(d.Placeholder(i + 1))
+		if i < len(r.Values) {
+			args = append(args, r.Values[i])
+		} else {
+			args = append(args, nil)
+		}
+	}
+	b.WriteString(")")
+	return Statement{SQL: b.String(), Args: args}
+}
+
+// writeKeyPredicates appends " WHERE pk = ? AND …" and returns the
+// argument list extended with the key values.
+func writeKeyPredicates(b *strings.Builder, d Dialect, cols []string, vals, args []any) []any {
 	b.WriteString(" WHERE ")
-	for i, pk := range c.PKCols {
+	for i, pk := range cols {
 		if i > 0 {
 			b.WriteString(" AND ")
 		}
 		b.WriteString(d.QuoteIdent(pk))
 		b.WriteString(" = ")
 		b.WriteString(d.Placeholder(len(args) + 1))
-		args = append(args, c.PKVals[i])
+		args = append(args, vals[i])
 	}
-	return Statement{SQL: b.String(), Args: args}
+	return args
 }
 
 // Statements renders the whole changeset in commit order.
 func (cs *Changeset) Statements(d Dialect) []Statement {
-	out := make([]Statement, 0, len(cs.changes))
-	for _, c := range cs.changes {
-		out = append(out, UpdateSQL(d, c))
+	out := make([]Statement, 0, len(cs.ops))
+	for _, c := range cs.ops {
+		out = append(out, c.Statement(d))
 	}
 	return out
 }

--- a/internal/db/changeset_test.go
+++ b/internal/db/changeset_test.go
@@ -65,6 +65,202 @@ func TestUpdateSQLCompositeKeyAndNull(t *testing.T) {
 	}
 }
 
+// A row delete names every key column and binds every key value, in
+// each engine's own quoting and placeholder style.
+func TestDeleteSQLPerDialect(t *testing.T) {
+	r := RowDelete{
+		Table:  "users",
+		PKCols: []string{"id"},
+		PKVals: []any{int64(3)},
+	}
+	cases := []struct {
+		engine Engine
+		want   string
+	}{
+		{EngineSQLite, `DELETE FROM "users" WHERE "id" = ?`},
+		{EnginePostgres, `DELETE FROM "users" WHERE "id" = $1`},
+		{EngineMySQL, "DELETE FROM `users` WHERE `id` = ?"},
+	}
+	for _, tc := range cases {
+		st := DeleteSQL(dialect(t, tc.engine), r)
+		if st.SQL != tc.want {
+			t.Errorf("%s: SQL = %q, want %q", tc.engine, st.SQL, tc.want)
+		}
+		if !slices.Equal(st.Args, []any{any(int64(3))}) {
+			t.Errorf("%s: args = %v", tc.engine, st.Args)
+		}
+	}
+
+	// A composite key contributes one predicate per column.
+	st := DeleteSQL(dialect(t, EnginePostgres), RowDelete{
+		Database: "app",
+		Table:    "grades",
+		PKCols:   []string{"student", "course"},
+		PKVals:   []any{int64(1), "math"},
+	})
+	want := `DELETE FROM "app"."grades" WHERE "student" = $1 AND "course" = $2`
+	if st.SQL != want {
+		t.Fatalf("SQL = %q, want %q", st.SQL, want)
+	}
+}
+
+// An insert names only the columns the form filled in; every value is a
+// bound parameter and NULL is a bound nil.
+func TestInsertSQLPerDialect(t *testing.T) {
+	r := RowInsert{
+		Table:   "users",
+		Columns: []string{"name", "email"},
+		Values:  []any{"ada", nil},
+	}
+	cases := []struct {
+		engine Engine
+		want   string
+	}{
+		{EngineSQLite, `INSERT INTO "users" ("name", "email") VALUES (?, ?)`},
+		{EnginePostgres, `INSERT INTO "users" ("name", "email") VALUES ($1, $2)`},
+		{EngineMySQL, "INSERT INTO `users` (`name`, `email`) VALUES (?, ?)"},
+	}
+	for _, tc := range cases {
+		st := InsertSQL(dialect(t, tc.engine), r)
+		if st.SQL != tc.want {
+			t.Errorf("%s: SQL = %q, want %q", tc.engine, st.SQL, tc.want)
+		}
+		if !slices.Equal(st.Args, []any{any("ada"), nil}) {
+			t.Errorf("%s: args = %v", tc.engine, st.Args)
+		}
+	}
+}
+
+// An insert that leaves every column to its default is still a valid
+// statement — and MySQL spells that differently from everyone else.
+func TestInsertSQLDefaultValues(t *testing.T) {
+	r := RowInsert{Table: "users"}
+	cases := []struct {
+		engine Engine
+		want   string
+	}{
+		{EngineSQLite, `INSERT INTO "users" DEFAULT VALUES`},
+		{EnginePostgres, `INSERT INTO "users" DEFAULT VALUES`},
+		{EngineDuckDB, `INSERT INTO "users" DEFAULT VALUES`},
+		{EngineMySQL, "INSERT INTO `users` () VALUES ()"},
+		{EngineMariaDB, "INSERT INTO `users` () VALUES ()"},
+	}
+	for _, tc := range cases {
+		st := InsertSQL(dialect(t, tc.engine), r)
+		if st.SQL != tc.want {
+			t.Errorf("%s: SQL = %q, want %q", tc.engine, st.SQL, tc.want)
+		}
+		if len(st.Args) != 0 {
+			t.Errorf("%s: args = %v, want none", tc.engine, st.Args)
+		}
+	}
+}
+
+// Row operations share the changeset with cell edits: they commit in
+// staging order, a delete is staged once, and staging it drops the
+// pending edits of the row it removes.
+func TestChangesetRowOperations(t *testing.T) {
+	cs := NewChangeset()
+	cs.Stage(CellChange{Table: "t", PKCols: []string{"id"}, PKVals: []any{int64(1)},
+		Column: "c", NewValue: "kept"})
+	cs.Stage(CellChange{Table: "t", PKCols: []string{"id"}, PKVals: []any{int64(2)},
+		Column: "c", NewValue: "doomed"})
+
+	del := RowDelete{Table: "t", PKCols: []string{"id"}, PKVals: []any{int64(2)}}
+	if !cs.StageDelete(del) {
+		t.Fatal("StageDelete reported the delete as already staged")
+	}
+	if cs.StageDelete(del) {
+		t.Fatal("StageDelete staged the same row twice")
+	}
+	if _, ok := cs.Lookup("", "t", []any{int64(2)}, "c"); ok {
+		t.Fatal("staging a delete kept the edits of the row it removes")
+	}
+	if _, ok := cs.Lookup("", "t", []any{int64(1)}, "c"); !ok {
+		t.Fatal("staging a delete dropped another row's edit")
+	}
+	if !cs.DeleteStaged("", "t", []any{int64(2)}) {
+		t.Fatal("DeleteStaged does not see the staged delete")
+	}
+
+	// Two identical inserts are two rows, not one replaced staging.
+	a := cs.StageInsert(RowInsert{Table: "t", Columns: []string{"c"}, Values: []any{"new"}})
+	b := cs.StageInsert(RowInsert{Table: "t", Columns: []string{"c"}, Values: []any{"new"}})
+	if a.ID == b.ID {
+		t.Fatal("two staged inserts share an id")
+	}
+	if got := cs.InsertsFor("", "t"); len(got) != 2 {
+		t.Fatalf("InsertsFor = %d, want both inserts", len(got))
+	}
+
+	// Commit order is staging order, and every kind renders itself.
+	stmts := cs.Statements(dialect(t, EngineSQLite))
+	wantSQL := []string{
+		`UPDATE "t" SET "c" = ? WHERE "id" = ?`,
+		`DELETE FROM "t" WHERE "id" = ?`,
+		`INSERT INTO "t" ("c") VALUES (?)`,
+		`INSERT INTO "t" ("c") VALUES (?)`,
+	}
+	if len(stmts) != len(wantSQL) {
+		t.Fatalf("statements = %d, want %d", len(stmts), len(wantSQL))
+	}
+	for i, want := range wantSQL {
+		if stmts[i].SQL != want {
+			t.Errorf("statement %d = %q, want %q", i, stmts[i].SQL, want)
+		}
+	}
+
+	// Unstaging is per operation.
+	if !cs.UnstageInsert("", "t", a.ID) {
+		t.Fatal("UnstageInsert missed a staged insert")
+	}
+	if !cs.UnstageDelete("", "t", []any{int64(2)}) {
+		t.Fatal("UnstageDelete missed the staged delete")
+	}
+	if cs.Len() != 2 {
+		t.Fatalf("Len = %d, want the remaining edit and insert", cs.Len())
+	}
+	if cs.PKColsFor("", "t") == nil {
+		t.Fatal("PKColsFor lost the key columns")
+	}
+}
+
+// A mixed changeset applies as one transaction.
+func TestExecTxMixedRowOperations(t *testing.T) {
+	ctx := context.Background()
+	drv := openTest(t, EngineSQLite, ":memory:")
+	seed(t, drv)
+	d := drv.Dialect()
+
+	cs := NewChangeset()
+	cs.Stage(CellChange{Table: "users", PKCols: []string{"id"}, PKVals: []any{int64(1)},
+		Column: "email", NewValue: "new@example.com"})
+	cs.StageDelete(RowDelete{Table: "users", PKCols: []string{"id"}, PKVals: []any{int64(2)}})
+	cs.StageInsert(RowInsert{Table: "users",
+		Columns: []string{"id", "name", "email"},
+		Values:  []any{int64(99), "zoe", nil}})
+
+	if _, err := drv.ExecTx(ctx, cs.Statements(d)); err != nil {
+		t.Fatalf("ExecTx: %v", err)
+	}
+	rs, err := drv.Query(ctx, "SELECT id, name, email FROM users ORDER BY id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := rs.Rows[0][2]; got != "new@example.com" {
+		t.Errorf("row 1 email = %v, want the update applied", got)
+	}
+	for _, row := range rs.Rows {
+		if row[0] == int64(2) {
+			t.Error("the deleted row is still there")
+		}
+	}
+	last := rs.Rows[len(rs.Rows)-1]
+	if last[0] != int64(99) || last[1] != "zoe" || last[2] != nil {
+		t.Errorf("inserted row = %v, want (99, zoe, NULL)", last)
+	}
+}
+
 // Staging the same cell twice replaces the change and keeps the original
 // OldValue; unstaging removes exactly one cell.
 func TestChangesetStageReplaceUnstage(t *testing.T) {

--- a/internal/db/dialect_helpers.go
+++ b/internal/db/dialect_helpers.go
@@ -117,6 +117,19 @@ func synthesizeDDL(d Dialect, database, table string, cols []Column, idx []Index
 	return b.String()
 }
 
+// defaultValuesClause is how an engine spells "insert a row and take
+// every column's default". PostgreSQL, SQLite and DuckDB accept the
+// standard DEFAULT VALUES; MySQL and MariaDB do not and want an empty
+// column list instead. The clause includes its leading space.
+func defaultValuesClause(d Dialect) string {
+	switch d.Engine() {
+	case EngineMySQL, EngineMariaDB:
+		return " () VALUES ()"
+	default:
+		return " DEFAULT VALUES"
+	}
+}
+
 // quoteAll quotes a column list for a parenthesized clause.
 func quoteAll(d Dialect, names []string) string {
 	out := make([]string, 0, len(names))

--- a/internal/ui/data.go
+++ b/internal/ui/data.go
@@ -52,6 +52,11 @@ type dataView struct {
 	// stale offset behind.
 	row, col int
 
+	// extraRows is how many phantom rows (staged inserts) the grid
+	// appends after the page. The changeset owns them; this is the count
+	// Model.clampCursor mirrors here so the cursor can reach them.
+	extraRows int
+
 	loading bool
 	err     string
 
@@ -86,11 +91,16 @@ func (d dataView) sortOn(name string) (desc, ok bool) {
 	return d.sort.Desc, true
 }
 
+// rowCount is how many rows the grid renders: the page plus the phantom
+// rows of the staged inserts.
+func (d dataView) rowCount() int { return len(d.rows) + d.extraRows }
+
 // clampCursor keeps the cell cursor inside the page after it changed
-// shape (new page, fewer columns, empty result).
+// shape (new page, fewer columns, empty result). Callers on the Model go
+// through Model.clampCursor, which refreshes extraRows first.
 func (d *dataView) clampCursor() {
-	if d.row >= len(d.rows) {
-		d.row = len(d.rows) - 1
+	if d.row >= d.rowCount() {
+		d.row = d.rowCount() - 1
 	}
 	if d.row < 0 {
 		d.row = 0
@@ -300,14 +310,14 @@ func (m Model) updateData(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m.updateMetaKeys(1)
 		}
 		m.data.row++
-		m.data.clampCursor()
+		m.clampCursor()
 		return m, nil
 	case key.Matches(msg, k.Up):
 		if m.tab.metadata() {
 			return m.updateMetaKeys(-1)
 		}
 		m.data.row--
-		m.data.clampCursor()
+		m.clampCursor()
 		return m, nil
 	case key.Matches(msg, k.Back):
 		m.focusBack()
@@ -351,10 +361,10 @@ func (m Model) dataActions(id actionID) (Model, tea.Cmd, bool) {
 	switch id {
 	case actColLeft:
 		m.data.col--
-		m.data.clampCursor()
+		m.clampCursor()
 	case actColRight:
 		m.data.col++
-		m.data.clampCursor()
+		m.clampCursor()
 	case actNextPage:
 		cmd := m.turnPage(1)
 		return m, cmd, true
@@ -376,17 +386,36 @@ func (m Model) dataActions(id actionID) (Model, tea.Cmd, bool) {
 			func(mm *Model, value string) tea.Cmd { return mm.setDataFilter(value) },
 		)
 	case actViewCell:
-		v, ok := m.data.cell()
-		if !ok {
-			return m, nil, true
-		}
 		name := ""
 		if m.data.col < len(m.data.cols) {
 			name = m.data.cols[m.data.col].Name
 		}
+		if ins, ok := m.phantomAtCursor(); ok {
+			// A staged insert has no fetched cell; show what it will bind.
+			v, bound := insertValueFor(ins, name)
+			if !bound {
+				m.modal = &confirmModal{title: "Cell — " + name, body: "left to the column's DEFAULT."}
+				return m, nil, true
+			}
+			m.modal = newCellModal(name, v)
+			return m, nil, true
+		}
+		v, ok := m.data.cell()
+		if !ok {
+			return m, nil, true
+		}
 		m.modal = newCellModal(name, v)
 	case actEditCell:
 		cmd := m.startEdit()
+		return m, cmd, true
+	case actDeleteRow:
+		cmd := m.startDelete()
+		return m, cmd, true
+	case actInsertRow:
+		cmd := m.startInsert(false)
+		return m, cmd, true
+	case actDuplicateRow:
+		cmd := m.startInsert(true)
 		return m, cmd, true
 	case actCommitChanges:
 		cmd := m.openCommitModal()

--- a/internal/ui/data_test.go
+++ b/internal/ui/data_test.go
@@ -319,7 +319,7 @@ func TestWideTableScrollsHorizontally(t *testing.T) {
 	next, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
 	m = next.(Model)
 
-	cols := m.buildGrid()
+	cols, _ := m.buildGrid()
 	start, end := columnWindow(cols, 0, 30)
 	if start != 0 || end >= len(cols) {
 		t.Fatalf("window at the first column = [%d,%d), want a partial window from 0", start, end)

--- a/internal/ui/datagrid.go
+++ b/internal/ui/datagrid.go
@@ -22,6 +22,20 @@ const (
 // cannot be confused with the string "NULL".
 const nullText = "NULL"
 
+// rowKind is how a rendered row relates to the changeset: an untouched
+// page row, a row staged for deletion, or a phantom row standing for a
+// staged insert that does not exist in the database yet.
+type rowKind int
+
+const (
+	rowPlain rowKind = iota
+	rowDeleted
+	rowInserted
+)
+
+// defaultText marks a phantom row's cell that the INSERT leaves out.
+const defaultText = "DEFAULT"
+
 // gridColumn is one rendered column: its header, its type and the
 // already-formatted cells of the page under it.
 type gridColumn struct {
@@ -34,10 +48,26 @@ type gridColumn struct {
 }
 
 // buildGrid formats the whole page once so column widths, the header
-// and every row agree on the same strings.
-func (m Model) buildGrid() []gridColumn {
+// and every row agree on the same strings. The staged inserts of the
+// open table are appended as phantom rows after the page, which is why
+// it also returns what each rendered row is.
+func (m Model) buildGrid() ([]gridColumn, []rowKind) {
 	d := m.data
 	rowKeys := m.stagedRowKeys()
+	inserts := m.stagedInserts()
+	n := len(d.rows) + len(inserts)
+
+	kinds := make([]rowKind, n)
+	for r := range d.rows {
+		if rowKeys != nil && rowKeys[r] != nil &&
+			m.changes.DeleteStaged(d.database, d.table, rowKeys[r]) {
+			kinds[r] = rowDeleted
+		}
+	}
+	for i := range inserts {
+		kinds[len(d.rows)+i] = rowInserted
+	}
+
 	cols := make([]gridColumn, len(d.cols))
 	for i, c := range d.cols {
 		header := c.Name
@@ -51,9 +81,9 @@ func (m Model) buildGrid() []gridColumn {
 		g := gridColumn{
 			header: header,
 			typ:    strings.ToLower(c.DataType),
-			cells:  make([]string, len(d.rows)),
-			nulls:  make([]bool, len(d.rows)),
-			staged: make([]bool, len(d.rows)),
+			cells:  make([]string, n),
+			nulls:  make([]bool, n),
+			staged: make([]bool, n),
 			width:  maxInt(lipgloss.Width(header), lipgloss.Width(c.DataType)),
 		}
 		for r, row := range d.rows {
@@ -71,7 +101,22 @@ func (m Model) buildGrid() []gridColumn {
 			}
 			g.nulls[r] = v == nil
 			g.cells[r] = flatten(db.FormatValue(v, nullText))
-			if w := lipgloss.Width(g.cells[r]); w > g.width {
+		}
+		for j, ins := range inserts {
+			r := len(d.rows) + j
+			v, bound := insertValueFor(ins, c.Name)
+			switch {
+			case !bound:
+				g.cells[r] = defaultText
+			case v == nil:
+				g.nulls[r] = true
+				g.cells[r] = nullText
+			default:
+				g.cells[r] = flatten(db.FormatValue(v, nullText))
+			}
+		}
+		for _, cell := range g.cells {
+			if w := lipgloss.Width(cell); w > g.width {
 				g.width = w
 			}
 		}
@@ -83,14 +128,15 @@ func (m Model) buildGrid() []gridColumn {
 		}
 		cols[i] = g
 	}
-	return cols
+	return cols, kinds
 }
 
 // stagedRowKeys returns each page row's primary key values, or nil when
-// nothing is staged for the open table. The key columns come from the
-// changeset itself, so highlighting works without a metadata fetch.
+// the primary key of the open table is not known. The key columns come
+// from the metadata when it is loaded and from the changeset otherwise,
+// so highlighting survives a dropped metadata cache.
 func (m Model) stagedRowKeys() [][]any {
-	pkCols := m.changes.PKColsFor(m.data.database, m.data.table)
+	pkCols := m.pkColumns()
 	if pkCols == nil {
 		return nil
 	}
@@ -182,15 +228,15 @@ func (m Model) dataContent(w, h int) string {
 	case len(d.cols) == 0:
 		lines = append(lines, "", m.style.muted.Render("no columns"))
 	default:
-		cols := m.buildGrid()
+		cols, kinds := m.buildGrid()
 		cs, ce := columnWindow(cols, d.col, w)
-		rs, re := rowWindow(len(d.rows), d.row, bodyRows)
+		rs, re := rowWindow(len(kinds), d.row, bodyRows)
 
 		lines = append(lines, m.gridHeader(cols[cs:ce], cs, w))
 		for r := rs; r < re; r++ {
-			lines = append(lines, m.gridRow(cols[cs:ce], cs, r, w))
+			lines = append(lines, m.gridRow(cols[cs:ce], cs, r, kinds[r], w))
 		}
-		if len(d.rows) == 0 {
+		if len(kinds) == 0 {
 			lines = append(lines, m.style.muted.Render("no rows match"))
 		}
 		if cs > 0 || ce < len(cols) {
@@ -228,7 +274,7 @@ func (m Model) gridHeader(cols []gridColumn, first, w int) string {
 
 // gridRow renders one row of the page, tinting the cursor row and, more
 // strongly, the cursor cell.
-func (m Model) gridRow(cols []gridColumn, first, r, w int) string {
+func (m Model) gridRow(cols []gridColumn, first, r int, kind rowKind, w int) string {
 	var b strings.Builder
 	onRow := r == m.data.row && m.focus == panelMain
 	for i, c := range cols {
@@ -244,16 +290,19 @@ func (m Model) gridRow(cols []gridColumn, first, r, w int) string {
 		if r < len(c.cells) {
 			text, isNull, isStaged = c.cells[r], c.nulls[r], c.staged[r]
 		}
-		b.WriteString(m.cellStyle(onRow, first+i == m.data.col, isNull, isStaged).
+		b.WriteString(m.cellStyle(onRow, first+i == m.data.col, isNull, isStaged, kind).
 			Render(pad(truncate(text, c.width), c.width)))
 	}
 	return truncate(b.String(), w)
 }
 
-// cellStyle picks the tint of one cell from the cursor position, whether
-// the value is NULL and whether an edit of it is staged. Staged wins
-// over NULL: yellow is the "pending" color throughout the app.
-func (m Model) cellStyle(onRow, onCol, isNull, isStaged bool) lipgloss.Style {
+// cellStyle picks the tint of one cell from the cursor position, what
+// the row is staged as, whether the value is NULL and whether an edit of
+// it is staged. A staged row op wins over everything below it: the whole
+// row is going away or arriving, so a per-cell tint would only muddle
+// it. Otherwise staged wins over NULL — yellow is the "pending" color
+// throughout the app.
+func (m Model) cellStyle(onRow, onCol, isNull, isStaged bool, kind rowKind) lipgloss.Style {
 	style := lipgloss.NewStyle()
 	switch {
 	case onRow && onCol && m.focus == panelMain:
@@ -262,6 +311,10 @@ func (m Model) cellStyle(onRow, onCol, isNull, isStaged bool) lipgloss.Style {
 		style = m.style.rowCursor
 	}
 	switch {
+	case kind == rowDeleted:
+		return style.Foreground(colorRed).Strikethrough(true)
+	case kind == rowInserted:
+		return style.Foreground(colorGreen).Bold(true)
 	case isStaged:
 		style = style.Foreground(colorYellow).Bold(true)
 	case isNull:

--- a/internal/ui/edit.go
+++ b/internal/ui/edit.go
@@ -49,17 +49,16 @@ func (m *Model) startEdit() tea.Cmd {
 	if !m.data.open() || m.tab.metadata() || m.driver == nil {
 		return nil
 	}
+	if m.onPhantomRow() {
+		return logCmd("-- edit skipped: the cursor is on a staged insert (u unstages it)")
+	}
 	if len(m.data.rows) == 0 {
 		return logCmd("-- edit skipped: no rows on this page")
 	}
 	if m.meta.loaded {
 		return m.openEditModal()
 	}
-	m.meta.editAfterLoad = true
-	if m.meta.loading {
-		return nil
-	}
-	return m.startMetaLoad()
+	return m.deferUntilMeta(actEditCell)
 }
 
 // editIdentity returns the primary key columns of the open table and
@@ -72,7 +71,7 @@ func (m Model) editIdentity(row int) (pkCols []string, pkVals []any, problem str
 		}
 	}
 	if len(pkCols) == 0 {
-		return nil, nil, "the table has no primary key, so a row cannot be identified safely.\n\nlazysql refuses to guess row identity — add a primary key to edit this table."
+		return nil, nil, "the table has no primary key, so a row cannot be identified safely.\n\nlazysql refuses to guess row identity — add a primary key to edit or delete rows here. Inserting is still allowed."
 	}
 	if row < 0 || row >= len(m.data.rows) {
 		return nil, nil, "no row under the cursor."
@@ -113,6 +112,9 @@ func (m *Model) openEditModal() tea.Cmd {
 	if problem != "" {
 		m.modal = &confirmModal{title: "Editing disabled", body: problem, danger: true}
 		return nil
+	}
+	if m.changes.DeleteStaged(m.data.database, m.data.table, pkVals) {
+		return logCmd("-- edit skipped: the row is staged for deletion (u unstages it)")
 	}
 	if m.data.col >= len(m.data.cols) {
 		return nil
@@ -168,18 +170,32 @@ func (m *Model) stageChange(c db.CellChange) tea.Cmd {
 	return logCmd("-- stage: %s;  -- args %v", st.SQL, st.Args)
 }
 
-// unstageAtCursor is `u`: drop the staged change of the cell under the
-// cursor, if there is one.
+// unstageAtCursor is `u`: drop the staged change under the cursor. A
+// phantom row unstages its whole INSERT, a row staged for deletion
+// unstages the DELETE, and anything else unstages the cursor cell —
+// the row-level operations come first because on those rows there is no
+// cell change to remove anyway.
 func (m *Model) unstageAtCursor() tea.Cmd {
 	if !m.data.open() || m.tab.metadata() {
 		return nil
 	}
-	pkCols := m.changes.PKColsFor(m.data.database, m.data.table)
+	if ins, ok := m.phantomAtCursor(); ok {
+		m.changes.UnstageInsert(ins.Database, ins.Table, ins.ID)
+		m.clampCursor()
+		return logCmd("-- unstage insert into %s", ins.Table)
+	}
+	pkCols := m.pkColumns()
 	if pkCols == nil {
 		return logCmd("-- nothing staged for %s", m.data.table)
 	}
 	pkVals, ok := m.rowKeyVals(pkCols, m.data.row)
-	if !ok || m.data.col >= len(m.data.cols) {
+	if !ok {
+		return nil
+	}
+	if m.changes.UnstageDelete(m.data.database, m.data.table, pkVals) {
+		return logCmd("-- unstage delete of %s (%s)", m.data.table, rowLabel(pkCols, pkVals))
+	}
+	if m.data.col >= len(m.data.cols) {
 		return nil
 	}
 	colName := m.data.cols[m.data.col].Name
@@ -187,6 +203,25 @@ func (m *Model) unstageAtCursor() tea.Cmd {
 		return logCmd("-- unstage %s.%s", m.data.table, colName)
 	}
 	return logCmd("-- no staged change under the cursor")
+}
+
+// pkColumns names the primary key of the open table. The metadata is
+// the source of truth, but a changeset that already holds a change of
+// the table knows them too — which is how the grid keeps highlighting
+// staged rows after the metadata cache was dropped.
+func (m Model) pkColumns() []string {
+	if m.meta.loaded && m.meta.table == m.data.table {
+		var cols []string
+		for _, c := range m.meta.cols {
+			if c.PrimaryKey {
+				cols = append(cols, c.Name)
+			}
+		}
+		if cols != nil {
+			return cols
+		}
+	}
+	return m.changes.PKColsFor(m.data.database, m.data.table)
 }
 
 // confirmDiscard is `U`: throw the whole changeset away, after asking.

--- a/internal/ui/edit_test.go
+++ b/internal/ui/edit_test.go
@@ -232,7 +232,10 @@ func TestEditKeysAreDocumented(t *testing.T) {
 	m := dataBrowsing(t)
 	m = send(t, m, press('?'))
 	out := m.View().Content
-	for _, want := range []string{"edit cell", "commit staged changes", "unstage cell", "discard staged changes"} {
+	for _, want := range []string{
+		"edit cell", "stage row delete", "insert row", "duplicate row",
+		"commit staged changes", "unstage", "discard staged changes",
+	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("help is missing %q", want)
 		}

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -10,8 +10,9 @@ import (
 
 // formModal is the reusable multi-field popup: a vertical stack of labelled
 // fields with one cursor, an inline validation error line, and the usual
-// enter/esc contract. The connection editor is the first user; row insert and
-// filter builders will reuse it.
+// enter/esc contract. The connection editor is its user. (The row insert form
+// is its own modal: its fields are columns, and each one cycles between a
+// typed value, NULL and the column's default rather than holding a string.)
 //
 // Fields can be hidden dynamically (`visible`), which is how the engine choice
 // swaps host/port for a file path without rebuilding the modal.

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -47,6 +47,9 @@ type keyMap struct {
 
 	// Staged editing (Data tab).
 	EditCell       key.Binding
+	DeleteRow      key.Binding
+	InsertRow      key.Binding
+	DuplicateRow   key.Binding
 	CommitChanges  key.Binding
 	UnstageCell    key.Binding
 	DiscardChanges key.Binding
@@ -94,8 +97,11 @@ func newKeyMap() keyMap {
 		ViewCell:    key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "view cell")),
 
 		EditCell:       key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit cell")),
+		DeleteRow:      key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "stage row delete")),
+		InsertRow:      key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "insert row")),
+		DuplicateRow:   key.NewBinding(key.WithKeys("D"), key.WithHelp("D", "duplicate row")),
 		CommitChanges:  key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "commit staged changes")),
-		UnstageCell:    key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "unstage cell")),
+		UnstageCell:    key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "unstage")),
 		DiscardChanges: key.NewBinding(key.WithKeys("U"), key.WithHelp("U", "discard staged changes")),
 
 		PrevMainTab: key.NewBinding(key.WithKeys("["), key.WithHelp("[", "prev tab")),
@@ -119,7 +125,10 @@ func (k keyMap) global() []key.Binding {
 type actionID int
 
 const (
-	actConnect actionID = iota
+	// actNone is the zero value, so a struct field can mean "no action
+	// pending" without a second bool next to it.
+	actNone actionID = iota
+	actConnect
 	actNewConnection
 	actEditConnection
 	actDropConnection
@@ -137,6 +146,9 @@ const (
 	actWhereFilter
 	actViewCell
 	actEditCell
+	actDeleteRow
+	actInsertRow
+	actDuplicateRow
 	actCommitChanges
 	actUnstageCell
 	actDiscardChanges
@@ -191,6 +203,9 @@ func (k keyMap) panelActions(id panelID) []action {
 			{actWhereFilter, k.WhereFilter},
 			{actViewCell, k.ViewCell},
 			{actEditCell, k.EditCell},
+			{actDeleteRow, k.DeleteRow},
+			{actInsertRow, k.InsertRow},
+			{actDuplicateRow, k.DuplicateRow},
 			{actCommitChanges, k.CommitChanges},
 			{actUnstageCell, k.UnstageCell},
 			{actDiscardChanges, k.DiscardChanges},

--- a/internal/ui/meta.go
+++ b/internal/ui/meta.go
@@ -59,11 +59,11 @@ type metaView struct {
 	// of each tab, so switching tabs back and forth keeps the position.
 	row [mainTabCount]int
 
-	// copyAfterLoad makes `y` work on a tab that has not been opened
-	// yet: the copy runs when the metadata lands. editAfterLoad does the
-	// same for `e`, which needs the primary key from the metadata.
-	copyAfterLoad bool
-	editAfterLoad bool
+	// afterLoad is the action to re-run once the metadata lands, so keys
+	// that need it work on a tab that has never been opened: `y` needs
+	// the DDL, and `e`/`d`/`n`/`D` need the primary key and the column
+	// list. actNone means nothing is waiting.
+	afterLoad actionID
 
 	req int
 }
@@ -223,7 +223,13 @@ func (m *Model) copyDDL() tea.Cmd {
 	// Nothing cached yet: fetch, then copy when the reply lands. `y`
 	// works from the Data tab too, where ensureMeta would not fetch, so
 	// the load is started directly.
-	m.meta.copyAfterLoad = true
+	return m.deferUntilMeta(actCopyDDL)
+}
+
+// deferUntilMeta parks an action until the metadata fetch lands and
+// starts that fetch when it is not already running.
+func (m *Model) deferUntilMeta(id actionID) tea.Cmd {
+	m.meta.afterLoad = id
 	if m.meta.loading {
 		return nil
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -389,7 +389,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.data.cols = msg.result.Columns
 		m.data.rows = msg.result.Rows
-		m.data.clampCursor()
+		m.clampCursor()
 		return m, nil
 
 	case metaLoadedMsg:
@@ -400,8 +400,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.meta.loaded = true
 		if msg.err != nil {
 			m.meta.err = msg.err.Error()
-			m.meta.copyAfterLoad = false
-			m.meta.editAfterLoad = false
+			m.meta.afterLoad = actNone
 			return m, logCmd("-- introspect %s FAILED: %v", msg.table, msg.err)
 		}
 		m.meta.cols, m.meta.indexes, m.meta.fks = msg.cols, msg.indexes, msg.fks
@@ -409,15 +408,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.ddlErr != nil {
 			m.meta.ddlErr = msg.ddlErr.Error()
 		}
-		if m.meta.copyAfterLoad {
-			m.meta.copyAfterLoad = false
-			cmd := m.copyDDL()
-			return m, cmd
-		}
-		if m.meta.editAfterLoad {
-			m.meta.editAfterLoad = false
-			cmd := m.openEditModal()
-			return m, cmd
+		// A key pressed before the metadata existed runs now. The action
+		// takes the same path it would have taken with a warm cache.
+		if id := m.meta.afterLoad; id != actNone {
+			m.meta.afterLoad = actNone
+			mm, cmd := m.runAction(id)
+			return mm, cmd
 		}
 		return m, nil
 

--- a/internal/ui/rowops.go
+++ b/internal/ui/rowops.go
@@ -1,0 +1,517 @@
+package ui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"charm.land/bubbles/v2/textinput"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"lazysql/internal/db"
+)
+
+// Whole-row operations, staged through the same changeset as cell edits
+// and committed in the same transaction. `d` stages a DELETE of the row
+// under the cursor, `n` opens an insert form, `D` opens the same form
+// prefilled from the current row. Nothing here executes SQL.
+
+// ---------- staged inserts as phantom rows ----------
+
+// stagedInserts are the pending INSERTs of the open table, in staging
+// order. The grid renders them after the last real row of the page.
+func (m Model) stagedInserts() []db.RowInsert {
+	if !m.data.open() {
+		return nil
+	}
+	return m.changes.InsertsFor(m.data.database, m.data.table)
+}
+
+// phantomAtCursor returns the staged insert the cursor sits on, if the
+// cursor left the real rows of the page.
+func (m Model) phantomAtCursor() (db.RowInsert, bool) {
+	ins := m.stagedInserts()
+	i := m.data.row - len(m.data.rows)
+	if i < 0 || i >= len(ins) {
+		return db.RowInsert{}, false
+	}
+	return ins[i], true
+}
+
+func (m Model) onPhantomRow() bool {
+	_, ok := m.phantomAtCursor()
+	return ok
+}
+
+// clampCursor re-derives how many phantom rows the grid has and then
+// clamps the cell cursor. Every place that moves the cursor or changes
+// the page goes through here, so staging or unstaging an insert can
+// never leave the cursor pointing past the last rendered row.
+func (m *Model) clampCursor() {
+	m.data.extraRows = len(m.stagedInserts())
+	m.data.clampCursor()
+}
+
+// ---------- delete ----------
+
+// startDelete is `d` on the Data tab. Like `e` it needs the primary key
+// from the metadata, and waits for the fetch when nothing cached it yet.
+func (m *Model) startDelete() tea.Cmd {
+	if !m.data.open() || m.tab.metadata() || m.driver == nil {
+		return nil
+	}
+	if m.onPhantomRow() {
+		return logCmd("-- delete skipped: the row is a staged insert (u unstages it)")
+	}
+	if len(m.data.rows) == 0 {
+		return logCmd("-- delete skipped: no rows on this page")
+	}
+	if m.meta.loaded {
+		return m.stageDeleteAtCursor()
+	}
+	return m.deferUntilMeta(actDeleteRow)
+}
+
+// stageDeleteAtCursor records the DELETE of the row under the cursor.
+// Staging it also drops that row's staged cell edits — see
+// Changeset.StageDelete.
+func (m *Model) stageDeleteAtCursor() tea.Cmd {
+	pkCols, pkVals, problem := m.editIdentity(m.data.row)
+	if problem != "" {
+		m.modal = &confirmModal{title: "Deleting disabled", body: problem, danger: true}
+		return nil
+	}
+	r := db.RowDelete{
+		Database: m.data.database,
+		Table:    m.data.table,
+		PKCols:   pkCols,
+		PKVals:   pkVals,
+	}
+	if !m.changes.StageDelete(r) {
+		return logCmd("-- already staged: delete of %s (%s)", r.Table, rowLabel(pkCols, pkVals))
+	}
+	st := db.DeleteSQL(m.driver.Dialect(), r)
+	return logCmd("-- stage: %s;  -- args %v", st.SQL, st.Args)
+}
+
+// ---------- insert and duplicate ----------
+
+// startInsert is `n` (fresh row) and `D` (duplicate of the row under the
+// cursor). Both need the column list, so both wait for the metadata.
+// Unlike delete, neither needs a primary key: a PK-less table can still
+// be inserted into.
+func (m *Model) startInsert(duplicate bool) tea.Cmd {
+	if !m.data.open() || m.tab.metadata() || m.driver == nil {
+		return nil
+	}
+	if duplicate {
+		if m.onPhantomRow() {
+			return logCmd("-- duplicate skipped: the row is itself a staged insert")
+		}
+		if len(m.data.rows) == 0 {
+			return logCmd("-- duplicate skipped: no rows on this page")
+		}
+	}
+	if m.meta.loaded {
+		return m.openInsertModal(duplicate)
+	}
+	if duplicate {
+		return m.deferUntilMeta(actDuplicateRow)
+	}
+	return m.deferUntilMeta(actInsertRow)
+}
+
+// openInsertModal builds the insert form from the table's columns,
+// optionally prefilled with the row under the cursor.
+func (m *Model) openInsertModal(duplicate bool) tea.Cmd {
+	if len(m.meta.cols) == 0 {
+		m.modal = &confirmModal{
+			title:  "Insert disabled",
+			body:   "the engine reported no columns for this relation.",
+			danger: true,
+		}
+		return nil
+	}
+	title := "Insert row into " + m.data.table
+	var prefill map[string]any
+	if duplicate {
+		prefill = m.effectiveRow(m.data.row)
+		if prefill == nil {
+			return logCmd("-- duplicate skipped: no row under the cursor")
+		}
+		title = "Duplicate row of " + m.data.table
+	}
+	m.modal = newInsertRowModal(title, m.data.database, m.data.table, m.meta.cols, prefill)
+	return nil
+}
+
+// effectiveRow is one page row as the grid shows it: the fetched values
+// with the row's staged cell edits applied, keyed by column name. That
+// is what `D` duplicates — copying values the user can see beats copying
+// values only the server still holds.
+func (m Model) effectiveRow(row int) map[string]any {
+	if row < 0 || row >= len(m.data.rows) {
+		return nil
+	}
+	var pkVals []any
+	if pkCols := m.pkColumns(); pkCols != nil {
+		pkVals, _ = m.rowKeyVals(pkCols, row)
+	}
+	out := make(map[string]any, len(m.data.cols))
+	for i, c := range m.data.cols {
+		var v any
+		if i < len(m.data.rows[row]) {
+			v = m.data.rows[row][i]
+		}
+		if pkVals != nil {
+			if ch, ok := m.changes.Lookup(m.data.database, m.data.table, pkVals, c.Name); ok {
+				v = ch.NewValue
+			}
+		}
+		out[c.Name] = v
+	}
+	return out
+}
+
+// stageInsert records a confirmed insert form.
+func (m *Model) stageInsert(r db.RowInsert) tea.Cmd {
+	r = m.changes.StageInsert(r)
+	m.clampCursor()
+	st := db.InsertSQL(m.driver.Dialect(), r)
+	return logCmd("-- stage: %s;  -- args %v", st.SQL, st.Args)
+}
+
+// insertValueFor returns the value a staged insert binds for a column.
+// bound is false when the insert leaves the column out, i.e. the engine
+// will apply its default.
+func insertValueFor(r db.RowInsert, column string) (value any, bound bool) {
+	for i, c := range r.Columns {
+		if c != column {
+			continue
+		}
+		if i < len(r.Values) {
+			return r.Values[i], true
+		}
+		return nil, true
+	}
+	return nil, false
+}
+
+// ---------- column value inference ----------
+
+// autoAssigned reports whether the engine fills a column in by itself
+// when the INSERT leaves it out — a DEFAULT clause, an auto-increment /
+// identity / serial column, or SQLite's `INTEGER PRIMARY KEY` rowid
+// alias, which auto-assigns without declaring anything.
+func autoAssigned(c db.Column) bool {
+	if c.Default != nil {
+		return true
+	}
+	extra := strings.ToLower(c.Extra)
+	for _, marker := range []string{"auto_increment", "autoincrement", "identity", "generated", "serial"} {
+		if strings.Contains(extra, marker) {
+			return true
+		}
+	}
+	return c.PrimaryKey && columnKind(c.DataType) == kindInt
+}
+
+// columnKind classifies a declared type well enough to bind a typed
+// parameter. Anything unrecognized — and deliberately NUMERIC/DECIMAL,
+// where a float64 would lose digits — is bound as a string and the
+// engine converts it.
+type valueKind int
+
+const (
+	kindText valueKind = iota
+	kindInt
+	kindFloat
+	kindBool
+)
+
+func columnKind(dataType string) valueKind {
+	base := strings.ToLower(strings.TrimSpace(dataType))
+	if i := strings.IndexAny(base, " ("); i >= 0 {
+		base = base[:i]
+	}
+	switch base {
+	case "int", "integer", "bigint", "smallint", "tinyint", "mediumint",
+		"int2", "int4", "int8", "serial", "bigserial", "smallserial",
+		"hugeint", "ubigint", "uinteger", "usmallint", "utinyint":
+		return kindInt
+	case "float", "double", "real", "float4", "float8":
+		return kindFloat
+	case "bool", "boolean":
+		return kindBool
+	}
+	return kindText
+}
+
+// convertForColumn turns form text into a typed parameter guided by the
+// column's declared type. Text that does not parse stays a string, the
+// same rule the cell editor uses.
+func convertForColumn(text string, c db.Column) any {
+	switch columnKind(c.DataType) {
+	case kindInt:
+		if v, err := strconv.ParseInt(strings.TrimSpace(text), 10, 64); err == nil {
+			return v
+		}
+	case kindFloat:
+		if v, err := strconv.ParseFloat(strings.TrimSpace(text), 64); err == nil {
+			return v
+		}
+	case kindBool:
+		if v, err := strconv.ParseBool(strings.TrimSpace(text)); err == nil {
+			return v
+		}
+	}
+	return text
+}
+
+// ---------- insert modal ----------
+
+// insertMode is what one field contributes to the staged INSERT.
+type insertMode int
+
+const (
+	insertValue   insertMode = iota // bind the typed value
+	insertNull                      // bind an explicit SQL NULL
+	insertDefault                   // leave the column out of the statement
+)
+
+// insertField is one column's row in the form.
+type insertField struct {
+	col   db.Column
+	input textinput.Model
+	mode  insertMode
+}
+
+// insertRowModal is the `n` / `D` popup: one field per column, each
+// cycling between a typed value, NULL and the column's default.
+type insertRowModal struct {
+	title           string
+	database, table string
+	fields          []*insertField
+	cursor          int
+	offset          int
+	err             string
+}
+
+func newInsertRowModal(title, database, table string, cols []db.Column, prefill map[string]any) *insertRowModal {
+	f := &insertRowModal{title: title, database: database, table: table}
+	for _, c := range cols {
+		ti := textinput.New()
+		ti.Placeholder = strings.ToLower(c.DataType)
+		ti.SetWidth(34)
+		fl := &insertField{col: c, input: ti}
+
+		v, prefilled := prefill[c.Name]
+		switch {
+		// A duplicate clears the key: reusing it would collide, and an
+		// auto-assigned column gets a fresh value from the engine.
+		case prefilled && (c.PrimaryKey || autoAssigned(c)):
+			fl.mode = insertDefault
+			if !autoAssigned(c) {
+				// Nothing will fill it in, so the user has to.
+				fl.mode = insertValue
+			}
+		case prefilled && v == nil:
+			fl.mode = insertNull
+		case prefilled:
+			fl.mode = insertValue
+			fl.input.SetValue(db.FormatValue(v, ""))
+		case autoAssigned(c):
+			fl.mode = insertDefault
+		case c.Nullable:
+			fl.mode = insertNull
+		}
+		fl.input.CursorEnd()
+		f.fields = append(f.fields, fl)
+	}
+	f.syncFocus()
+	return f
+}
+
+// syncFocus keeps exactly the field under the cursor focused, so only
+// one input blinks and receives runes.
+func (f *insertRowModal) syncFocus() {
+	for i, fl := range f.fields {
+		if i == f.cursor {
+			fl.input.Focus()
+		} else {
+			fl.input.Blur()
+		}
+	}
+}
+
+func (f *insertRowModal) move(delta int) {
+	if len(f.fields) == 0 {
+		return
+	}
+	f.cursor = (f.cursor + delta + len(f.fields)) % len(f.fields)
+	f.syncFocus()
+}
+
+func (f *insertRowModal) current() *insertField {
+	if f.cursor < 0 || f.cursor >= len(f.fields) {
+		return nil
+	}
+	return f.fields[f.cursor]
+}
+
+func (f *insertRowModal) update(msg tea.KeyPressMsg, m *Model) (bool, tea.Cmd) {
+	cur := f.current()
+	switch msg.String() {
+	case "esc":
+		return true, nil
+	case "tab", "down":
+		f.move(1)
+		return false, nil
+	case "shift+tab", "up":
+		f.move(-1)
+		return false, nil
+	case "ctrl+n":
+		if cur != nil {
+			cur.mode = toggleMode(cur.mode, insertNull)
+		}
+		return false, nil
+	case "ctrl+d":
+		if cur != nil {
+			cur.mode = toggleMode(cur.mode, insertDefault)
+		}
+		return false, nil
+	case "enter":
+		r, problem := f.build()
+		if problem != "" {
+			f.err = problem
+			return false, nil
+		}
+		return true, m.stageInsert(r)
+	}
+	if cur == nil {
+		return false, nil
+	}
+	// Typing means the user wants a value again, whatever the mode was.
+	if msg.Text != "" {
+		cur.mode = insertValue
+	}
+	var cmd tea.Cmd
+	cur.input, cmd = cur.input.Update(msg)
+	return false, cmd
+}
+
+// toggleMode switches a field into a mode, or back to a typed value when
+// it is already in it, so one key both sets and clears NULL / DEFAULT.
+func toggleMode(cur, want insertMode) insertMode {
+	if cur == want {
+		return insertValue
+	}
+	return want
+}
+
+// build validates the form and renders it as a staged insert. A NOT NULL
+// column that nothing will fill in is the one thing the form refuses:
+// the engine would reject it on commit and roll the whole changeset
+// back, which is a slow way to learn about a typo.
+func (f *insertRowModal) build() (db.RowInsert, string) {
+	r := db.RowInsert{Database: f.database, Table: f.table}
+	for _, fl := range f.fields {
+		switch fl.mode {
+		case insertNull:
+			if !fl.col.Nullable {
+				return r, fmt.Sprintf("%s is NOT NULL — give it a value", fl.col.Name)
+			}
+			r.Columns = append(r.Columns, fl.col.Name)
+			r.Values = append(r.Values, nil)
+		case insertDefault:
+			if !fl.col.Nullable && !autoAssigned(fl.col) {
+				return r, fmt.Sprintf("%s is NOT NULL and has no default — give it a value", fl.col.Name)
+			}
+		default:
+			r.Columns = append(r.Columns, fl.col.Name)
+			r.Values = append(r.Values, convertForColumn(fl.input.Value(), fl.col))
+		}
+	}
+	return r, ""
+}
+
+func (f *insertRowModal) view(s styles, maxW, maxH int) string {
+	width := min(maxW-8, 72)
+	if width < 20 {
+		width = 20
+	}
+	labelW := 0
+	for _, fl := range f.fields {
+		if w := lipgloss.Width(fl.col.Name); w > labelW {
+			labelW = w
+		}
+	}
+	inputW := min(38, maxInt(width-labelW-6, 12))
+
+	// title, blank, error, blank, footer, borders
+	rows := maxH - 8
+	if rows < 1 {
+		rows = 1
+	}
+	if rows > len(f.fields) {
+		rows = len(f.fields)
+	}
+	if f.cursor < f.offset {
+		f.offset = f.cursor
+	}
+	if f.cursor >= f.offset+rows {
+		f.offset = f.cursor - rows + 1
+	}
+	if maxOff := len(f.fields) - rows; f.offset > maxOff {
+		f.offset = maxOff
+	}
+	if f.offset < 0 {
+		f.offset = 0
+	}
+
+	var b strings.Builder
+	b.WriteString(s.modalTitle.Render(truncate(f.title, width)) + "\n\n")
+	for i := f.offset; i < f.offset+rows && i < len(f.fields); i++ {
+		fl := f.fields[i]
+		fl.input.SetWidth(inputW)
+		label := fl.col.Name + strings.Repeat(" ", labelW-lipgloss.Width(fl.col.Name))
+		marker := "  "
+		if i == f.cursor {
+			marker = s.keyHint.Render("▸ ")
+			label = s.titleFocused.Render(label)
+		} else {
+			label = s.muted.Render(label)
+		}
+		b.WriteString(marker + label + "  " + truncate(f.fieldValue(s, fl), inputW+22) + "\n")
+	}
+	if len(f.fields) > rows {
+		b.WriteString(s.muted.Render(fmt.Sprintf("… %d of %d columns\n",
+			f.offset+rows, len(f.fields))))
+	}
+	if f.err != "" {
+		b.WriteString("\n" + s.danger.Render("✗ "+f.err) + "\n")
+	}
+	b.WriteString("\n" + s.muted.Render(
+		"tab/↑↓ field · ctrl+n NULL · ctrl+d default · enter stage · esc cancel"))
+	return s.modal.Render(b.String())
+}
+
+// fieldValue renders one field's contribution: the input, a dim NULL or
+// the default the column falls back to.
+func (f *insertRowModal) fieldValue(s styles, fl *insertField) string {
+	switch fl.mode {
+	case insertNull:
+		return s.muted.Render(nullText)
+	case insertDefault:
+		if fl.col.Default != nil {
+			return s.pending.Render("DEFAULT ") + s.muted.Render(flatten(*fl.col.Default))
+		}
+		if fl.col.Extra != "" {
+			return s.pending.Render("DEFAULT ") + s.muted.Render("("+fl.col.Extra+")")
+		}
+		return s.pending.Render("DEFAULT")
+	default:
+		return fl.input.View()
+	}
+}

--- a/internal/ui/rowops_test.go
+++ b/internal/ui/rowops_test.go
@@ -1,0 +1,417 @@
+package ui
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/db"
+)
+
+// insertForm drives a key that should open the insert form and returns
+// it, so a test can fill fields in before submitting.
+func insertForm(t *testing.T, m Model, key rune) (Model, *insertRowModal) {
+	t.Helper()
+	m = send(t, m, press(key))
+	f, ok := m.modal.(*insertRowModal)
+	if !ok {
+		t.Fatalf("%c opened %T, want the insert form", key, m.modal)
+	}
+	return m, f
+}
+
+// setField puts a typed value into one field of the insert form.
+func setField(f *insertRowModal, name, value string) {
+	for _, fl := range f.fields {
+		if fl.col.Name == name {
+			fl.mode = insertValue
+			fl.input.SetValue(value)
+			return
+		}
+	}
+}
+
+// strictTable opens a fixture whose second column is NOT NULL without a
+// default — the case the insert form has to reject before commit.
+func strictTable(t *testing.T, m Model) Model {
+	t.Helper()
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`DROP TABLE IF EXISTS strictrows`,
+		`CREATE TABLE strictrows (id INTEGER PRIMARY KEY, name TEXT NOT NULL, note TEXT)`,
+		`INSERT INTO strictrows (id, name, note) VALUES (1, 'a', NULL)`,
+	} {
+		if _, err := m.driver.Exec(ctx, stmt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m = send(t, m, press('3'), press('R'))
+	if !m.panels[panelTables].selectByName("strictrows") {
+		t.Fatalf("fixture not listed: %v", m.panels[panelTables].items)
+	}
+	return send(t, m, special(tea.KeyEnter, 0))
+}
+
+// `d` stages a DELETE without executing it, the row is rendered
+// struck through, and `u` takes it back.
+func TestStageRowDeleteAndUnstage(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('d'))
+
+	if m.changes.Len() != 1 {
+		t.Fatalf("changeset = %d, want the delete staged", m.changes.Len())
+	}
+	if !m.changes.DeleteStaged("", "grid", []any{int64(1)}) {
+		t.Fatal("the delete was not staged for the row under the cursor")
+	}
+	if !logContains(m, `-- stage: DELETE FROM "grid" WHERE "id" = ?;  -- args [1]`) {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	// Nothing ran: the row is still in the database.
+	rs, err := m.driver.Query(context.Background(), "SELECT count(*) FROM grid WHERE id = 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rs.Rows[0][0] != int64(1) {
+		t.Fatal("the DELETE executed before the commit")
+	}
+	// The grid marks it, and the badge counts it.
+	_, kinds := m.buildGrid()
+	if kinds[0] != rowDeleted {
+		t.Fatalf("row kind = %v, want it rendered as deleted", kinds[0])
+	}
+	if !strings.Contains(m.View().Content, "1 staged change") {
+		t.Error("status badge missing")
+	}
+
+	// Pressing d again says so rather than stacking a second DELETE.
+	m = send(t, m, press('d'))
+	if m.changes.Len() != 1 {
+		t.Fatalf("changeset = %d, want the second d to be a no-op", m.changes.Len())
+	}
+	if !logContains(m, "-- already staged: delete of grid") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+
+	m = send(t, m, press('u'))
+	if m.changes.Len() != 0 {
+		t.Fatalf("changeset = %d after u, want the delete unstaged", m.changes.Len())
+	}
+}
+
+// Staging a delete drops the pending edits of the row it removes, and
+// editing a row already staged for deletion is refused.
+func TestStagedDeleteSupersedesCellEdits(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('l'))
+	m = stageEdit(t, m, "doomed")
+	if m.changes.Len() != 1 {
+		t.Fatalf("changeset = %d, want the edit staged", m.changes.Len())
+	}
+
+	m = send(t, m, press('d'))
+	if m.changes.Len() != 1 {
+		t.Fatalf("changeset = %d, want the edit replaced by the delete", m.changes.Len())
+	}
+	if _, ok := m.changes.Lookup("", "grid", []any{int64(1)}, "name"); ok {
+		t.Fatal("the edit of the deleted row survived")
+	}
+
+	m = send(t, m, press('e'))
+	if _, ok := m.modal.(*editCellModal); ok {
+		t.Fatal("e opened the editor on a row staged for deletion")
+	}
+	if !logContains(m, "the row is staged for deletion") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+}
+
+// A table without a primary key cannot be deleted from — the same rule
+// as editing — but it can still be inserted into.
+func TestDeleteDisabledWithoutPrimaryKeyInsertAllowed(t *testing.T) {
+	m := dataBrowsing(t)
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`DROP TABLE IF EXISTS nopkrows`,
+		`CREATE TABLE nopkrows (x INTEGER, y TEXT)`,
+		`INSERT INTO nopkrows (x, y) VALUES (1, 'a')`,
+	} {
+		if _, err := m.driver.Exec(ctx, stmt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	m = send(t, m, press('3'), press('R'))
+	if !m.panels[panelTables].selectByName("nopkrows") {
+		t.Fatalf("fixture not listed: %v", m.panels[panelTables].items)
+	}
+	m = send(t, m, special(tea.KeyEnter, 0), press('d'))
+
+	cm, ok := m.modal.(*confirmModal)
+	if !ok {
+		t.Fatalf("d opened %T, want the explanation", m.modal)
+	}
+	if !strings.Contains(cm.body, "no primary key") {
+		t.Fatalf("body = %q, want it to name the missing key", cm.body)
+	}
+	if m.changes.Len() != 0 {
+		t.Fatal("a delete got staged on a PK-less table")
+	}
+
+	m = send(t, m, special(tea.KeyEscape, 0))
+	m, f := insertForm(t, m, 'n')
+	setField(f, "x", "7")
+	setField(f, "y", "inserted")
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if m.changes.Len() != 1 {
+		t.Fatalf("changeset = %d, want the insert staged on the PK-less table", m.changes.Len())
+	}
+}
+
+// `n` stages an INSERT that shows up as a phantom row at the end of the
+// page, reachable by the cursor and removable with `u`.
+func TestInsertStagesPhantomRow(t *testing.T) {
+	m := dataBrowsing(t)
+	m, f := insertForm(t, m, 'n')
+
+	// The auto-assigned key defaults; the nullable columns start as NULL.
+	if f.fields[0].col.Name != "id" || f.fields[0].mode != insertDefault {
+		t.Fatalf("id field mode = %v, want DEFAULT", f.fields[0].mode)
+	}
+	if f.fields[2].mode != insertNull {
+		t.Fatalf("nullable field mode = %v, want NULL", f.fields[2].mode)
+	}
+	setField(f, "name", "phantom")
+	m = send(t, m, special(tea.KeyEnter, 0))
+
+	ins := m.changes.InsertsFor("", "grid")
+	if len(ins) != 1 {
+		t.Fatalf("staged inserts = %d, want 1", len(ins))
+	}
+	if len(ins[0].Columns) != 3 || ins[0].Columns[0] != "name" {
+		t.Fatalf("insert columns = %v, want id left to its default", ins[0].Columns)
+	}
+	if !logContains(m, `-- stage: INSERT INTO "grid" ("name", "note", "payload") VALUES (?, ?, ?)`) {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+
+	// It renders as an extra green row after the page.
+	cols, kinds := m.buildGrid()
+	if len(kinds) != len(m.data.rows)+1 || kinds[len(kinds)-1] != rowInserted {
+		t.Fatalf("row kinds = %d rows, last = %v", len(kinds), kinds[len(kinds)-1])
+	}
+	if got := cols[1].cells[len(kinds)-1]; got != "phantom" {
+		t.Fatalf("phantom cell = %q, want the staged value", got)
+	}
+	if got := cols[0].cells[len(kinds)-1]; got != defaultText {
+		t.Fatalf("phantom key cell = %q, want %q", got, defaultText)
+	}
+
+	// The cursor reaches it, and `u` there unstages the whole INSERT.
+	m.data.row = len(m.data.rows)
+	m.clampCursor()
+	if m.data.row != len(m.data.rows) {
+		t.Fatalf("cursor row = %d, want the phantom row reachable", m.data.row)
+	}
+	m = send(t, m, press('u'))
+	if m.changes.Len() != 0 {
+		t.Fatalf("changeset = %d after u, want the insert unstaged", m.changes.Len())
+	}
+	if m.data.row >= len(m.data.rows) {
+		t.Fatal("the cursor stayed on a row that no longer exists")
+	}
+}
+
+// The form refuses a NOT NULL column that nothing would fill in, both
+// for an explicit NULL and for a DEFAULT the column does not have.
+func TestInsertFormValidatesNotNull(t *testing.T) {
+	m := strictTable(t, browsing(t))
+	m, f := insertForm(t, m, 'n')
+
+	// cursor onto `name`, then stage NULL into it.
+	m = send(t, m, special(tea.KeyDown, 0), ctrl('n'))
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if m.modal != f {
+		t.Fatal("the form closed on an invalid NULL")
+	}
+	if !strings.Contains(f.err, "name is NOT NULL") {
+		t.Fatalf("error = %q, want it to name the column", f.err)
+	}
+	if m.changes.Len() != 0 {
+		t.Fatal("an invalid row got staged")
+	}
+
+	m = send(t, m, ctrl('d'))
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if m.modal != f || !strings.Contains(f.err, "no default") {
+		t.Fatalf("error = %q, want the missing default named", f.err)
+	}
+
+	setField(f, "name", "valid")
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if m.modal != nil || m.changes.Len() != 1 {
+		t.Fatalf("modal = %T, changeset = %d, want the valid row staged", m.modal, m.changes.Len())
+	}
+}
+
+// `D` prefills the form from the row under the cursor and clears the key
+// so the duplicate cannot collide with its original.
+func TestDuplicateRowPrefillsAndClearsKey(t *testing.T) {
+	m := dataBrowsing(t)
+	m, f := insertForm(t, m, 'D')
+
+	if f.fields[0].col.Name != "id" || f.fields[0].mode != insertDefault {
+		t.Fatalf("id field mode = %v, want the key cleared to DEFAULT", f.fields[0].mode)
+	}
+	if got := f.fields[1].input.Value(); got != "name-1" {
+		t.Fatalf("name field = %q, want the row's value", got)
+	}
+	if f.fields[2].mode != insertNull {
+		t.Fatalf("note field mode = %v, want NULL prefilled from the row", f.fields[2].mode)
+	}
+
+	m = send(t, m, special(tea.KeyEnter, 0))
+	ins := m.changes.InsertsFor("", "grid")
+	if len(ins) != 1 {
+		t.Fatalf("staged inserts = %d, want 1", len(ins))
+	}
+	for _, c := range ins[0].Columns {
+		if c == "id" {
+			t.Fatal("the duplicate carried the original's primary key")
+		}
+	}
+	v, bound := insertValueFor(ins[0], "name")
+	if !bound || v != "name-1" {
+		t.Fatalf("duplicated name = %v, want the original value", v)
+	}
+}
+
+// A duplicate copies the value the grid shows, staged edits included.
+func TestDuplicateUsesStagedValues(t *testing.T) {
+	m := dataBrowsing(t)
+	m = send(t, m, press('l'))
+	m = stageEdit(t, m, "edited")
+	m, f := insertForm(t, m, 'D')
+	if got := f.fields[1].input.Value(); got != "edited" {
+		t.Fatalf("name field = %q, want the staged value", got)
+	}
+}
+
+// The whole changeset — an edit, a delete and an insert — commits in one
+// transaction, and the commit confirmation shows all three statements.
+func TestRowOpsCommitInOneTransaction(t *testing.T) {
+	m := strictTable(t, browsing(t))
+	ctx := context.Background()
+	if _, err := m.driver.Exec(ctx,
+		`INSERT INTO strictrows (id, name, note) VALUES (2, 'b', NULL), (3, 'c', NULL)`); err != nil {
+		t.Fatal(err)
+	}
+	m = send(t, m, press('R'))
+
+	// edit row 1, delete row 2, insert a fresh row.
+	m = send(t, m, press('l'))
+	m = stageEdit(t, m, "edited")
+	m = send(t, m, press('j'), press('d'))
+	m, f := insertForm(t, m, 'n')
+	setField(f, "name", "fresh")
+	m = send(t, m, special(tea.KeyEnter, 0))
+
+	if m.changes.Len() != 3 {
+		t.Fatalf("changeset = %d, want the edit, the delete and the insert", m.changes.Len())
+	}
+
+	m = send(t, m, press('c'))
+	cm, ok := m.modal.(*confirmModal)
+	if !ok {
+		t.Fatalf("c opened %T, want the commit confirmation", m.modal)
+	}
+	for _, want := range []string{"UPDATE", "DELETE FROM", "INSERT INTO"} {
+		if !strings.Contains(cm.body, want) {
+			t.Errorf("commit modal is missing the %s statement:\n%s", want, cm.body)
+		}
+	}
+	if !strings.Contains(cm.body, "one transaction") {
+		t.Error("commit modal does not say the statements share a transaction")
+	}
+
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if m.changes.Len() != 0 {
+		t.Fatalf("changeset = %d after commit, want it cleared", m.changes.Len())
+	}
+	if !logContains(m, "BEGIN;") || !logContains(m, "COMMIT;") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+
+	rs, err := m.driver.Query(ctx, "SELECT id, name FROM strictrows ORDER BY id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rs.Rows) != 3 {
+		t.Fatalf("rows = %v, want 1 edited, 2 deleted and one inserted", rs.Rows)
+	}
+	if rs.Rows[0][1] != "edited" {
+		t.Errorf("row 1 name = %v, want the edit applied", rs.Rows[0][1])
+	}
+	if rs.Rows[1][0] != int64(3) {
+		t.Errorf("second row id = %v, want row 2 deleted", rs.Rows[1][0])
+	}
+	if rs.Rows[2][1] != "fresh" {
+		t.Errorf("last row = %v, want the inserted one", rs.Rows[2])
+	}
+}
+
+// A failing commit applies none of the row operations and keeps them.
+func TestRowOpsCommitFailureRollsBack(t *testing.T) {
+	m := strictTable(t, browsing(t))
+	m = send(t, m, press('d')) // delete the only row
+	m, f := insertForm(t, m, 'n')
+	// Reuse the key of the row this same commit deletes — but the INSERT
+	// runs after the DELETE, so make it collide with itself instead.
+	setField(f, "id", "1")
+	setField(f, "name", "collides")
+	m = send(t, m, special(tea.KeyEnter, 0))
+	m, f2 := insertForm(t, m, 'n')
+	setField(f2, "id", "1")
+	setField(f2, "name", "collides again")
+	m = send(t, m, special(tea.KeyEnter, 0))
+
+	m = send(t, m, press('c'), special(tea.KeyEnter, 0))
+	if !logContains(m, "COMMIT FAILED") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	if m.changes.Len() != 3 {
+		t.Fatalf("changeset = %d after a failed commit, want it kept", m.changes.Len())
+	}
+	rs, err := m.driver.Query(context.Background(), "SELECT count(*) FROM strictrows")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rs.Rows[0][0] != int64(1) {
+		t.Fatalf("rows = %v, want the transaction rolled back entirely", rs.Rows[0][0])
+	}
+}
+
+// The type of a form value follows the column's declared type, so an
+// integer column gets an int64 parameter rather than its text.
+func TestConvertForColumnFollowsDeclaredType(t *testing.T) {
+	cases := []struct {
+		typ  string
+		text string
+		want any
+	}{
+		{"INTEGER", "42", int64(42)},
+		{"bigint", "42", int64(42)},
+		{"double precision", "1.5", 1.5},
+		{"boolean", "true", true},
+		{"text", "42", "42"},
+		{"numeric(10,2)", "1.50", "1.50"}, // exact digits, not a float64
+		{"INTEGER", "not a number", "not a number"},
+	}
+	for _, tc := range cases {
+		got := convertForColumn(tc.text, db.Column{DataType: tc.typ})
+		if got != tc.want {
+			t.Errorf("%s %q = %#v, want %#v", tc.typ, tc.text, got, tc.want)
+		}
+	}
+}

--- a/wiki/design/staged-changeset.md
+++ b/wiki/design/staged-changeset.md
@@ -1,7 +1,7 @@
 ---
 type: Design Decision
-title: Staged cell edits with an explicit commit transaction
-description: Why edits accumulate in an engine-agnostic changeset instead of executing, how a row is identified only by its declared primary key, and how the commit runs everything in one transaction.
+title: Staged cell edits and row operations with an explicit commit transaction
+description: Why edits, row deletes and row inserts accumulate in an engine-agnostic changeset instead of executing, how a row is identified only by its declared primary key, and how the commit runs everything in one transaction.
 tags: [tui, db, editing, changeset, transactions, security]
 generated:
   by: claude-code/fable-5
@@ -29,14 +29,64 @@ travel as parameters. The changeset is keyed by
 `(database, table, column, typed pk values)`, so editing a cell twice
 replaces the pending change (keeping the original `OldValue`) instead
 of stacking two UPDATEs, and restoring the original value in the
-editor unstages the cell. Row insert/delete (a separate issue) will
-extend the same structure.
+editor unstages the cell.
+
+### Row operations are the same changeset, not a second one
+
+`d`, `n` and `D` stage `db.RowDelete` and `db.RowInsert` values into the
+*same* `Changeset` as cell edits, so `c` still commits everything in one
+transaction and `U` still discards everything. The three types satisfy
+one `db.Change` interface — `key()`, `target()` and
+`Statement(dialect)` — and the changeset keeps a single ordered `[]Change`
+plus a key index, which is what makes commit order equal staging order
+across kinds. The interface's methods are unexported, so no UI package
+can add a fourth kind carrying its own SQL text.
+
+Keying differs by kind, because identity does:
+
+- a delete keys on `(database, table, typed pk values)`, so pressing `d`
+  twice on a row is a no-op instead of two DELETEs;
+- an insert has *no* natural identity — two identical new rows are two
+  rows — so `StageInsert` assigns a monotonic `ID` and `u` unstages by
+  it.
+
+Staging a delete drops that row's pending cell edits (`StageDelete`):
+UPDATEing a row the same transaction removes is dead work, and hiding it
+under a strikethrough row would be worse. For the same reason `e` on a
+row already staged for deletion is refused rather than silently staged.
+
+### The grid renders what is staged, including rows that do not exist
+
+`buildGrid` returns a `rowKind` per rendered row next to the columns:
+plain, deleted (red, struck through) or inserted. Staged inserts are
+appended after the page as *phantom* rows — green, with `DEFAULT` in
+every column the INSERT leaves out — so the pending row is visible where
+it will land. The cursor has to be able to reach them, so `dataView`
+carries an `extraRows` count that `Model.clampCursor` re-derives from the
+changeset before every clamp; `dataView` itself never learns about the
+changeset.
+
+### Inserts name only the columns the form filled in
+
+The insert form (`n`, or `D` prefilled from the row under the cursor)
+gives every column three states: a typed value, an explicit `NULL`
+(`ctrl+n`) or the column's default (`ctrl+d`). A column left on DEFAULT
+is simply absent from the generated statement, which is how
+auto-increment and `DEFAULT`-clause columns get their engine-assigned
+value — and why `D` clears the key of the row it duplicates. The form
+refuses to stage a NOT NULL column that nothing will fill in; everything
+else is left to the engine, with the commit's rollback as the safety
+net. Deleting needs the primary key and is disabled without one;
+inserting does not, and is allowed on a PK-less table.
 
 ### Rows are identified by the primary key, or not at all
 
 The key columns come from the cached metadata fetch (the same one the
-Structure tab uses; `e` triggers it lazily like `y` does for the DDL,
-via `metaView.editAfterLoad`). A table without a declared primary key
+Structure tab uses). `e`, `d`, `n` and `D` all need it before they can
+open anything, so they park themselves in `metaView.afterLoad` — one
+`actionID`, replayed through `runAction` when the reply lands — and the
+same key works identically warm or cold. A table without a declared
+primary key
 gets an explanatory modal instead of an editor: identifying a row by
 "all columns" or a rowid heuristic can silently hit more rows than the
 one on screen, so lazysql refuses to guess. For rendering, the grid
@@ -47,15 +97,18 @@ cache was reset.
 
 ### Commit is one transaction, and failure keeps the changeset
 
-`ExecTx` wraps all statements in `BeginTx … Commit`; the first error
+`ExecTx` wraps all statements — UPDATEs, DELETEs and INSERTs alike — in
+`BeginTx … Commit`; the first error
 rolls everything back and the reply keeps the changeset intact, so the
 user fixes the offending edit and retries. On success the exact
 parameterized statements are appended to the command log between
 `BEGIN;` and `COMMIT;` lines, recorded in the history panel, the
-changeset is cleared and the page reloads. `u` unstages the cursor
-cell, `U` confirms and discards everything; `resetBrowse` (connection
-switch/removal) also discards, because staged changes reference tables
-of the connection that owned them.
+changeset is cleared and the page reloads. `u` unstages whatever is
+under the cursor — a phantom row's whole INSERT, a struck-through row's
+DELETE, otherwise the cursor cell — and `U` confirms and discards
+everything; `resetBrowse` (connection switch/removal) also discards,
+because staged changes reference tables of the connection that owned
+them.
 
 ## Consequences
 
@@ -69,3 +122,13 @@ of the connection that owned them.
   the safety net.
 - The status line badge ("3 staged changes") counts the whole
   changeset, not just the open table, because `c` commits all of it.
+- Insert form text is bound with the type the *column* declares
+  (`convertForColumn`), not the type a neighbouring value happened to
+  have. `NUMERIC`/`DECIMAL` are deliberately bound as strings: a
+  `float64` would drop digits the user typed.
+- `D` duplicates the values the grid *shows*, staged cell edits
+  included. Copying values only the server still holds would contradict
+  what the user is looking at.
+- An insert with every column on DEFAULT is still a valid statement, and
+  the engines disagree on how to spell it — see
+  [reference/insert-default-values](../reference/insert-default-values.md).

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -15,7 +15,7 @@ concept with YAML frontmatter. Concept IDs are bundle-relative paths without
 - [design/catalog-browsing](design/catalog-browsing.md) — Design Decision — async catalog loads, inline fuzzy filter, tables/views sub-tabs, pseudo-database for single-namespace engines.
 - [design/data-grid](design/data-grid.md) — Design Decision — one-page-at-a-time main view, derived scroll windows, the `panelMain` focus target, and the parse-first quick filter.
 - [design/main-view-tabs](design/main-view-tabs.md) — Design Decision — Data/Structure/Indexes/DDL tabs behind one metadata fetch, `[`/`]` cycling instead of digits, and what survives a relation change.
-- [design/staged-changeset](design/staged-changeset.md) — Design Decision — cell edits stage into an engine-agnostic changeset, rows are identified only by their primary key, and the commit runs every UPDATE in one transaction.
+- [design/staged-changeset](design/staged-changeset.md) — Design Decision — cell edits, row deletes and row inserts stage into one engine-agnostic changeset, rows are identified only by their primary key, and the commit runs every statement in one transaction.
 
 ## reference
 
@@ -23,3 +23,4 @@ concept with YAML frontmatter. Concept IDs are bundle-relative paths without
 - [reference/dsn-formats](reference/dsn-formats.md) — Dialect Note — per-engine DSN shapes and their escaping/URI quirks.
 - [reference/dialect-introspection-quirks](reference/dialect-introspection-quirks.md) — Dialect Note — engine-specific introspection gotchas (PRAGMA placeholders, duckdb_* functions, pg_index, SHOW CREATE TABLE).
 - [reference/sqlite-double-quoted-strings](reference/sqlite-double-quoted-strings.md) — Dialect Note — SQLite reads an unresolvable double-quoted identifier as a string literal, so a filter on a misspelled column matches nothing instead of erroring.
+- [reference/insert-default-values](reference/insert-default-values.md) — Dialect Note — `DEFAULT VALUES` vs. MySQL's empty column list for an INSERT that names no columns.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -94,3 +94,28 @@ Chronological history of wiki changes, newest last.
   parameterized UPDATEs, and `Driver.ExecTx` commits everything in one
   transaction — failure rolls back and keeps the changeset. Tables
   without a declared primary key are not editable at all.
+- Extended [design/staged-changeset](design/staged-changeset.md) with
+  whole-row operations (issue #8): `d` stages a `db.RowDelete`, `n` opens
+  an insert form that stages a `db.RowInsert`, and `D` opens the same
+  form prefilled from the row under the cursor with its key cleared.
+  All three share the existing `db.Changeset`, which now holds one
+  ordered `[]db.Change` behind a `key()`/`target()`/`Statement(dialect)`
+  interface — so commit order is staging order across kinds and `c`
+  still runs everything in a single `ExecTx` transaction.
+- Recorded the two decisions that were not obvious while implementing
+  it: staging a delete drops that row's pending cell edits (and `e` on a
+  row staged for deletion is refused), and a staged insert has no natural
+  identity, so the changeset assigns it a monotonic `ID` that `u`
+  unstages by. The grid grew a `rowKind` per rendered row — struck-through
+  red deletes, green phantom insert rows appended after the page with
+  `DEFAULT` in every omitted column — and `dataView.extraRows`, which
+  `Model.clampCursor` re-derives from the changeset so the cursor can
+  reach a row that does not exist in the database yet.
+- Replaced `metaView.copyAfterLoad`/`editAfterLoad` with a single
+  `afterLoad actionID` (with an `actNone` zero value): four keys now need
+  the metadata before they can open anything, and replaying the action
+  through `runAction` keeps a cold key press identical to a warm one.
+- Added [reference/insert-default-values](reference/insert-default-values.md):
+  an INSERT that names no columns is `DEFAULT VALUES` in PostgreSQL,
+  SQLite and DuckDB and `() VALUES ()` in MySQL/MariaDB, and each form is
+  a syntax error in the other family.

--- a/wiki/reference/insert-default-values.md
+++ b/wiki/reference/insert-default-values.md
@@ -1,0 +1,46 @@
+---
+type: Dialect Note
+title: INSERT with no columns is spelled two different ways
+description: PostgreSQL, SQLite and DuckDB accept the standard DEFAULT VALUES; MySQL and MariaDB reject it and want an empty column list instead.
+tags: [db, dialect, mysql, mariadb, postgres, sqlite, duckdb, insert]
+generated:
+  by: claude-code/fable-5
+  at: 2026-08-09T00:00:00Z
+sources:
+  - resource: https://dev.mysql.com/doc/refman/8.4/en/insert.html
+  - resource: https://www.postgresql.org/docs/current/sql-insert.html
+  - resource: https://www.sqlite.org/lang_insert.html
+---
+
+# INSERT with no columns
+
+lazysql's insert form lets every column stay on its default, so
+`db.InsertSQL` has to be able to render an INSERT that names no columns
+at all. There is no single spelling for it.
+
+| Engine | Statement |
+| --- | --- |
+| PostgreSQL | `INSERT INTO "t" DEFAULT VALUES` |
+| SQLite | `INSERT INTO "t" DEFAULT VALUES` |
+| DuckDB | `INSERT INTO "t" DEFAULT VALUES` |
+| MySQL | ``INSERT INTO `t` () VALUES ()`` |
+| MariaDB | ``INSERT INTO `t` () VALUES ()`` |
+
+`DEFAULT VALUES` is the SQL-standard form and is a syntax error in
+MySQL/MariaDB; the empty-column form is a MySQL extension and is a
+syntax error in PostgreSQL. `defaultValuesClause` in
+`internal/db/dialect_helpers.go` picks between them from
+`Dialect.Engine()`.
+
+Two things worth knowing before relying on it:
+
+- The row it inserts is only valid if every column has a default, is
+  nullable, or is auto-assigned. The insert form checks that before
+  staging (see
+  [design/staged-changeset](../design/staged-changeset.md)), so the
+  clause is normally reached only when the check passed.
+- MySQL in strict mode still rejects a NOT NULL column with no default
+  here, which is the same error it gives for an explicit column list —
+  the transaction rolls back and the changeset survives.
+
+Related: [reference/dialect-introspection-quirks](dialect-introspection-quirks.md).


### PR DESCRIPTION
Extends the pending changeset with row inserts, deletes, and duplicates. Phantom rendering for staged rows, per-dialect INSERT/DELETE/DEFAULT VALUES generation, mixed three-kind commit in a single transaction with rollback keeping the changeset. SQL-generation tests for all five engines; live round trip against in-process SQLite.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139rhNA79AoksWw97zoxwWA