### PR TITLE
Add copy and export for cell, row, and table

### DIFF
--- a/internal/db/literal.go
+++ b/internal/db/literal.go
@@ -1,0 +1,156 @@
+package db
+
+import (
+	"math"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// SQL literals. Everything lazysql *executes* is parameterized — see
+// changeset.go — so this file exists only for the SQL text lazysql
+// *hands to the user*: the INSERT statements of a copy or an export.
+// Those have to carry their values inline, which makes correct
+// per-dialect escaping the whole job.
+
+// QuoteLiteral renders a normalized cell value (nil, string, int64,
+// float64, bool, time.Time) as a SQL literal for the dialect. Anything
+// else is rendered through FormatValue and quoted as text, which is the
+// safe reading for a type the scanner could not normalize.
+func QuoteLiteral(d Dialect, v any) string {
+	switch x := v.(type) {
+	case nil:
+		return "NULL"
+	case string:
+		return quoteString(d, x)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case float64:
+		// Neither infinity nor NaN is a portable numeric literal; every
+		// engine that accepts them at all accepts the quoted spelling.
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return quoteString(d, strconv.FormatFloat(x, 'g', -1, 64))
+		}
+		return strconv.FormatFloat(x, 'g', -1, 64)
+	case bool:
+		return boolLiteral(d, x)
+	case time.Time:
+		return quoteString(d, timeLiteral(d, x))
+	default:
+		return quoteString(d, FormatValue(x, ""))
+	}
+}
+
+// quoteString escapes a string literal. Doubling the single quote is
+// universal; MySQL and MariaDB additionally read a backslash as an
+// escape character (NO_BACKSLASH_ESCAPES off, which is the default), so
+// there the backslash has to be doubled too. Doing that unconditionally
+// would corrupt every Windows path exported from PostgreSQL, where
+// standard_conforming_strings leaves the backslash literal.
+func quoteString(d Dialect, s string) string {
+	// The backslash pass runs first: doubling a quote never introduces a
+	// backslash, and doubling a backslash never introduces a quote, so
+	// neither pass can see the other's output.
+	if backslashEscapes(d) {
+		s = strings.ReplaceAll(s, "\\", "\\\\")
+	}
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}
+
+// backslashEscapes reports whether the engine treats a backslash inside
+// a string literal as an escape character.
+func backslashEscapes(d Dialect) bool {
+	switch engineOf(d) {
+	case EngineMySQL, EngineMariaDB:
+		return true
+	default:
+		return false
+	}
+}
+
+// boolLiteral spells a boolean. MySQL and MariaDB have no real boolean
+// type — TRUE/FALSE are aliases for 1/0 there — and a TINYINT column
+// round-trips more predictably as the number it stores.
+func boolLiteral(d Dialect, b bool) string {
+	switch engineOf(d) {
+	case EngineMySQL, EngineMariaDB:
+		if b {
+			return "1"
+		}
+		return "0"
+	default:
+		return strings.ToUpper(strconv.FormatBool(b))
+	}
+}
+
+// timeLiteral formats a timestamp for the dialect. MySQL and MariaDB
+// reject the RFC 3339 "T" separator and the zone suffix in a DATETIME
+// literal, so they get the SQL spelling in UTC; every other engine
+// parses RFC 3339 and keeps the offset.
+func timeLiteral(d Dialect, t time.Time) string {
+	switch engineOf(d) {
+	case EngineMySQL, EngineMariaDB:
+		return t.UTC().Format("2006-01-02 15:04:05.999999")
+	default:
+		return t.Format(time.RFC3339Nano)
+	}
+}
+
+// engineOf is nil-safe so serialization code can render values without
+// a connection — the fallback is the standard-conforming spelling.
+func engineOf(d Dialect) Engine {
+	if d == nil {
+		return ""
+	}
+	return d.Engine()
+}
+
+// QualifiedTable renders database.table with per-dialect quoting,
+// omitting the database part when empty. With no dialect the name is
+// returned unquoted, which is what a preview without a connection wants.
+func QualifiedTable(d Dialect, database, table string) string {
+	if d == nil {
+		if database == "" {
+			return table
+		}
+		return database + "." + table
+	}
+	return qualifiedTable(d, database, table)
+}
+
+// QuoteIdentifier quotes one identifier, nil-safe like QualifiedTable.
+func QuoteIdentifier(d Dialect, ident string) string {
+	if d == nil {
+		return ident
+	}
+	return d.QuoteIdent(ident)
+}
+
+// InsertStatement renders a literal (non-parameterized) INSERT for the
+// copy and export flows. Unlike InsertSQL it is text the user takes
+// away, never something lazysql executes.
+func InsertStatement(d Dialect, database, table string, cols []Column, values []any) string {
+	var b strings.Builder
+	b.WriteString("INSERT INTO ")
+	b.WriteString(QualifiedTable(d, database, table))
+	b.WriteString(" (")
+	for i, c := range cols {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(QuoteIdentifier(d, c.Name))
+	}
+	b.WriteString(") VALUES (")
+	for i := range cols {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		var v any
+		if i < len(values) {
+			v = values[i]
+		}
+		b.WriteString(QuoteLiteral(d, v))
+	}
+	b.WriteString(");")
+	return b.String()
+}

--- a/internal/db/literal_test.go
+++ b/internal/db/literal_test.go
@@ -1,0 +1,98 @@
+package db
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func mustDialect(t *testing.T, e Engine) Dialect {
+	t.Helper()
+	d, err := DialectFor(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+// Every scalar the scanner produces has one correct literal spelling
+// per dialect, and NULL is spelled NULL in all of them.
+func TestQuoteLiteral(t *testing.T) {
+	ts := time.Date(2026, 8, 9, 12, 34, 56, 0, time.UTC)
+	tests := []struct {
+		engine Engine
+		in     any
+		want   string
+	}{
+		{EngineSQLite, nil, "NULL"},
+		{EngineMySQL, nil, "NULL"},
+		{EnginePostgres, nil, "NULL"},
+
+		{EnginePostgres, "plain", "'plain'"},
+		{EnginePostgres, "it's", "'it''s'"},
+		// standard_conforming_strings: the backslash is data.
+		{EnginePostgres, `C:\tmp`, `'C:\tmp'`},
+		// MySQL reads a backslash as an escape, so it has to be doubled.
+		{EngineMySQL, `C:\tmp`, `'C:\\tmp'`},
+		{EngineMySQL, `it's\`, `'it''s\\'`},
+		{EngineMariaDB, `a\b`, `'a\\b'`},
+		{EngineSQLite, `a\b`, `'a\b'`},
+
+		{EngineSQLite, int64(-7), "-7"},
+		{EngineSQLite, 1.5, "1.5"},
+		{EngineSQLite, math.NaN(), "'NaN'"},
+		{EngineSQLite, math.Inf(1), "'+Inf'"},
+
+		{EnginePostgres, true, "TRUE"},
+		{EngineDuckDB, false, "FALSE"},
+		{EngineMySQL, true, "1"},
+		{EngineMariaDB, false, "0"},
+
+		{EnginePostgres, ts, "'2026-08-09T12:34:56Z'"},
+		{EngineMySQL, ts, "'2026-08-09 12:34:56'"},
+	}
+	for _, tt := range tests {
+		d := mustDialect(t, tt.engine)
+		if got := QuoteLiteral(d, tt.in); got != tt.want {
+			t.Errorf("%s QuoteLiteral(%#v) = %s, want %s", tt.engine, tt.in, got, tt.want)
+		}
+	}
+}
+
+// A nil dialect is the no-connection case: literals still render, with
+// the standard-conforming escaping.
+func TestQuoteLiteralWithoutDialect(t *testing.T) {
+	if got := QuoteLiteral(nil, `it's\`); got != `'it''s\'` {
+		t.Errorf("QuoteLiteral(nil, …) = %s", got)
+	}
+	if got := QualifiedTable(nil, "main", "users"); got != "main.users" {
+		t.Errorf("QualifiedTable(nil, …) = %s", got)
+	}
+}
+
+// The generated INSERT quotes identifiers per dialect and inlines every
+// value as a literal — it is text for the user, never something the app
+// executes.
+func TestInsertStatement(t *testing.T) {
+	cols := []Column{{Name: "id"}, {Name: "name"}, {Name: "note"}}
+	values := []any{int64(1), "O'Hara", nil}
+
+	pg := mustDialect(t, EnginePostgres)
+	want := `INSERT INTO "app"."users" ("id", "name", "note") VALUES (1, 'O''Hara', NULL);`
+	if got := InsertStatement(pg, "app", "users", cols, values); got != want {
+		t.Errorf("postgres INSERT =\n%s\nwant\n%s", got, want)
+	}
+
+	my := mustDialect(t, EngineMySQL)
+	want = "INSERT INTO `users` (`id`, `name`, `note`) VALUES (1, 'O''Hara', NULL);"
+	if got := InsertStatement(my, "", "users", cols, values); got != want {
+		t.Errorf("mysql INSERT =\n%s\nwant\n%s", got, want)
+	}
+
+	// A row shorter than the column list binds NULL for the rest rather
+	// than producing a statement with too few values.
+	want = `INSERT INTO "users" ("id", "name", "note") VALUES (1, NULL, NULL);`
+	if got := InsertStatement(mustDialect(t, EngineSQLite), "", "users", cols, values[:1]); got != want {
+		t.Errorf("short row INSERT =\n%s\nwant\n%s", got, want)
+	}
+}

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -1,0 +1,447 @@
+// Package export serializes result rows to CSV, JSON and SQL, and
+// streams whole tables through those serializers a page at a time.
+//
+// Nothing here holds more than one page of rows: a writer is fed row by
+// row and flushes into the io.Writer it was built on, so exporting a
+// 100k-row table costs the same memory as exporting a 100-row one.
+package export
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"lazysql/internal/db"
+)
+
+// Format is one serialization the copy menu and the file export share.
+type Format string
+
+const (
+	FormatCSV  Format = "csv"
+	FormatJSON Format = "json"
+	FormatSQL  Format = "sql"
+)
+
+// FormatForPath infers the format from a file extension, which is how
+// `E` decides what to write.
+func FormatForPath(path string) (Format, error) {
+	switch ext := strings.ToLower(filepath.Ext(path)); ext {
+	case ".csv":
+		return FormatCSV, nil
+	case ".json":
+		return FormatJSON, nil
+	case ".sql":
+		return FormatSQL, nil
+	case "":
+		return "", errors.New("no file extension — use .csv, .json or .sql")
+	default:
+		return "", fmt.Errorf("unsupported extension %q — use .csv, .json or .sql", ext)
+	}
+}
+
+// Options carries what a format needs beyond the rows themselves. Only
+// the SQL writer reads any of it.
+type Options struct {
+	// Dialect quotes identifiers and escapes literals. A nil dialect is
+	// allowed: identifiers are then left unquoted, which is what a
+	// preview built without a connection wants.
+	Dialect  db.Dialect
+	Database string
+	Table    string
+
+	// DDL, when set, is written ahead of the INSERTs by the SQL writer.
+	// It is the "CREATE TABLE + INSERTs" copy-menu variant.
+	DDL string
+}
+
+// Writer serializes a result set incrementally. Begin is called once
+// with the columns — before any row, and even when there are no rows,
+// so a CSV still gets its header and a JSON still gets its brackets.
+type Writer interface {
+	Begin(cols []db.Column) error
+	Row(values []any) error
+	End() error
+}
+
+// NewWriter builds the writer for a format.
+func NewWriter(w io.Writer, f Format, o Options) (Writer, error) {
+	switch f {
+	case FormatCSV:
+		return &csvWriter{w: csv.NewWriter(w)}, nil
+	case FormatJSON:
+		return &jsonWriter{w: w}, nil
+	case FormatSQL:
+		return &sqlWriter{w: w, opt: o}, nil
+	default:
+		return nil, fmt.Errorf("export: unknown format %q", f)
+	}
+}
+
+// ---------- CSV ----------
+
+type csvWriter struct {
+	w    *csv.Writer
+	cols int
+	buf  []string
+}
+
+func (c *csvWriter) Begin(cols []db.Column) error {
+	c.cols = len(cols)
+	c.buf = make([]string, len(cols))
+	names := make([]string, len(cols))
+	for i, col := range cols {
+		names[i] = col.Name
+	}
+	return c.w.Write(names)
+}
+
+func (c *csvWriter) Row(values []any) error {
+	for i := range c.buf {
+		var v any
+		if i < len(values) {
+			v = values[i]
+		}
+		c.buf[i] = csvValue(v)
+	}
+	return c.w.Write(c.buf)
+}
+
+func (c *csvWriter) End() error {
+	c.w.Flush()
+	return c.w.Error()
+}
+
+// csvValue renders one cell. SQL NULL becomes an empty field: CSV has
+// no null, and the `\N` convention MySQL's own tooling uses is not
+// readable by anything else — an empty field at least round-trips
+// through every spreadsheet. encoding/csv quotes whatever needs it, so
+// a value containing a comma, a quote or a newline stays one field.
+func csvValue(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return x
+	case bool:
+		return strconv.FormatBool(x)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case float64:
+		return strconv.FormatFloat(x, 'g', -1, 64)
+	case time.Time:
+		return x.Format(time.RFC3339Nano)
+	default:
+		return db.FormatValue(x, "")
+	}
+}
+
+// ---------- JSON ----------
+
+// jsonWriter streams a JSON array of objects. It is written by hand
+// rather than with an Encoder over a slice because the array must be
+// emitted incrementally, and because a Go map would lose the column
+// order the user is looking at.
+type jsonWriter struct {
+	w     io.Writer
+	keys  []string
+	nth   int
+	begun bool
+}
+
+func (j *jsonWriter) Begin(cols []db.Column) error {
+	j.keys = jsonKeys(cols)
+	j.begun = true
+	_, err := io.WriteString(j.w, "[")
+	return err
+}
+
+func (j *jsonWriter) Row(values []any) error {
+	var b strings.Builder
+	if j.nth > 0 {
+		b.WriteString(",")
+	}
+	b.WriteString("\n  ")
+	b.WriteString(jsonObject(j.keys, values))
+	j.nth++
+	_, err := io.WriteString(j.w, b.String())
+	return err
+}
+
+// jsonObject renders one row as a single-line JSON object. keys are
+// already-quoted column names, in the order the grid shows them.
+func jsonObject(keys []string, values []any) string {
+	var b strings.Builder
+	b.WriteString("{")
+	for i, key := range keys {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		var v any
+		if i < len(values) {
+			v = values[i]
+		}
+		b.WriteString(key)
+		b.WriteString(": ")
+		b.WriteString(jsonValue(v))
+	}
+	b.WriteString("}")
+	return b.String()
+}
+
+// jsonKeys quotes the column names once for reuse across rows.
+func jsonKeys(cols []db.Column) []string {
+	out := make([]string, len(cols))
+	for i, c := range cols {
+		out[i] = quoteJSON(c.Name)
+	}
+	return out
+}
+
+func (j *jsonWriter) End() error {
+	if !j.begun {
+		_, err := io.WriteString(j.w, "[]\n")
+		return err
+	}
+	if j.nth == 0 {
+		_, err := io.WriteString(j.w, "]\n")
+		return err
+	}
+	_, err := io.WriteString(j.w, "\n]\n")
+	return err
+}
+
+// jsonValue renders one cell as a JSON value. SQL NULL becomes JSON
+// null — the one format of the three that can say so exactly — and the
+// numeric types stay numbers instead of being stringified. Infinity and
+// NaN have no JSON spelling at all, so they degrade to null.
+func jsonValue(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return strconv.FormatBool(x)
+	case int64:
+		return strconv.FormatInt(x, 10)
+	case float64:
+		if math.IsNaN(x) || math.IsInf(x, 0) {
+			return "null"
+		}
+		return strconv.FormatFloat(x, 'g', -1, 64)
+	case time.Time:
+		return quoteJSON(x.Format(time.RFC3339Nano))
+	case string:
+		return quoteJSON(x)
+	default:
+		return quoteJSON(db.FormatValue(x, ""))
+	}
+}
+
+func quoteJSON(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		// json.Marshal of a string only fails on invalid UTF-8, which it
+		// replaces rather than rejects; this branch is unreachable in
+		// practice and a quoted empty string is the harmless reading.
+		return `""`
+	}
+	return string(b)
+}
+
+// ---------- SQL ----------
+
+// sqlWriter emits one INSERT per row, optionally preceded by the
+// table's DDL. Values are rendered as dialect-escaped literals: this is
+// text handed to the user, not a statement lazysql executes.
+type sqlWriter struct {
+	w    io.Writer
+	opt  Options
+	cols []db.Column
+}
+
+func (s *sqlWriter) Begin(cols []db.Column) error {
+	s.cols = cols
+	if s.opt.DDL == "" {
+		return nil
+	}
+	ddl := strings.TrimRight(s.opt.DDL, " \t\n")
+	if !strings.HasSuffix(ddl, ";") {
+		ddl += ";"
+	}
+	_, err := io.WriteString(s.w, ddl+"\n\n")
+	return err
+}
+
+func (s *sqlWriter) Row(values []any) error {
+	stmt := db.InsertStatement(s.opt.Dialect, s.opt.Database, s.opt.Table, s.cols, values)
+	_, err := io.WriteString(s.w, stmt+"\n")
+	return err
+}
+
+func (s *sqlWriter) End() error { return nil }
+
+// ---------- streaming ----------
+
+// Pager reads one page of the exported result. It is the seam between
+// this package and the driver: the UI closes over the table, filter and
+// sort, so the stream inherits exactly what the grid is showing.
+type Pager func(ctx context.Context, limit, offset int) (*db.ResultSet, error)
+
+// StreamOptions tunes one Stream run.
+type StreamOptions struct {
+	// PageSize is how many rows one round trip reads. It is the whole
+	// memory bound of an export.
+	PageSize int
+	// MaxRows caps the export; 0 means no cap. The clipboard variants
+	// set it, because a clipboard copy has to be materialized in full.
+	MaxRows int64
+	// Progress is called with the running row count, at most once per
+	// ProgressEvery rows plus once at the end.
+	Progress      func(rows int64)
+	ProgressEvery int64
+}
+
+// DefaultPageSize is the streaming page size. It is larger than the
+// grid's page because an export has no rendering cost per row and
+// fewer, bigger round trips finish sooner.
+const DefaultPageSize = 1000
+
+// Stream reads pages until one comes back short and feeds every row to
+// the writer. It returns how many rows were written and whether it
+// stopped early because MaxRows was reached. A cancelled context aborts
+// between pages and between rows, so `X` interrupts a long export
+// without waiting for it to finish.
+func Stream(ctx context.Context, w Writer, page Pager, o StreamOptions) (rows int64, truncated bool, err error) {
+	pageSize := o.PageSize
+	if pageSize <= 0 {
+		pageSize = DefaultPageSize
+	}
+	every := o.ProgressEvery
+	if every <= 0 {
+		every = 5000
+	}
+
+	var (
+		offset     int
+		reportedAt int64
+		begun      bool
+	)
+	for {
+		if err := ctx.Err(); err != nil {
+			return rows, truncated, err
+		}
+		limit := pageSize
+		if o.MaxRows > 0 {
+			if left := o.MaxRows - rows; int64(limit) > left {
+				limit = int(left)
+			}
+		}
+		if limit <= 0 {
+			truncated = true
+			break
+		}
+
+		rs, err := page(ctx, limit, offset)
+		if err != nil {
+			return rows, truncated, err
+		}
+		if !begun {
+			if err := w.Begin(rs.Columns); err != nil {
+				return rows, truncated, err
+			}
+			begun = true
+		}
+		for _, r := range rs.Rows {
+			if err := ctx.Err(); err != nil {
+				return rows, truncated, err
+			}
+			if err := w.Row(r); err != nil {
+				return rows, truncated, err
+			}
+			rows++
+		}
+		offset += len(rs.Rows)
+		if o.Progress != nil && rows-reportedAt >= every {
+			reportedAt = rows
+			o.Progress(rows)
+		}
+		// A page shorter than what was asked for is the last one. The
+		// engine has no other way to say "that was all".
+		if len(rs.Rows) < limit {
+			break
+		}
+		if o.MaxRows > 0 && rows >= o.MaxRows {
+			truncated = true
+			break
+		}
+	}
+
+	// An empty result never reached the Begin above, but a CSV still
+	// owes its header and a JSON its brackets.
+	if !begun {
+		if err := w.Begin(nil); err != nil {
+			return rows, truncated, err
+		}
+	}
+	if o.Progress != nil && rows != reportedAt {
+		o.Progress(rows)
+	}
+	return rows, truncated, w.End()
+}
+
+// Row serializes a single row the way the copy menu offers it: a bare
+// CSV line with no header, a single JSON object rather than a
+// one-element array, and one INSERT statement. The three go through the
+// same value renderers as Stream, so a row and the table it came from
+// can never disagree about quoting.
+func Row(f Format, o Options, cols []db.Column, values []any) (string, error) {
+	switch f {
+	case FormatCSV:
+		var b strings.Builder
+		w := &csvWriter{w: csv.NewWriter(&b), cols: len(cols), buf: make([]string, len(cols))}
+		if err := w.Row(values); err != nil {
+			return "", err
+		}
+		if err := w.End(); err != nil {
+			return "", err
+		}
+		return strings.TrimRight(b.String(), "\r\n"), nil
+	case FormatJSON:
+		return jsonObject(jsonKeys(cols), values), nil
+	case FormatSQL:
+		return db.InsertStatement(o.Dialect, o.Database, o.Table, cols, values), nil
+	default:
+		return "", fmt.Errorf("export: unknown format %q", f)
+	}
+}
+
+// Rows serializes an already-materialized set of rows — one cell, one
+// row, or the visible page. It shares the writers with Stream so a
+// single row and a whole table can never disagree about quoting.
+func Rows(f Format, o Options, cols []db.Column, rows [][]any) (string, error) {
+	var b strings.Builder
+	w, err := NewWriter(&b, f, o)
+	if err != nil {
+		return "", err
+	}
+	if err := w.Begin(cols); err != nil {
+		return "", err
+	}
+	for _, r := range rows {
+		if err := w.Row(r); err != nil {
+			return "", err
+		}
+	}
+	if err := w.End(); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -1,0 +1,360 @@
+package export
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"lazysql/internal/db"
+)
+
+func cols(names ...string) []db.Column {
+	out := make([]db.Column, len(names))
+	for i, n := range names {
+		out[i] = db.Column{Name: n}
+	}
+	return out
+}
+
+func sqliteDialect(t *testing.T) db.Dialect {
+	t.Helper()
+	d, err := db.DialectFor(db.EngineSQLite)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func TestFormatForPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want Format
+		ok   bool
+	}{
+		{"users.csv", FormatCSV, true},
+		{"/tmp/USERS.CSV", FormatCSV, true},
+		{"dump.json", FormatJSON, true},
+		{"dump.sql", FormatSQL, true},
+		{"dump.txt", "", false},
+		{"dump", "", false},
+	}
+	for _, tt := range tests {
+		got, err := FormatForPath(tt.path)
+		if tt.ok != (err == nil) {
+			t.Errorf("FormatForPath(%q) err = %v, want ok=%v", tt.path, err, tt.ok)
+			continue
+		}
+		if tt.ok && got != tt.want {
+			t.Errorf("FormatForPath(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+// CSV quotes whatever needs quoting and spells SQL NULL as an empty
+// field — not `\N`, which nothing outside MySQL's own tooling reads.
+func TestCSVQuotingAndNulls(t *testing.T) {
+	rows := [][]any{
+		{int64(1), "plain", true},
+		{int64(2), "has,comma", false},
+		{int64(3), "has\"quote", nil},
+		{int64(4), "has\nnewline", nil},
+		{nil, nil, nil},
+	}
+	got, err := Rows(FormatCSV, Options{}, cols("id", "text", "flag"), rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "id,text,flag\n" +
+		"1,plain,true\n" +
+		"2,\"has,comma\",false\n" +
+		"3,\"has\"\"quote\",\n" +
+		"4,\"has\nnewline\",\n" +
+		",,\n"
+	if got != want {
+		t.Errorf("CSV =\n%q\nwant\n%q", got, want)
+	}
+}
+
+// An empty result still gets its header row, so the file describes the
+// table rather than being blank.
+func TestCSVEmptyResultKeepsHeader(t *testing.T) {
+	got, err := Rows(FormatCSV, Options{}, cols("id", "name"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "id,name\n" {
+		t.Errorf("CSV = %q", got)
+	}
+}
+
+// JSON keeps types: numbers stay numbers, booleans booleans, and NULL
+// becomes null rather than the string "NULL" or an empty string.
+func TestJSONTypesAndNulls(t *testing.T) {
+	ts := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	rows := [][]any{
+		{int64(1), 2.5, true, "text", ts},
+		{nil, nil, nil, nil, nil},
+	}
+	got, err := Rows(FormatJSON, Options{}, cols("i", "f", "b", "s", "t"), rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var decoded []map[string]any
+	if err := json.Unmarshal([]byte(got), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, got)
+	}
+	if len(decoded) != 2 {
+		t.Fatalf("decoded %d rows, want 2", len(decoded))
+	}
+	if decoded[0]["i"] != float64(1) || decoded[0]["f"] != 2.5 {
+		t.Errorf("numbers did not survive: %#v", decoded[0])
+	}
+	if decoded[0]["b"] != true || decoded[0]["s"] != "text" {
+		t.Errorf("scalars did not survive: %#v", decoded[0])
+	}
+	if decoded[0]["t"] != "2026-08-09T12:00:00Z" {
+		t.Errorf("timestamp = %#v", decoded[0]["t"])
+	}
+	for k, v := range decoded[1] {
+		if v != nil {
+			t.Errorf("NULL column %q decoded as %#v, want nil", k, v)
+		}
+	}
+	// The null must be present as a key, not omitted.
+	if len(decoded[1]) != 5 {
+		t.Errorf("NULL row has %d keys, want 5", len(decoded[1]))
+	}
+}
+
+// An empty JSON export is a valid empty array, not an empty file.
+func TestJSONEmptyResultIsEmptyArray(t *testing.T) {
+	got, err := Rows(FormatJSON, Options{}, cols("id"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded []map[string]any
+	if err := json.Unmarshal([]byte(got), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v (%q)", err, got)
+	}
+	if len(decoded) != 0 {
+		t.Errorf("decoded %d rows, want 0", len(decoded))
+	}
+}
+
+// The SQL export writes dialect-quoted INSERTs, spells NULL as NULL,
+// and puts the DDL in front when one was supplied.
+func TestSQLInsertsAndDDL(t *testing.T) {
+	o := Options{
+		Dialect:  sqliteDialect(t),
+		Database: "main",
+		Table:    "users",
+		DDL:      "CREATE TABLE users (id INTEGER, name TEXT)",
+	}
+	rows := [][]any{
+		{int64(1), "O'Hara"},
+		{int64(2), nil},
+	}
+	got, err := Rows(FormatSQL, o, cols("id", "name"), rows)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "CREATE TABLE users (id INTEGER, name TEXT);\n\n" +
+		`INSERT INTO "main"."users" ("id", "name") VALUES (1, 'O''Hara');` + "\n" +
+		`INSERT INTO "main"."users" ("id", "name") VALUES (2, NULL);` + "\n"
+	if got != want {
+		t.Errorf("SQL =\n%s\nwant\n%s", got, want)
+	}
+
+	// Without a DDL the export is INSERTs only.
+	o.DDL = ""
+	got, err = Rows(FormatSQL, o, cols("id", "name"), rows[:1])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got, "CREATE TABLE") {
+		t.Errorf("SQL without DDL still has a CREATE:\n%s", got)
+	}
+}
+
+// The single-row variants of the copy menu: a bare CSV line with no
+// header, one JSON object rather than an array, one INSERT.
+func TestRowVariants(t *testing.T) {
+	c := cols("id", "name")
+	values := []any{int64(7), nil}
+
+	got, err := Row(FormatCSV, Options{}, c, values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "7," {
+		t.Errorf("row CSV = %q, want %q", got, "7,")
+	}
+
+	got, err = Row(FormatJSON, Options{}, c, values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != `{"id": 7, "name": null}` {
+		t.Errorf("row JSON = %q", got)
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(got), &obj); err != nil {
+		t.Fatalf("row JSON does not parse: %v", err)
+	}
+
+	got, err = Row(FormatSQL, Options{Dialect: sqliteDialect(t), Table: "users"}, c, values)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != `INSERT INTO "users" ("id", "name") VALUES (7, NULL);` {
+		t.Errorf("row SQL = %q", got)
+	}
+}
+
+// pagerOf serves n synthetic rows a page at a time and records the
+// largest page it was ever asked for.
+func pagerOf(n int, maxSeen *int) Pager {
+	return func(ctx context.Context, limit, offset int) (*db.ResultSet, error) {
+		if limit > *maxSeen {
+			*maxSeen = limit
+		}
+		rs := &db.ResultSet{Columns: cols("id", "name")}
+		for i := offset; i < offset+limit && i < n; i++ {
+			rs.Rows = append(rs.Rows, []any{int64(i), fmt.Sprintf("row-%d", i)})
+		}
+		return rs, nil
+	}
+}
+
+// A 100k-row table streams through in pages: the export never holds
+// more than one page of rows, whatever the table's size.
+func TestStreamLargeTableStaysPaged(t *testing.T) {
+	const total = 100_000
+	maxPage := 0
+	// io.Discard keeps the test honest about memory: nothing but the
+	// current page is ever retained.
+	w, err := NewWriter(io.Discard, FormatCSV, Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var progress []int64
+	rows, truncated, err := Stream(context.Background(), w, pagerOf(total, &maxPage), StreamOptions{
+		PageSize:      DefaultPageSize,
+		ProgressEvery: 25_000,
+		Progress:      func(n int64) { progress = append(progress, n) },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows != total {
+		t.Errorf("streamed %d rows, want %d", rows, total)
+	}
+	if truncated {
+		t.Error("an uncapped stream reported truncation")
+	}
+	if maxPage != DefaultPageSize {
+		t.Errorf("largest page requested = %d, want %d", maxPage, DefaultPageSize)
+	}
+	if len(progress) == 0 || progress[len(progress)-1] != total {
+		t.Errorf("progress = %v, want it to end at %d", progress, total)
+	}
+}
+
+// A table whose size is an exact multiple of the page size still ends:
+// the loop reads one more page, gets nothing, and stops.
+func TestStreamExactPageMultiple(t *testing.T) {
+	maxPage := 0
+	var b strings.Builder
+	w, _ := NewWriter(&b, FormatCSV, Options{})
+	rows, _, err := Stream(context.Background(), w, pagerOf(20, &maxPage), StreamOptions{PageSize: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows != 20 {
+		t.Errorf("streamed %d rows, want 20", rows)
+	}
+}
+
+// MaxRows is the clipboard cap: it stops the stream and says so,
+// instead of truncating silently.
+func TestStreamMaxRowsReportsTruncation(t *testing.T) {
+	maxPage := 0
+	var b strings.Builder
+	w, _ := NewWriter(&b, FormatCSV, Options{})
+	rows, truncated, err := Stream(context.Background(), w, pagerOf(5000, &maxPage), StreamOptions{
+		PageSize: 1000,
+		MaxRows:  2500,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows != 2500 || !truncated {
+		t.Errorf("rows = %d truncated = %v, want 2500 true", rows, truncated)
+	}
+	// The cap also shrinks the last page so the engine is never asked
+	// for rows that would be thrown away.
+	if maxPage > 1000 {
+		t.Errorf("largest page = %d, want it bounded by PageSize", maxPage)
+	}
+}
+
+// A table smaller than the cap is not reported as truncated.
+func TestStreamUnderMaxRowsIsNotTruncated(t *testing.T) {
+	maxPage := 0
+	var b strings.Builder
+	w, _ := NewWriter(&b, FormatCSV, Options{})
+	rows, truncated, err := Stream(context.Background(), w, pagerOf(10, &maxPage), StreamOptions{
+		PageSize: 1000,
+		MaxRows:  5000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows != 10 || truncated {
+		t.Errorf("rows = %d truncated = %v, want 10 false", rows, truncated)
+	}
+}
+
+// Cancelling the context stops the stream promptly and surfaces the
+// cancellation, which is what makes `X` work mid-export.
+func TestStreamCancels(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	maxPage := 0
+	page := pagerOf(1_000_000, &maxPage)
+	var b strings.Builder
+	w, _ := NewWriter(&b, FormatCSV, Options{})
+
+	rows, _, err := Stream(ctx, w, func(c context.Context, limit, offset int) (*db.ResultSet, error) {
+		if offset >= 2000 {
+			cancel()
+		}
+		return page(c, limit, offset)
+	}, StreamOptions{PageSize: 1000})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if rows > 4000 {
+		t.Errorf("kept streaming past the cancellation: %d rows", rows)
+	}
+	cancel()
+}
+
+// A failing page aborts the stream and reports the driver's error.
+func TestStreamPropagatesPageError(t *testing.T) {
+	boom := errors.New("boom")
+	var b strings.Builder
+	w, _ := NewWriter(&b, FormatCSV, Options{})
+	_, _, err := Stream(context.Background(), w,
+		func(context.Context, int, int) (*db.ResultSet, error) { return nil, boom },
+		StreamOptions{PageSize: 10})
+	if !errors.Is(err, boom) {
+		t.Fatalf("err = %v, want boom", err)
+	}
+}

--- a/internal/ui/clipboard.go
+++ b/internal/ui/clipboard.go
@@ -2,6 +2,11 @@ package ui
 
 import (
 	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/atotto/clipboard"
 )
@@ -9,7 +14,7 @@ import (
 // clipboardWrite is the one place lazysql talks to the system
 // clipboard. It is a variable so tests can replace it: a test run must
 // never overwrite the developer's real clipboard. The copy/export flows
-// will grow around this seam rather than call the library directly.
+// grow around this seam rather than call the library directly.
 var clipboardWrite = writeClipboard
 
 func writeClipboard(text string) error {
@@ -18,4 +23,74 @@ func writeClipboard(text string) error {
 		return errors.New("no clipboard available in this environment")
 	}
 	return clipboard.WriteAll(text)
+}
+
+// spillFile is where a failed clipboard write lands. It is a variable
+// for the same reason clipboardWrite is: tests must not leave files in
+// the developer's temp directory.
+var spillFile = writeSpillFile
+
+func writeSpillFile(name, text string) (string, error) {
+	f, err := os.CreateTemp("", spillPattern(name))
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	if _, err := io.WriteString(f, text); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
+}
+
+// spillPattern turns a copy's subject into a recognizable temp file
+// name, keeping the extension after the random part so the file opens
+// in the right thing.
+func spillPattern(name string) string {
+	ext := filepath.Ext(name)
+	base := strings.TrimSuffix(name, ext)
+	base = strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, base)
+	if base == "" {
+		base = "copy"
+	}
+	return "lazysql-" + base + "-*" + ext
+}
+
+// copyOut is every copy in the app: it puts text on the system
+// clipboard and, when there is no clipboard to put it on — an SSH
+// session, a bare tty, a container — spills it to a temp file and
+// reports the path instead. A copy therefore never simply fails; the
+// worst case is that the user has to reach for the file.
+//
+// The returned line is ready for the command log.
+func copyOut(subject, filename, text string) string {
+	err := clipboardWrite(text)
+	if err == nil {
+		return fmt.Sprintf("-- copy %s to clipboard (%s)", subject, byteCount(len(text)))
+	}
+	path, spillErr := spillFile(filename, text)
+	if spillErr != nil {
+		return fmt.Sprintf("-- copy %s FAILED: %v (and no temp file: %v)", subject, err, spillErr)
+	}
+	return fmt.Sprintf("-- copy %s: no clipboard (%v) — wrote %s to %s", subject, err, byteCount(len(text)), path)
+}
+
+// byteCount renders a size the way the command log wants it: exact for
+// anything small enough to read, rounded once it stops being useful.
+func byteCount(n int) string {
+	switch {
+	case n < 1024:
+		return fmt.Sprintf("%d bytes", n)
+	case n < 1024*1024:
+		return fmt.Sprintf("%.1f KiB", float64(n)/1024)
+	default:
+		return fmt.Sprintf("%.1f MiB", float64(n)/(1024*1024))
+	}
 }

--- a/internal/ui/copy.go
+++ b/internal/ui/copy.go
@@ -1,0 +1,281 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/db"
+	"lazysql/internal/export"
+)
+
+// The `y` copy menu. Every entry ends up as text on the clipboard (or,
+// with no clipboard around, in a temp file — see copyOut). The three
+// scopes are the cell under the cursor, the row under the cursor and
+// the whole table with the grid's filter and sort applied.
+//
+// Cell and row copies are served from the page already in memory. Table
+// copies stream pages exactly like the file export does, capped at
+// copyRowLimit because a clipboard has to hold the whole thing at once.
+
+// copyRowLimit bounds a whole-table clipboard copy. Beyond it the copy
+// is truncated and the command log says so — `E` writes the rest to a
+// file without ever materializing it.
+const copyRowLimit = 5000
+
+// copyTimeout bounds a whole-table clipboard copy. It is generous
+// because the copy walks every page, and the export flow (`E`), which
+// is the right tool for a table that takes longer, is cancellable.
+const copyTimeout = 2 * time.Minute
+
+// ---------- messages ----------
+
+// copiedMsg is the outcome of a copy, already rendered for the log.
+type copiedMsg struct{ line string }
+
+// ---------- the menu ----------
+
+// copyMenu is `y`: the context-aware copy menu. Which entries it offers
+// depends on where the cursor is — the cell and row scopes need a real
+// row under it, and the metadata tabs have no row at all.
+func (m *Model) copyMenu() tea.Cmd {
+	if !m.data.open() {
+		return logCmd("-- copy skipped: no relation open")
+	}
+	var entries []menuEntry
+	add := func(k, label string, id actionID) {
+		entries = append(entries, menuEntry{key: k, label: label, action: func(mm *Model) tea.Cmd {
+			next, cmd := mm.runAction(id)
+			*mm = next
+			return cmd
+		}})
+	}
+
+	// Lowercase is the row scope, uppercase the table scope. `j` and `k`
+	// are not available here: the menu itself moves with them.
+	if m.copyableRow() {
+		add("c", "cell — raw value", actCopyCell)
+		add("r", "row — CSV line", actCopyRowCSV)
+		add("o", "row — JSON object", actCopyRowJSON)
+		add("i", "row — INSERT statement", actCopyRowInsert)
+	}
+	add("C", "table — CSV", actCopyTableCSV)
+	add("O", "table — JSON array", actCopyTableJSON)
+	add("I", "table — INSERT statements", actCopyTableInsert)
+	add("A", "table — CREATE TABLE + INSERTs", actCopyTableSchema)
+	add("d", "DDL statement", actCopyDDL)
+	entries = append(entries, menuEntry{key: "esc", label: "cancel"})
+
+	m.modal = &menuModal{title: "Copy — " + m.data.table, entries: entries}
+	return nil
+}
+
+// copyableRow reports whether the cursor sits on a row a copy can be
+// built from: a fetched row of the Data tab. A staged insert has no
+// value for the columns it leaves to the engine, so copying it would
+// have to invent NULLs — the copy menu leaves it out instead.
+func (m Model) copyableRow() bool {
+	if m.tab.metadata() || m.onPhantomRow() {
+		return false
+	}
+	return m.data.row >= 0 && m.data.row < len(m.data.rows)
+}
+
+// ---------- cell and row ----------
+
+// rowValues returns one page row as the grid shows it: the fetched
+// values with that row's staged cell edits applied, in column order.
+// Copying what is on screen beats copying what only the server still
+// holds — the same rule `D` (duplicate row) follows.
+func (m Model) rowValues(row int) ([]any, bool) {
+	if row < 0 || row >= len(m.data.rows) {
+		return nil, false
+	}
+	var pkVals []any
+	if pkCols := m.pkColumns(); pkCols != nil {
+		pkVals, _ = m.rowKeyVals(pkCols, row)
+	}
+	out := make([]any, len(m.data.cols))
+	for i, c := range m.data.cols {
+		if i < len(m.data.rows[row]) {
+			out[i] = m.data.rows[row][i]
+		}
+		if pkVals != nil {
+			if ch, ok := m.changes.Lookup(m.data.database, m.data.table, pkVals, c.Name); ok {
+				out[i] = ch.NewValue
+			}
+		}
+	}
+	return out, true
+}
+
+// copyCell copies the raw value under the cursor. A NULL copies as an
+// empty string: the cell holds no text, and pasting the four letters
+// "NULL" into a form would be a silent lie. The log says which it was.
+func (m Model) copyCell() tea.Cmd {
+	values, ok := m.rowValues(m.data.row)
+	if !ok || m.data.col < 0 || m.data.col >= len(values) {
+		return logCmd("-- copy cell skipped: no cell under the cursor")
+	}
+	name := m.data.cols[m.data.col].Name
+	v := values[m.data.col]
+	subject := fmt.Sprintf("cell %s.%s", m.data.table, name)
+	if v == nil {
+		subject += " (NULL → empty)"
+	}
+	text := db.FormatValue(v, "")
+	return copyTextCmd(subject, m.data.table+"-"+name+".txt", text)
+}
+
+// copyRow copies the row under the cursor in one of the three row
+// formats.
+func (m Model) copyRow(f export.Format) tea.Cmd {
+	values, ok := m.rowValues(m.data.row)
+	if !ok {
+		return logCmd("-- copy row skipped: no row under the cursor")
+	}
+	text, err := export.Row(f, m.exportOptions(""), m.data.cols, values)
+	if err != nil {
+		return logCmd("-- copy row FAILED: %v", err)
+	}
+	return copyTextCmd(
+		fmt.Sprintf("row of %s as %s", m.data.table, strings.ToUpper(string(f))),
+		fmt.Sprintf("%s-row.%s", m.data.table, f),
+		text,
+	)
+}
+
+// exportOptions is what the serializers need about the open relation.
+// ddl is non-empty only for the CREATE TABLE + INSERTs variant.
+func (m Model) exportOptions(ddl string) export.Options {
+	o := export.Options{Database: m.data.database, Table: m.data.table, DDL: ddl}
+	if m.driver != nil {
+		o.Dialect = m.driver.Dialect()
+	}
+	return o
+}
+
+// copyTextCmd hands text to the clipboard off the update loop; the
+// clipboard library shells out, which is not something Update may wait
+// for.
+func copyTextCmd(subject, filename, text string) tea.Cmd {
+	return func() tea.Msg { return copiedMsg{line: copyOut(subject, filename, text)} }
+}
+
+// ---------- whole table ----------
+
+// copyTable streams the whole table — the grid's filter and sort
+// included — into a buffer and copies it. It is capped at copyRowLimit:
+// unlike a file export, a clipboard copy cannot be streamed anywhere,
+// so the cap is what keeps `y` from trying to hold a 100k-row table in
+// memory. Reaching it is reported, never silent.
+func (m *Model) copyTable(f export.Format, withDDL bool) tea.Cmd {
+	if !m.data.open() {
+		return logCmd("-- copy table skipped: no relation open")
+	}
+	if m.driver == nil {
+		return logCmd("-- copy table skipped: not connected")
+	}
+	if withDDL && !m.meta.loaded {
+		// The DDL has never been fetched. Park the copy and replay it
+		// when the metadata lands, the same way `y` on a cold DDL tab
+		// already works.
+		return m.deferUntilMeta(actCopyTableSchema)
+	}
+	ddl := ""
+	if withDDL {
+		if m.meta.ddl == "" {
+			return logCmd("-- copy table skipped: %s", m.ddlProblem())
+		}
+		ddl = m.meta.ddl
+	}
+
+	d := m.data
+	opts := m.exportOptions(ddl)
+	pager := pagerFor(m.driver, d)
+	label := strings.ToUpper(string(f))
+	if withDDL {
+		label = "CREATE + INSERTs"
+	}
+	name := fmt.Sprintf("%s.%s", d.table, f)
+
+	return tea.Batch(
+		logCmd("-- copy %s as %s (streaming, max %d rows)…", d.table, label, copyRowLimit),
+		func() tea.Msg {
+			ctx, cancel := context.WithTimeout(context.Background(), copyTimeout)
+			defer cancel()
+
+			var b strings.Builder
+			w, err := export.NewWriter(&b, f, opts)
+			if err != nil {
+				return copiedMsg{line: fmt.Sprintf("-- copy %s FAILED: %v", d.table, err)}
+			}
+			rows, truncated, err := export.Stream(ctx, w, pager, export.StreamOptions{
+				PageSize: export.DefaultPageSize,
+				MaxRows:  copyRowLimit,
+			})
+			if err != nil {
+				return copiedMsg{line: fmt.Sprintf("-- copy %s FAILED after %d rows: %v", d.table, rows, err)}
+			}
+			line := copyOut(fmt.Sprintf("%s as %s (%d rows)", d.table, label, rows), name, b.String())
+			if truncated {
+				line += fmt.Sprintf("  -- TRUNCATED at %d rows, press E to export the whole table", copyRowLimit)
+			}
+			return copiedMsg{line: line}
+		},
+	)
+}
+
+// pagerFor closes over the driver and the grid's query shape, so an
+// export reads exactly the rows the grid would page through.
+func pagerFor(drv db.Driver, d dataView) export.Pager {
+	return func(ctx context.Context, limit, offset int) (*db.ResultSet, error) {
+		return drv.QueryPage(ctx, d.database, d.table, d.filter, d.sort, limit, offset)
+	}
+}
+
+// ---------- dispatch ----------
+
+// copyActions handles the copy menu and its entries. Like dataActions
+// it runs from runAction, so a key press, the `a` menu and the copy
+// menu all reach the same code.
+func (m Model) copyActions(id actionID) (Model, tea.Cmd, bool) {
+	switch id {
+	case actCopyMenu:
+		cmd := m.copyMenu()
+		return m, cmd, true
+	case actCopyCell:
+		return m, m.copyCell(), true
+	case actCopyRowCSV:
+		return m, m.copyRow(export.FormatCSV), true
+	case actCopyRowJSON:
+		return m, m.copyRow(export.FormatJSON), true
+	case actCopyRowInsert:
+		return m, m.copyRow(export.FormatSQL), true
+	case actCopyTableCSV:
+		cmd := m.copyTable(export.FormatCSV, false)
+		return m, cmd, true
+	case actCopyTableJSON:
+		cmd := m.copyTable(export.FormatJSON, false)
+		return m, cmd, true
+	case actCopyTableInsert:
+		cmd := m.copyTable(export.FormatSQL, false)
+		return m, cmd, true
+	case actCopyTableSchema:
+		cmd := m.copyTable(export.FormatSQL, true)
+		return m, cmd, true
+
+	// The file export shares this dispatcher: it is the same feature
+	// seen from the other end, and `E` is offered next to `y`.
+	case actExportTable:
+		cmd := m.startExport()
+		return m, cmd, true
+	case actCancelExport:
+		cmd := m.cancelExport()
+		return m, cmd, true
+	}
+	return m, nil, false
+}

--- a/internal/ui/copy_test.go
+++ b/internal/ui/copy_test.go
@@ -1,0 +1,252 @@
+package ui
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// copyBrowsing is metaBrowsing with a second order row that has a NULL
+// in it and a value that needs CSV quoting, so one fixture covers the
+// interesting cases of all three formats.
+func copyBrowsing(t *testing.T) Model {
+	t.Helper()
+	m := metaBrowsing(t)
+	for _, stmt := range []string{
+		`INSERT INTO orders (id, person_id, status) VALUES (2, 1, NULL)`,
+		`INSERT INTO orders (id, person_id, status) VALUES (3, 1, 'a,b "c"')`,
+	} {
+		if _, err := m.driver.Exec(t.Context(), stmt); err != nil {
+			t.Fatalf("fixture %q: %v", stmt, err)
+		}
+	}
+	return send(t, m, press('R'))
+}
+
+// menuLabels is what the open modal offers, for asserting on which
+// scopes the copy menu exposed.
+func menuLabels(t *testing.T, m Model) []string {
+	t.Helper()
+	mm, ok := m.modal.(*menuModal)
+	if !ok {
+		t.Fatalf("modal = %T, want a menu", m.modal)
+	}
+	out := make([]string, 0, len(mm.entries))
+	for _, e := range mm.entries {
+		out = append(out, e.key+" "+e.label)
+	}
+	return out
+}
+
+func hasLabel(labels []string, want string) bool {
+	for _, l := range labels {
+		if strings.Contains(l, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// `y` on the Data tab offers all three scopes; on a metadata tab the
+// cell and row entries are gone, because there is no row under the
+// cursor there.
+func TestCopyMenuIsContextAware(t *testing.T) {
+	m := send(t, copyBrowsing(t), press('y'))
+	labels := menuLabels(t, m)
+	for _, want := range []string{"cell", "row — CSV", "row — JSON", "row — INSERT",
+		"table — CSV", "table — JSON", "table — INSERT", "CREATE TABLE + INSERTs", "DDL"} {
+		if !hasLabel(labels, want) {
+			t.Errorf("copy menu is missing %q: %v", want, labels)
+		}
+	}
+
+	// Structure tab: no row scope.
+	m = send(t, copyBrowsing(t), press(']'), press('y'))
+	labels = menuLabels(t, m)
+	if hasLabel(labels, "cell") || hasLabel(labels, "row — CSV") {
+		t.Errorf("copy menu offers a row scope on a metadata tab: %v", labels)
+	}
+	if !hasLabel(labels, "table — CSV") || !hasLabel(labels, "DDL") {
+		t.Errorf("copy menu lost its table scope on a metadata tab: %v", labels)
+	}
+}
+
+// esc closes the copy menu without copying anything.
+func TestCopyMenuEscCancels(t *testing.T) {
+	got := fakeClipboard(t)
+	m := send(t, copyBrowsing(t), press('y'), special(tea.KeyEscape, 0))
+	if m.modal != nil {
+		t.Errorf("esc left the modal open: %T", m.modal)
+	}
+	if *got != "" {
+		t.Errorf("esc copied %q", *got)
+	}
+}
+
+// The cell scope copies the raw value — and a NULL cell copies as an
+// empty string, with the log saying so rather than pasting "NULL".
+func TestCopyCell(t *testing.T) {
+	got := fakeClipboard(t)
+
+	// Row 0, column "status" = 'new'.
+	m := send(t, copyBrowsing(t), press('l'), press('l'), press('y'), press('c'))
+	if *got != "new" {
+		t.Fatalf("clipboard = %q, want %q", *got, "new")
+	}
+	if !logContains(m, "copy cell orders.status") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+
+	// Row 1 has a NULL status.
+	*got = "unset"
+	m = send(t, copyBrowsing(t), press('l'), press('l'), press('j'), press('y'), press('c'))
+	if *got != "" {
+		t.Fatalf("NULL cell copied %q, want an empty string", *got)
+	}
+	if !logContains(m, "NULL → empty") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+}
+
+// The row scope produces a bare CSV line, a JSON object and an INSERT —
+// each with NULL spelled the way that format spells it.
+func TestCopyRowFormats(t *testing.T) {
+	got := fakeClipboard(t)
+
+	// Row 1: id 2, person_id 1, status NULL.
+	base := send(t, copyBrowsing(t), press('j'))
+
+	send(t, base, press('y'), press('r'))
+	if *got != "2,1," {
+		t.Errorf("row CSV = %q, want %q", *got, "2,1,")
+	}
+
+	send(t, base, press('y'), press('o'))
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(*got), &obj); err != nil {
+		t.Fatalf("row JSON %q does not parse: %v", *got, err)
+	}
+	if v, ok := obj["status"]; !ok || v != nil {
+		t.Errorf("row JSON status = %#v, want an explicit null", obj["status"])
+	}
+	if obj["id"] != float64(2) {
+		t.Errorf("row JSON id = %#v, want the number 2", obj["id"])
+	}
+
+	send(t, base, press('y'), press('i'))
+	want := `INSERT INTO "orders" ("id", "person_id", "status") VALUES (2, 1, NULL);`
+	if *got != want {
+		t.Errorf("row INSERT =\n%s\nwant\n%s", *got, want)
+	}
+}
+
+// A staged cell edit is copied as it appears on screen, not as the
+// server still has it.
+func TestCopyRowUsesStagedEdits(t *testing.T) {
+	got := fakeClipboard(t)
+
+	m := send(t, copyBrowsing(t), press('l'), press('l'), press('e'))
+	if m.modal == nil {
+		t.Fatal("e did not open the cell editor")
+	}
+	m = send(t, m, press('X'), special(tea.KeyEnter, 0))
+	m = send(t, m, press('y'), press('r'))
+	if *got != "1,1,newX" {
+		t.Errorf("row CSV = %q, want the staged value", *got)
+	}
+}
+
+// The table scope streams every row of the relation, not just the
+// visible page, and quotes what CSV needs quoting.
+func TestCopyTableCSV(t *testing.T) {
+	got := fakeClipboard(t)
+	send(t, copyBrowsing(t), press('y'), press('C'))
+
+	lines := strings.Split(strings.TrimRight(*got, "\n"), "\n")
+	if len(lines) != 4 { // header + 3 rows
+		t.Fatalf("table CSV has %d lines, want 4:\n%s", len(lines), *got)
+	}
+	if lines[0] != "id,person_id,status" {
+		t.Errorf("header = %q", lines[0])
+	}
+	if lines[2] != "2,1," {
+		t.Errorf("NULL row = %q, want an empty field", lines[2])
+	}
+	if !strings.Contains(*got, `"a,b ""c"""`) {
+		t.Errorf("CSV did not quote the awkward value:\n%s", *got)
+	}
+}
+
+// The table filter and sort carry into a copy: what is copied is what
+// the grid is showing.
+func TestCopyTableRespectsFilter(t *testing.T) {
+	got := fakeClipboard(t)
+	m := send(t, copyBrowsing(t), press('f'))
+	m = send(t, m, press('i'), press('d'), press(' '), press('='), press(' '), press('2'),
+		special(tea.KeyEnter, 0))
+	send(t, m, press('y'), press('C'))
+
+	lines := strings.Split(strings.TrimRight(*got, "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("filtered CSV has %d lines, want 2:\n%s", len(lines), *got)
+	}
+	if !strings.HasPrefix(lines[1], "2,") {
+		t.Errorf("filtered CSV row = %q", lines[1])
+	}
+}
+
+// The CREATE TABLE + INSERTs variant works from the Data tab, where the
+// metadata has not been fetched yet: the copy waits for it.
+func TestCopyTableSchemaFetchesDDL(t *testing.T) {
+	got := fakeClipboard(t)
+	m := send(t, copyBrowsing(t), press('y'), press('A'))
+	if m.tab != mainTabData {
+		t.Errorf("the copy changed the tab to %v", m.tab)
+	}
+	if !strings.Contains(*got, "CREATE TABLE") {
+		t.Fatalf("clipboard = %q", *got)
+	}
+	if !strings.Contains(*got, `INSERT INTO "orders"`) {
+		t.Fatalf("clipboard has no INSERTs:\n%s", *got)
+	}
+	if i, j := strings.Index(*got, "CREATE TABLE"), strings.Index(*got, "INSERT INTO"); i > j {
+		t.Errorf("the DDL comes after the INSERTs")
+	}
+}
+
+// A whole-table JSON copy is a valid array of typed objects.
+func TestCopyTableJSON(t *testing.T) {
+	got := fakeClipboard(t)
+	send(t, copyBrowsing(t), press('y'), press('O'))
+
+	var decoded []map[string]any
+	if err := json.Unmarshal([]byte(*got), &decoded); err != nil {
+		t.Fatalf("table JSON does not parse: %v\n%s", err, *got)
+	}
+	if len(decoded) != 3 {
+		t.Fatalf("decoded %d rows, want 3", len(decoded))
+	}
+	if decoded[1]["status"] != nil {
+		t.Errorf("NULL decoded as %#v", decoded[1]["status"])
+	}
+}
+
+// With no clipboard around, a copy still succeeds: the text lands in a
+// temp file and the log names the path.
+func TestCopyDegradesToTempFile(t *testing.T) {
+	prev := clipboardWrite
+	clipboardWrite = func(string) error { return os.ErrNotExist }
+	t.Cleanup(func() { clipboardWrite = prev })
+	spilled := fakeSpill(t)
+
+	m := send(t, copyBrowsing(t), press('y'), press('r'))
+	if *spilled == "" {
+		t.Fatal("nothing was written to the fallback file")
+	}
+	if !logContains(m, "no clipboard") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+}

--- a/internal/ui/export.go
+++ b/internal/ui/export.go
@@ -1,0 +1,284 @@
+package ui
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/export"
+)
+
+// `E` exports the open relation to a file. Unlike a copy it is not
+// bounded by what fits in memory: the writer streams pages straight
+// into the file, so the export costs one page of rows whatever the
+// table's size. The format comes from the extension, progress goes to
+// the command log, and `X` cancels a run that is taking too long.
+
+// exportProgressEvery is how many rows pass between progress lines. It
+// is large enough that a fast export logs a handful of lines and small
+// enough that a slow one keeps saying it is alive.
+const exportProgressEvery = 5000
+
+// exportState is the one export a Model may have in flight. Only one
+// runs at a time: a second `E` would race two writers over the log, and
+// nothing about the flow needs a queue.
+type exportState struct {
+	running bool
+	// id distinguishes the run a message belongs to, so the reply of a
+	// cancelled export cannot resurrect the progress line of its
+	// successor.
+	id int
+	// table names the relation being exported, for the cancel and
+	// "already running" log lines. The path travels with the worker's
+	// own messages instead, so a stale reply can never name the wrong
+	// file.
+	table  string
+	cancel context.CancelFunc
+	// ch carries progress and the final outcome out of the worker
+	// goroutine. It is unbuffered: a UI that stopped reading should
+	// block the worker rather than let it run ahead.
+	ch chan tea.Msg
+}
+
+// ---------- messages ----------
+
+type exportProgressMsg struct {
+	id   int
+	rows int64
+}
+
+type exportDoneMsg struct {
+	id    int
+	path  string
+	rows  int64
+	bytes int64
+	err   error
+}
+
+// ---------- the flow ----------
+
+// startExport is `E`: prompt for a path, then stream. The prompt is
+// pre-filled with a plausible name so the common case is one keystroke
+// plus enter.
+func (m *Model) startExport() tea.Cmd {
+	if !m.data.open() {
+		return logCmd("-- export skipped: no relation open")
+	}
+	if m.driver == nil {
+		return logCmd("-- export skipped: not connected")
+	}
+	if m.export.running {
+		return logCmd("-- export skipped: %s is still exporting (X cancels it)", m.export.table)
+	}
+	m.modal = newPromptModal(
+		"Export "+m.data.table+" — file path",
+		"~/"+m.data.table+".csv",
+		defaultExportPath(m.data.table),
+		func(mm *Model, value string) tea.Cmd { return mm.runExport(value) },
+	)
+	return nil
+}
+
+// defaultExportPath is the prompt's initial value: the relation's name
+// as a CSV in the working directory.
+func defaultExportPath(table string) string {
+	name := strings.Map(func(r rune) rune {
+		if r == os.PathSeparator || r == '/' {
+			return '-'
+		}
+		return r
+	}, table)
+	return name + ".csv"
+}
+
+// runExport validates the path, opens the file and starts the worker.
+// Everything that can fail synchronously does so here, so the worker
+// only ever reports problems that needed the database.
+func (m *Model) runExport(path string) tea.Cmd {
+	if path == "" {
+		return logCmd("-- export cancelled: no path given")
+	}
+	full, err := expandPath(path)
+	if err != nil {
+		return logCmd("-- export FAILED: %v", err)
+	}
+	format, err := export.FormatForPath(full)
+	if err != nil {
+		return logCmd("-- export %s FAILED: %v", full, err)
+	}
+	if !m.data.open() || m.driver == nil {
+		return logCmd("-- export skipped: nothing open")
+	}
+
+	f, err := os.Create(full)
+	if err != nil {
+		return logCmd("-- export FAILED: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m.export = exportState{
+		running: true,
+		id:      m.export.id + 1,
+		table:   m.data.table,
+		cancel:  cancel,
+		ch:      make(chan tea.Msg),
+	}
+	m.keys.CancelExport.SetEnabled(true)
+
+	job := exportJob{
+		id:      m.export.id,
+		ctx:     ctx,
+		file:    f,
+		path:    full,
+		format:  format,
+		options: m.exportOptions(""),
+		pager:   pagerFor(m.driver, m.data),
+		ch:      m.export.ch,
+	}
+	return tea.Batch(
+		logCmd("-- export %s to %s as %s (streaming %d rows per page)…",
+			m.data.table, full, strings.ToUpper(string(format)), export.DefaultPageSize),
+		startExportCmd(job),
+	)
+}
+
+// expandPath resolves `~` and makes the path absolute, so the log line
+// names the file the user can actually open.
+func expandPath(path string) (string, error) {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("cannot resolve ~: %w", err)
+		}
+		path = filepath.Join(home, strings.TrimPrefix(strings.TrimPrefix(path, "~"), "/"))
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	return abs, nil
+}
+
+// ---------- the worker ----------
+
+// exportJob is everything the worker goroutine needs. It is a value, so
+// the goroutine shares nothing mutable with the Model.
+type exportJob struct {
+	id      int
+	ctx     context.Context
+	file    *os.File
+	path    string
+	format  export.Format
+	options export.Options
+	pager   export.Pager
+	ch      chan tea.Msg
+}
+
+// startExportCmd launches the worker and blocks until its first
+// message. Subsequent messages are pulled by waitExportCmd, which the
+// root re-issues after every progress line — the standard Bubbletea way
+// to turn a long job into a stream of messages.
+func startExportCmd(job exportJob) tea.Cmd {
+	return func() tea.Msg {
+		go job.run()
+		return <-job.ch
+	}
+}
+
+func waitExportCmd(ch chan tea.Msg) tea.Cmd {
+	if ch == nil {
+		return nil
+	}
+	return func() tea.Msg { return <-ch }
+}
+
+func (j exportJob) run() {
+	buf := bufio.NewWriterSize(j.file, 64*1024)
+	counting := &countingWriter{w: buf}
+
+	send := func(msg tea.Msg) bool {
+		// A cancelled export must not block forever on a UI that has
+		// stopped reading the channel.
+		select {
+		case j.ch <- msg:
+			return true
+		case <-j.ctx.Done():
+			return false
+		}
+	}
+
+	var rows int64
+	w, err := export.NewWriter(counting, j.format, j.options)
+	if err == nil {
+		rows, _, err = export.Stream(j.ctx, w, j.pager, export.StreamOptions{
+			PageSize:      export.DefaultPageSize,
+			ProgressEvery: exportProgressEvery,
+			Progress: func(n int64) {
+				send(exportProgressMsg{id: j.id, rows: n})
+			},
+		})
+	}
+	if flushErr := buf.Flush(); err == nil {
+		err = flushErr
+	}
+	if closeErr := j.file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		// A half-written export is worse than none: it looks complete.
+		os.Remove(j.path)
+	}
+
+	// The final message goes out even on cancellation, so the root can
+	// clear the running flag; a plain send would have been swallowed by
+	// the ctx.Done() branch above.
+	j.ch <- exportDoneMsg{id: j.id, path: j.path, rows: rows, bytes: counting.n, err: err}
+}
+
+// countingWriter tracks how much the export wrote, for the log line.
+type countingWriter struct {
+	w io.Writer
+	n int64
+}
+
+func (c *countingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	c.n += int64(n)
+	return n, err
+}
+
+// ---------- model wiring ----------
+
+// cancelExport is `X`. The worker notices the cancelled context between
+// pages and between rows and removes the partial file.
+func (m *Model) cancelExport() tea.Cmd {
+	if !m.export.running {
+		return nil
+	}
+	m.export.cancel()
+	return logCmd("-- cancelling export of %s…", m.export.table)
+}
+
+// finishExport clears the in-flight state and renders the outcome.
+func (m *Model) finishExport(msg exportDoneMsg) tea.Cmd {
+	m.export.running = false
+	m.export.cancel = nil
+	m.export.ch = nil
+	m.keys.CancelExport.SetEnabled(false)
+	switch {
+	case errors.Is(msg.err, context.Canceled):
+		return logCmd("-- export cancelled after %d rows — %s removed", msg.rows, msg.path)
+	case msg.err != nil:
+		return logCmd("-- export FAILED after %d rows: %v — %s removed", msg.rows, msg.err, msg.path)
+	default:
+		return logCmd("-- export wrote %d rows (%s) to %s",
+			msg.rows, byteCount(int(msg.bytes)), msg.path)
+	}
+}

--- a/internal/ui/export_test.go
+++ b/internal/ui/export_test.go
@@ -1,0 +1,298 @@
+package ui
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/db"
+	"lazysql/internal/export"
+)
+
+// typePath fills the open export prompt with a path and submits it.
+// The value is set directly rather than typed: a textinput answers
+// every keystroke with a cursor-blink command, which the synchronous
+// test driver would block on.
+func typePath(t *testing.T, m Model, path string) Model {
+	t.Helper()
+	p, ok := m.modal.(*promptModal)
+	if !ok {
+		t.Fatalf("modal = %T, want the export prompt", m.modal)
+	}
+	p.input.SetValue(path)
+	return send(t, m, special(tea.KeyEnter, 0))
+}
+
+// `E` prompts for a path and writes every row of the relation, not just
+// the visible page.
+func TestExportCSVWritesEveryRow(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "orders.csv")
+
+	m := send(t, copyBrowsing(t), press('E'))
+	m = typePath(t, m, path)
+
+	if m.export.running {
+		t.Error("the export is still marked as running after it finished")
+	}
+	if !logContains(m, "export wrote 3 rows") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("file has %d lines, want header + 3 rows:\n%s", len(lines), data)
+	}
+	if lines[0] != "id,person_id,status" {
+		t.Errorf("header = %q", lines[0])
+	}
+}
+
+// The format comes from the extension.
+func TestExportFormatFromExtension(t *testing.T) {
+	dir := t.TempDir()
+
+	m := send(t, copyBrowsing(t), press('E'))
+	m = typePath(t, m, filepath.Join(dir, "orders.json"))
+	data, err := os.ReadFile(filepath.Join(dir, "orders.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded []map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("exported JSON does not parse: %v\n%s", err, data)
+	}
+	if len(decoded) != 3 || decoded[1]["status"] != nil {
+		t.Errorf("exported JSON = %s", data)
+	}
+
+	m = send(t, m, press('E'))
+	m = typePath(t, m, filepath.Join(dir, "orders.sql"))
+	data, err = os.ReadFile(filepath.Join(dir, "orders.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `INSERT INTO "orders" ("id", "person_id", "status") VALUES (2, 1, NULL);`) {
+		t.Errorf("exported SQL = %s", data)
+	}
+}
+
+// An extension nothing can be inferred from is refused before any file
+// is created.
+func TestExportUnknownExtensionIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "orders.txt")
+
+	m := send(t, copyBrowsing(t), press('E'))
+	m = typePath(t, m, path)
+	if !logContains(m, "unsupported extension") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("a file was created anyway: %v", err)
+	}
+}
+
+// The export honors the grid's WHERE filter.
+func TestExportRespectsFilter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "filtered.csv")
+
+	m := send(t, copyBrowsing(t), press('f'))
+	m = send(t, m, press('i'), press('d'), press(' '), press('>'), press(' '), press('1'),
+		special(tea.KeyEnter, 0))
+	m = send(t, m, press('E'))
+	m = typePath(t, m, path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("filtered export has %d lines, want header + 2 rows:\n%s", len(lines), data)
+	}
+}
+
+// A table larger than one streaming page is written in full, and the
+// progress lines report it along the way.
+func TestExportStreamsManyPages(t *testing.T) {
+	m := copyBrowsing(t)
+	// 2500 rows is more than two full streaming pages and more than one
+	// grid page, so the export can only be complete if it streamed.
+	if _, err := m.driver.Exec(t.Context(),
+		`INSERT INTO orders (person_id, status)
+		 WITH RECURSIVE n(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM n WHERE i < 2500)
+		 SELECT 1, 'bulk' FROM n`); err != nil {
+		t.Fatal(err)
+	}
+	m = send(t, m, press('R'))
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.csv")
+	m = send(t, m, press('E'))
+	m = typePath(t, m, path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if want := 2503 + 1; len(lines) != want { // 3 fixture rows + 2500 + header
+		t.Fatalf("file has %d lines, want %d", len(lines), want)
+	}
+	if !logContains(m, fmt.Sprintf("export wrote %d rows", 2503)) {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+}
+
+// A whole-table clipboard copy is capped, and the cap is reported
+// rather than silently applied.
+func TestCopyTableTruncationIsReported(t *testing.T) {
+	got := fakeClipboard(t)
+	m := copyBrowsing(t)
+	if _, err := m.driver.Exec(t.Context(),
+		fmt.Sprintf(`INSERT INTO orders (person_id, status)
+		 WITH RECURSIVE n(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM n WHERE i < %d)
+		 SELECT 1, 'bulk' FROM n`, copyRowLimit+100)); err != nil {
+		t.Fatal(err)
+	}
+	m = send(t, m, press('R'), press('y'), press('C'))
+
+	if !logContains(m, "TRUNCATED") || !logContains(m, "press E to export") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	lines := strings.Split(strings.TrimRight(*got, "\n"), "\n")
+	if len(lines) != copyRowLimit+1 {
+		t.Errorf("copied %d lines, want the cap plus a header", len(lines))
+	}
+}
+
+// `X` is only offered while an export is running, so the options bar
+// does not advertise a key that would do nothing.
+func TestCancelExportBindingIsConditional(t *testing.T) {
+	m := copyBrowsing(t)
+	if m.keys.CancelExport.Enabled() {
+		t.Error("X is enabled with no export running")
+	}
+	if help := send(t, m, press('?')); strings.Contains(help.View().Content, "cancel export") {
+		t.Error("? advertises X with no export running")
+	}
+	if cmd := m.cancelExport(); cmd != nil {
+		t.Error("X did something with no export running")
+	}
+}
+
+// A cancelled export stops mid-stream and removes the partial file — a
+// half-written export is worse than none, because it looks complete.
+func TestExportCancellationRemovesPartialFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cancelled.csv")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	job := exportJob{
+		id:     1,
+		ctx:    ctx,
+		file:   f,
+		path:   path,
+		format: export.FormatCSV,
+		pager: func(c context.Context, limit, offset int) (*db.ResultSet, error) {
+			// The second page never arrives: the export is cancelled
+			// while the first one is being written.
+			if offset > 0 {
+				<-c.Done()
+				return nil, c.Err()
+			}
+			rs := &db.ResultSet{Columns: []db.Column{{Name: "id"}}}
+			for i := range limit {
+				rs.Rows = append(rs.Rows, []any{int64(i)})
+			}
+			return rs, nil
+		},
+		ch: make(chan tea.Msg),
+	}
+	go job.run()
+
+	cancel()
+	var done exportDoneMsg
+	for {
+		msg := <-job.ch
+		if d, ok := msg.(exportDoneMsg); ok {
+			done = d
+			break
+		}
+	}
+	if !errors.Is(done.err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", done.err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("the partial file survived: %v", err)
+	}
+
+	// The model turns that message into a log line and stops offering X.
+	m := copyBrowsing(t)
+	m.export = exportState{running: true, id: 1, table: "orders", cancel: func() {}}
+	m.keys.CancelExport.SetEnabled(true)
+	m = send(t, m, done)
+	if m.export.running || m.keys.CancelExport.Enabled() {
+		t.Error("the export state survived its own completion")
+	}
+	if !logContains(m, "export cancelled") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+}
+
+// `X` cancels the running export and is only bound while one runs.
+func TestCancelExportKeyCancels(t *testing.T) {
+	cancelled := false
+	m := copyBrowsing(t)
+	m.export = exportState{running: true, id: 1, table: "orders", cancel: func() { cancelled = true }}
+	m.keys.CancelExport.SetEnabled(true)
+
+	m = send(t, m, press('X'))
+	if !cancelled {
+		t.Fatal("X did not cancel the export")
+	}
+	if !logContains(m, "cancelling export of orders") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+	// `?` lists every binding of the focused panel, X included now.
+	if help := send(t, m, press('?')); !strings.Contains(help.View().Content, "cancel export") {
+		t.Error("? does not offer X while an export runs")
+	}
+}
+
+// Two exports never run at once: the second is refused rather than
+// racing the first over the log.
+func TestOnlyOneExportRunsAtATime(t *testing.T) {
+	m := copyBrowsing(t)
+	m.export.running = true
+	m.export.table = "orders"
+	next, cmd := m.runAction(actExportTable)
+	if next.modal != nil {
+		t.Error("a second export opened a prompt")
+	}
+	var lines []string
+	for _, msg := range drain(cmd) {
+		if l, ok := msg.(commandLogMsg); ok {
+			lines = append(lines, l.line)
+		}
+	}
+	if len(lines) != 1 || !strings.Contains(lines[0], "still exporting") {
+		t.Fatalf("log = %v", lines)
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -57,7 +57,11 @@ type keyMap struct {
 	// Main-view tabs (Data | Structure | Indexes | DDL).
 	PrevMainTab key.Binding
 	NextMainTab key.Binding
-	CopyDDL     key.Binding
+
+	// Copy and export.
+	CopyMenu     key.Binding
+	ExportTable  key.Binding
+	CancelExport key.Binding
 }
 
 func newKeyMap() keyMap {
@@ -106,7 +110,13 @@ func newKeyMap() keyMap {
 
 		PrevMainTab: key.NewBinding(key.WithKeys("["), key.WithHelp("[", "prev tab")),
 		NextMainTab: key.NewBinding(key.WithKeys("]"), key.WithHelp("]", "next tab")),
-		CopyDDL:     key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy DDL")),
+
+		CopyMenu:    key.NewBinding(key.WithKeys("y"), key.WithHelp("y", "copy…")),
+		ExportTable: key.NewBinding(key.WithKeys("E"), key.WithHelp("E", "export to file")),
+		// Only meaningful while an export is running, and shown only
+		// then: the options bar and `?` both skip disabled bindings.
+		CancelExport: key.NewBinding(
+			key.WithKeys("X"), key.WithHelp("X", "cancel export"), key.WithDisabled()),
 	}
 }
 
@@ -155,6 +165,21 @@ const (
 	actPrevMainTab
 	actNextMainTab
 	actCopyDDL
+
+	// Copy and export. Only actCopyMenu, actExportTable and
+	// actCancelExport are bound to keys; the rest are the entries of the
+	// `y` menu, dispatched through runAction like everything else.
+	actCopyMenu
+	actCopyCell
+	actCopyRowCSV
+	actCopyRowJSON
+	actCopyRowInsert
+	actCopyTableCSV
+	actCopyTableJSON
+	actCopyTableInsert
+	actCopyTableSchema
+	actExportTable
+	actCancelExport
 )
 
 // action pairs a dispatchable action with the binding that documents it.
@@ -209,7 +234,9 @@ func (k keyMap) panelActions(id panelID) []action {
 			{actCommitChanges, k.CommitChanges},
 			{actUnstageCell, k.UnstageCell},
 			{actDiscardChanges, k.DiscardChanges},
-			{actCopyDDL, k.CopyDDL},
+			{actCopyMenu, k.CopyMenu},
+			{actExportTable, k.ExportTable},
+			{actCancelExport, k.CancelExport},
 			{actRefresh, k.Refresh},
 		}
 	}

--- a/internal/ui/meta.go
+++ b/internal/ui/meta.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -115,17 +114,10 @@ func loadMetaCmd(drv db.Driver, v metaView, req int) tea.Cmd {
 	}
 }
 
-// copyDDLCmd puts a DDL statement on the system clipboard and reports
-// the outcome in the command log.
+// copyDDLCmd puts a DDL statement on the system clipboard, or in a temp
+// file when there is no clipboard, and reports which in the log.
 func copyDDLCmd(table, ddl string) tea.Cmd {
-	return func() tea.Msg {
-		if err := clipboardWrite(ddl); err != nil {
-			return commandLogMsg{line: fmt.Sprintf("-- copy DDL of %s FAILED: %v", table, err)}
-		}
-		return commandLogMsg{
-			line: fmt.Sprintf("-- copy DDL of %s to clipboard (%d bytes)", table, len(ddl)),
-		}
-	}
+	return copyTextCmd("DDL of "+table, table+"-ddl.sql", ddl)
 }
 
 // ---------- model wiring ----------

--- a/internal/ui/meta_test.go
+++ b/internal/ui/meta_test.go
@@ -60,6 +60,20 @@ func fakeClipboard(t *testing.T) *string {
 	return &got
 }
 
+// fakeSpill replaces the temp-file fallback, so a test that exercises a
+// missing clipboard leaves nothing behind on disk.
+func fakeSpill(t *testing.T) *string {
+	t.Helper()
+	var got string
+	prev := spillFile
+	spillFile = func(name, text string) (string, error) {
+		got = text
+		return "/tmp/fake-spill-" + name, nil
+	}
+	t.Cleanup(func() { spillFile = prev })
+	return &got
+}
+
 // `]` walks Data → Structure → Indexes → DDL and wraps; `[` walks back.
 func TestMainTabCycling(t *testing.T) {
 	m := metaBrowsing(t)
@@ -142,7 +156,7 @@ func TestDDLTabRendersStatement(t *testing.T) {
 		t.Fatalf("DDL = %q", m.meta.ddl)
 	}
 	out := m.View().Content
-	for _, want := range []string{"CREATE TABLE", "person_id", "y copies the statement"} {
+	for _, want := range []string{"CREATE TABLE", "person_id", "y opens the copy menu"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("DDL tab is missing %q", want)
 		}
@@ -168,12 +182,13 @@ func TestDDLTabScrolls(t *testing.T) {
 	}
 }
 
-// `y` copies the DDL, from the DDL tab and from the Data tab alike —
-// on the Data tab it fetches the metadata first.
+// `y` opens the copy menu; its DDL entry copies the CREATE statement,
+// from the DDL tab and from the Data tab alike — on the Data tab it
+// fetches the metadata first.
 func TestCopyDDLToClipboard(t *testing.T) {
 	got := fakeClipboard(t)
 
-	m := send(t, metaBrowsing(t), press(']'), press(']'), press(']'), press('y'))
+	m := send(t, metaBrowsing(t), press(']'), press(']'), press(']'), press('y'), press('d'))
 	if !strings.Contains(*got, "CREATE TABLE") {
 		t.Fatalf("clipboard = %q", *got)
 	}
@@ -182,7 +197,7 @@ func TestCopyDDLToClipboard(t *testing.T) {
 	}
 
 	*got = ""
-	m = send(t, metaBrowsing(t), press('y'))
+	m = send(t, metaBrowsing(t), press('y'), press('d'))
 	if m.tab != mainTabData {
 		t.Fatalf("y changed the tab to %v", m.tab)
 	}
@@ -191,14 +206,34 @@ func TestCopyDDLToClipboard(t *testing.T) {
 	}
 }
 
-// A clipboard the environment does not support fails loudly in the log
-// rather than silently doing nothing.
+// With no clipboard in the environment a copy degrades to a temp file
+// and the log names the path instead of just failing.
+func TestCopyDDLFallsBackToFile(t *testing.T) {
+	prev := clipboardWrite
+	clipboardWrite = func(string) error { return context.Canceled }
+	t.Cleanup(func() { clipboardWrite = prev })
+	spilled := fakeSpill(t)
+
+	m := send(t, metaBrowsing(t), press(']'), press(']'), press(']'), press('y'), press('d'))
+	if !strings.Contains(*spilled, "CREATE TABLE") {
+		t.Fatalf("spill file = %q", *spilled)
+	}
+	if !logContains(m, "no clipboard") || !logContains(m, "/tmp/fake-spill") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+}
+
+// When even the temp file cannot be written the copy fails loudly in
+// the log rather than silently doing nothing.
 func TestCopyDDLFailureIsLogged(t *testing.T) {
 	prev := clipboardWrite
 	clipboardWrite = func(string) error { return context.Canceled }
 	t.Cleanup(func() { clipboardWrite = prev })
+	prevSpill := spillFile
+	spillFile = func(string, string) (string, error) { return "", context.Canceled }
+	t.Cleanup(func() { spillFile = prevSpill })
 
-	m := send(t, metaBrowsing(t), press(']'), press(']'), press(']'), press('y'))
+	m := send(t, metaBrowsing(t), press(']'), press(']'), press(']'), press('y'), press('d'))
 	if !logContains(m, "-- copy DDL of orders FAILED") {
 		t.Fatalf("command log = %v", m.commandLog)
 	}

--- a/internal/ui/metaview.go
+++ b/internal/ui/metaview.go
@@ -207,7 +207,7 @@ func (m Model) ddlLines(w, h int) []string {
 		lines = append(lines, strings.ReplaceAll(l, "\t", "    "))
 	}
 	out := scrollLines(lines, m.meta.row[mainTabDDL], w, maxInt(h-1, 0))
-	hint := fmt.Sprintf("%d lines — y copies the statement", len(lines))
+	hint := fmt.Sprintf("%d lines — y opens the copy menu", len(lines))
 	return append(out, m.style.keyHint.Render(truncate(hint, w)))
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -100,6 +100,10 @@ type Model struct {
 	tab  mainTab
 	meta metaView
 
+	// export is the file export in flight, if any. At most one runs at
+	// a time; `X` cancels it.
+	export exportState
+
 	startupErr string
 
 	keys  keyMap
@@ -189,6 +193,10 @@ func (m *Model) resetBrowse() {
 	// Staged changes reference the connection's tables; they cannot
 	// survive it. They are discarded, not committed.
 	m.changes.Clear()
+	// An export reads through the driver that is about to be closed.
+	if m.export.running && m.export.cancel != nil {
+		m.export.cancel()
+	}
 	m.database = ""
 	m.table = ""
 	m.data = dataView{}
@@ -451,6 +459,30 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		)
 		return m, tea.Batch(cmds...)
 
+	case copiedMsg:
+		// A copy already rendered its own outcome — clipboard, temp-file
+		// fallback or failure — so the log line is taken as it is.
+		return m, logCmd("%s", msg.line)
+
+	case exportProgressMsg:
+		if msg.id != m.export.id || !m.export.running {
+			return m, nil
+		}
+		return m, tea.Batch(
+			logCmd("-- export %s: %d rows…", m.export.table, msg.rows),
+			waitExportCmd(m.export.ch),
+		)
+
+	case exportDoneMsg:
+		if msg.id != m.export.id {
+			return m, nil
+		}
+		// Bind the command first: finishExport clears the in-flight
+		// state on m, and Go may otherwise copy the pre-call model into
+		// the return value.
+		cmd := m.finishExport(msg)
+		return m, cmd
+
 	case connPersistedMsg:
 		if msg.err != nil {
 			return m, logCmd("-- %s %s FAILED: %v", msg.verb, msg.name, msg.err)
@@ -610,6 +642,9 @@ func (m Model) runAction(id actionID) (Model, tea.Cmd) {
 	// The main view's tab actions run first: they mean the same thing
 	// on every tab. The data grid's own actions live with the grid.
 	if mm, cmd, handled := m.metaActions(id); handled {
+		return mm, cmd
+	}
+	if mm, cmd, handled := m.copyActions(id); handled {
 		return mm, cmd
 	}
 	if mm, cmd, handled := m.dataActions(id); handled {

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -60,15 +60,19 @@ func special(code rune, mod tea.KeyMod) tea.KeyPressMsg {
 func send(t *testing.T, m Model, msgs ...tea.Msg) Model {
 	t.Helper()
 	for _, msg := range msgs {
-		next, cmd := m.Update(msg)
-		m = next.(Model)
-		for _, out := range drain(cmd) {
-			next, cmd2 := m.Update(out)
-			m = next.(Model)
-			for _, out2 := range drain(cmd2) {
-				next, _ := m.Update(out2)
-				m = next.(Model)
+		// Each key press is driven to a standstill before the next one:
+		// a message may produce commands whose messages produce more,
+		// and a flow like the file export is several rounds deep.
+		queue := []tea.Msg{msg}
+		for round := 0; len(queue) > 0; round++ {
+			if round > 10_000 {
+				t.Fatalf("message cascade did not settle after %T", msg)
 			}
+			head := queue[0]
+			queue = queue[1:]
+			next, cmd := m.Update(head)
+			m = next.(Model)
+			queue = append(queue, drain(cmd)...)
 		}
 	}
 	return m

--- a/issue_runner.py
+++ b/issue_runner.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Run Claude Code on open ike issues (> 1602), one fresh session per issue.
+
+With issue numbers as arguments (`issue_runner.py 1633 1634`) only those issues
+run, in the given order; they must be open, the MIN_ISSUE bound does not apply.
+Without arguments: fetches all open issues each round, picks the oldest with number > 1602,
+hands number/title/body/comments to a headless Claude session (model/effort
+from the issue's `model:*` / `effort:*` labels, default fable/medium), and
+repeats until no matching issue is left. Progress goes to stdout
+and issue_runner.log.
+
+Epic issues (label `epic`) are spec containers: scan mode skips them; naming
+one explicitly runs its open sub-issues (from the `- [ ] #N` task list) in
+list order instead.
+"""
+
+import json
+import logging
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = "TrueDaerk/ike"
+MIN_ISSUE = 1602  # exclusive lower bound
+WORKDIR = Path(__file__).resolve().parent
+LOG_FILE = WORKDIR / "issue_runner.log"
+
+log = logging.getLogger("issue_runner")
+
+
+def setup_logging() -> None:
+    log.setLevel(logging.DEBUG)
+    fmt = logging.Formatter("%(asctime)s %(levelname)-7s %(message)s")
+    fh = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    fh.setFormatter(fmt)
+    fh.setLevel(logging.DEBUG)
+    sh = logging.StreamHandler(sys.stdout)
+    sh.setFormatter(fmt)
+    sh.setLevel(logging.INFO)
+    log.addHandler(fh)
+    log.addHandler(sh)
+
+
+def run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    log.debug("exec: %s", " ".join(cmd))
+    return subprocess.run(cmd, capture_output=True, text=True, **kwargs)
+
+
+def open_issue_labels() -> dict[int, set[str]]:
+    """Open issue numbers mapped to their label names."""
+    proc = run([
+        "gh", "issue", "list", "--repo", REPO, "--state", "open",
+        "--limit", "500", "--json", "number,labels",
+    ])
+    if proc.returncode != 0:
+        log.error("gh issue list failed: %s", proc.stderr.strip())
+        sys.exit(1)
+    return {
+        i["number"]: {l.get("name", "") for l in i.get("labels") or []}
+        for i in json.loads(proc.stdout)
+    }
+
+
+def open_issues() -> set[int]:
+    return set(open_issue_labels())
+
+
+def next_issue() -> int | None:
+    """Lowest open non-epic issue number > MIN_ISSUE, or None.
+
+    Epic issues are spec containers worked through their sub-issues; handing
+    one to a Claude session would treat the spec as a work item and trip the
+    still-open loop guard afterwards.
+    """
+    labels = open_issue_labels()
+    numbers = [n for n, ls in labels.items() if n > MIN_ISSUE and "epic" not in ls]
+    skipped = [n for n, ls in labels.items() if n > MIN_ISSUE and "epic" in ls]
+    for n in sorted(skipped):
+        log.debug("skipping epic issue #%d in scan mode", n)
+    return min(numbers) if numbers else None
+
+
+def is_epic(issue: dict) -> bool:
+    return any((l.get("name") == "epic") for l in issue.get("labels") or [])
+
+
+def epic_subissues(issue: dict) -> list[int]:
+    """Sub-issue numbers from the epic's `- [ ] #N` task list, in list order.
+
+    Ticked boxes (`- [x] #N`) are included too — openness is checked against
+    the live issue state, not the checkbox, since task-list ticks can lag.
+    """
+    return [
+        int(m.group(1))
+        for m in re.finditer(r"^\s*-\s*\[[ xX]\]\s*#(\d+)",
+                             issue.get("body") or "", re.MULTILINE)
+    ]
+
+
+def issue_details(number: int) -> dict:
+    proc = run([
+        "gh", "issue", "view", str(number), "--repo", REPO,
+        "--json", "number,title,body,comments,labels",
+    ])
+    if proc.returncode != 0:
+        log.error("gh issue view %d failed: %s", number, proc.stderr.strip())
+        sys.exit(1)
+    return json.loads(proc.stdout)
+
+
+def model_and_effort(issue: dict) -> tuple[str, str]:
+    """Model/effort from `model:*` / `effort:*` labels; default fable/medium."""
+    model, effort = "fable", "medium"
+    for label in issue.get("labels") or []:
+        name = label.get("name", "")
+        if name.startswith("model:"):
+            model = name.removeprefix("model:")
+        elif name.startswith("effort:"):
+            effort = name.removeprefix("effort:")
+    return model, effort
+
+
+def build_prompt(issue: dict) -> str:
+    parts = [
+        f"Work on GitHub issue #{issue['number']} of {REPO}. "
+        "All issue information is included below — do not fetch the issue yourself.",
+        "",
+        f"# Issue #{issue['number']}: {issue['title']}",
+        "",
+        issue.get("body") or "(no body)",
+    ]
+    comments = issue.get("comments") or []
+    if comments:
+        parts += ["", "# Comments"]
+        for c in comments:
+            author = (c.get("author") or {}).get("login", "unknown")
+            parts += ["", f"## {author} ({c.get('createdAt', '')})", c.get("body", "")]
+    parts += [
+        "",
+        "# Instructions",
+        "Follow the repository change workflow (CLAUDE.md / wiki/process/change-workflow.md):",
+        "work on a branch `issue/<number>-<slug>` off an up-to-date main, implement the issue "
+        "with tests, update the wiki where behavior changes, run docgen if commands/keybinds "
+        "changed, bump the patch version in its own chore(version) commit, open a PR with "
+        f"`Closes #{issue['number']}`, merge it, delete the branch, and return to main.",
+    ]
+    return "\n".join(parts)
+
+
+def describe_tool_use(name: str, tool_input: dict) -> str | None:
+    """One-line summary of an important tool call, or None to skip it.
+
+    Only state-changing / long-running calls are reported: shell commands,
+    file writes, subagents. Reads, searches and plain text are noise here.
+    """
+    if name == "Bash":
+        detail = tool_input.get("description") or tool_input.get("command", "")
+    elif name in ("Edit", "Write", "NotebookEdit"):
+        detail = tool_input.get("file_path", "")
+    elif name in ("Agent", "Task"):
+        detail = tool_input.get("description", "")
+    elif name == "Skill":
+        detail = tool_input.get("skill", "")
+    else:
+        return None
+    detail = " ".join(detail.split())
+    if len(detail) > 160:
+        detail = detail[:157] + "..."
+    return f"{name}: {detail}" if detail else name
+
+
+def stream_event(event: dict) -> None:
+    """Log a single stream-json event from the Claude session."""
+    etype = event.get("type")
+    if etype == "assistant":
+        for block in (event.get("message") or {}).get("content") or []:
+            if block.get("type") != "tool_use":
+                continue
+            summary = describe_tool_use(block.get("name", "?"),
+                                        block.get("input") or {})
+            if summary:
+                log.info("  %s", summary)
+    elif etype == "result":
+        log.info("  result: %s (turns=%s, cost=$%.2f)",
+                 event.get("subtype", "?"), event.get("num_turns", "?"),
+                 event.get("total_cost_usd") or 0.0)
+
+
+def run_claude(prompt: str, model: str, effort: str) -> int:
+    proc = subprocess.Popen(
+        [
+            "claude", "-p", prompt,
+            "--model", model,
+            "--effort", effort,
+            "--dangerously-skip-permissions",
+            "--output-format", "stream-json",
+            "--verbose",
+        ],
+        cwd=WORKDIR, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+    )
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            stream_event(json.loads(line))
+        except json.JSONDecodeError:
+            log.debug("claude non-json line: %s", line)
+    stderr = proc.stderr.read() if proc.stderr else ""
+    if stderr.strip():
+        log.debug("claude stderr:\n%s", stderr.strip())
+    return proc.wait()
+
+
+def work_issue(number: int) -> None:
+    """Run one Claude session on the issue; exit on failure or if it stays open.
+
+    An epic issue is expanded instead: its open sub-issues run one by one in
+    task-list order, the epic itself is never handed to a session.
+    """
+    issue = issue_details(number)
+    if is_epic(issue):
+        work_epic(issue)
+        return
+    model, effort = model_and_effort(issue)
+    log.info("starting issue #%d (%s/%s): %s", number, model, effort, issue["title"])
+    start = time.monotonic()
+    rc = run_claude(build_prompt(issue), model, effort)
+    minutes = (time.monotonic() - start) / 60
+    log.info("claude exited rc=%d after %.1f min on issue #%d", rc, minutes, number)
+
+    if rc != 0:
+        log.error("claude failed on issue #%d — stopping", number)
+        sys.exit(1)
+    if number in open_issues():
+        log.error("issue #%d still open after run — stopping to avoid a loop", number)
+        sys.exit(1)
+
+
+def work_epic(issue: dict) -> None:
+    """Run an epic's open sub-issues in task-list order."""
+    number = issue["number"]
+    subs = epic_subissues(issue)
+    if not subs:
+        log.error("epic #%d has no task-list sub-issues — nothing to run", number)
+        sys.exit(1)
+    still_open = open_issues()
+    todo = [n for n in subs if n in still_open]
+    log.info("epic #%d: %d sub-issue(s), %d open: %s", number, len(subs),
+             len(todo), ", ".join(f"#{n}" for n in todo) or "-")
+    for sub in todo:
+        work_issue(sub)
+    if number in open_issues():
+        log.info("epic #%d: all sub-issues done but the epic is still open — "
+                 "close it (and its milestone) manually", number)
+
+
+def parse_args(argv: list[str]) -> list[int]:
+    """Issue numbers from argv (e.g. `issue_runner.py 1633 1634`); empty = scan mode."""
+    try:
+        return [int(a.lstrip("#")) for a in argv]
+    except ValueError:
+        print(f"usage: {sys.argv[0]} [issue-number ...]", file=sys.stderr)
+        sys.exit(2)
+
+
+def main() -> None:
+    selected = parse_args(sys.argv[1:])
+    setup_logging()
+
+    if selected:
+        log.info("issue runner started (repo=%s, selected: %s)",
+                 REPO, ", ".join(f"#{n}" for n in selected))
+        still_open = open_issues()
+        closed = [n for n in selected if n not in still_open]
+        if closed:
+            log.error("not open: %s — aborting", ", ".join(f"#{n}" for n in closed))
+            sys.exit(1)
+        for number in selected:
+            work_issue(number)
+        log.info("done after %d issue(s)", len(selected))
+        return
+
+    log.info("issue runner started (repo=%s, issues > %d)", REPO, MIN_ISSUE)
+    done = 0
+    while True:
+        number = next_issue()
+        if number is None:
+            log.info("no open issues > %d left — done after %d issue(s)", MIN_ISSUE, done)
+            return
+        work_issue(number)
+        done += 1
+
+
+if __name__ == "__main__":
+    main()

--- a/wiki/design/copy-and-export.md
+++ b/wiki/design/copy-and-export.md
@@ -1,0 +1,139 @@
+---
+type: Design Decision
+title: Copy menu and streaming file export
+description: Why serialization lives in its own package behind a three-method incremental Writer, why a whole-table copy is capped while a file export streams, how NULL is spelled in each format, and how the export is cancelled.
+tags: [tui, export, csv, json, sql, clipboard, streaming]
+generated:
+  by: claude-code/opus-5
+  at: 2026-08-09T00:00:00Z
+---
+
+# Copy and export
+
+## Decision
+
+Getting data *out* is one feature with two ends. `y` opens a
+context-aware copy menu whose result goes to the clipboard; `E` prompts
+for a path and writes the same bytes to a file. Both go through
+`internal/export`, so a single row and the table it came from can never
+disagree about quoting.
+
+`internal/export` knows nothing about the TUI and nothing about
+`database/sql`. It depends only on `internal/db` for the normalized cell
+types and the `Dialect`, which keeps the driver-abstraction rule intact:
+the serializers see `nil / string / int64 / float64 / bool / time.Time`
+and never a driver-private type.
+
+### The writer is incremental, not a function over a slice
+
+```go
+type Writer interface {
+    Begin(cols []db.Column) error
+    Row(values []any) error
+    End() error
+}
+```
+
+Three methods rather than `Serialize(rows) string` is the whole reason a
+100k-row export costs one page of memory. `Stream` walks pages through
+the same `Driver.QueryPage` the grid uses — inheriting its filter and
+sort for free — and feeds each row to the writer, which flushes into the
+`io.Writer` underneath. Nothing accumulates.
+
+`Begin` is called even for an empty result, so a CSV still gets its
+header and a JSON still gets `[]` rather than an empty file.
+
+A short page ends the stream: an engine has no other way to say "that
+was all", and asking for a count first would double the round trips for
+information the export does not need.
+
+### A clipboard copy is capped; a file export is not
+
+A file export streams to disk, so its size is bounded by the disk. A
+clipboard copy has to be materialized in full before the system
+clipboard will take it, so a whole-table copy stops at
+`copyRowLimit` (5000 rows) and the command log says so, naming `E` as
+the way to get the rest. Silently copying a prefix would be the one
+outcome the user cannot detect.
+
+### NULL, three times
+
+There is no single right answer, so each format gets the one its readers
+expect:
+
+| format | SQL NULL renders as |
+| --- | --- |
+| CSV | an empty field |
+| JSON | `null` |
+| SQL | `NULL` |
+
+The CSV choice is deliberate: MySQL's own tooling writes `\N`, which
+nothing outside MySQL reads, and an empty field at least round-trips
+through every spreadsheet. It does mean an empty string and a NULL are
+indistinguishable in CSV — which is a property of CSV, not of lazysql,
+and the reason the JSON and SQL variants exist next to it.
+
+JSON is the only one of the three that can say NULL exactly, so it also
+keeps numbers as numbers and booleans as booleans rather than
+stringifying everything. Infinity and NaN have no JSON spelling at all
+and degrade to `null`.
+
+### Generated SQL is literal, executed SQL is parameterized
+
+`db.QuoteLiteral` and `db.InsertStatement` (in `internal/db/literal.go`)
+exist only for text handed *to the user*. Everything lazysql executes
+still goes through the parameterized statements of
+[design/staged-changeset](staged-changeset.md). Keeping the two apart is
+what lets the escaping rules live in one small, well-tested file — see
+[reference/sql-literal-escaping](../reference/sql-literal-escaping.md)
+for the per-dialect rules.
+
+`.sql` exports INSERTs only. The `CREATE TABLE + INSERTs` variant is a
+copy-menu entry rather than an extension, because inferring it from the
+extension would make the same `.sql` path mean two different things
+depending on whether the DDL happened to be fetchable.
+
+### Progress and cancellation
+
+The export worker is a goroutine that pushes `exportProgressMsg` and one
+`exportDoneMsg` into an unbuffered channel; the root re-issues
+`waitExportCmd` after every progress line. The unbuffered channel is
+backpressure on purpose — a UI that has stopped reading should stall the
+worker rather than let it run ahead — and every progress send also
+selects on `ctx.Done()`, so a cancelled export cannot deadlock on a
+channel nobody is reading.
+
+`X` cancels by cancelling that context; `Stream` checks it between pages
+*and* between rows. A cancelled or failed export removes its partial
+file: a half-written export is worse than none, because it looks
+complete.
+
+Only one export runs at a time. `X` is bound to `key.WithDisabled()` and
+enabled only while one is running, so the options bar and `?` — which
+both skip disabled bindings — never advertise a key that would do
+nothing. That is the
+[design/keybindings-single-source](keybindings-single-source.md) rule
+applied to a conditional action.
+
+### Menu keys avoid `j` and `k`
+
+The copy menu is a `menuModal`, which moves its own cursor with `j`/`k`.
+Row-scope JSON is therefore `o` (object), not `j`. Lowercase is the row
+scope, uppercase the table scope.
+
+## Consequences
+
+- `y` no longer copies the DDL directly; it opens the menu, whose `d`
+  entry does. The DDL tab's hint changed to match.
+- A copy never simply fails. With no clipboard — an SSH session, a bare
+  tty, a container — the text spills to a temp file and the log names
+  the path. `clipboardWrite` and `spillFile` are both variables so a
+  test run can never touch the developer's clipboard or temp directory.
+- A whole-table copy or export of a relation the user is mid-edit on
+  reads the *server's* rows. Only the single-cell and single-row copies
+  apply the staged changeset, because those are built from the page the
+  user is looking at.
+- Offset paging without an explicit sort inherits the engine's
+  unspecified row order, so a large export can in principle skip or
+  repeat a row if the table is being written concurrently. Sorting the
+  grid before exporting makes the walk deterministic.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -16,6 +16,7 @@ concept with YAML frontmatter. Concept IDs are bundle-relative paths without
 - [design/data-grid](design/data-grid.md) — Design Decision — one-page-at-a-time main view, derived scroll windows, the `panelMain` focus target, and the parse-first quick filter.
 - [design/main-view-tabs](design/main-view-tabs.md) — Design Decision — Data/Structure/Indexes/DDL tabs behind one metadata fetch, `[`/`]` cycling instead of digits, and what survives a relation change.
 - [design/staged-changeset](design/staged-changeset.md) — Design Decision — cell edits, row deletes and row inserts stage into one engine-agnostic changeset, rows are identified only by their primary key, and the commit runs every statement in one transaction.
+- [design/copy-and-export](design/copy-and-export.md) — Design Decision — one incremental serializer package behind both the `y` copy menu and the `E` file export, why a clipboard copy is capped while a file export streams, how NULL is spelled per format, and how the export reports progress and cancels.
 
 ## reference
 
@@ -24,3 +25,4 @@ concept with YAML frontmatter. Concept IDs are bundle-relative paths without
 - [reference/dialect-introspection-quirks](reference/dialect-introspection-quirks.md) — Dialect Note — engine-specific introspection gotchas (PRAGMA placeholders, duckdb_* functions, pg_index, SHOW CREATE TABLE).
 - [reference/sqlite-double-quoted-strings](reference/sqlite-double-quoted-strings.md) — Dialect Note — SQLite reads an unresolvable double-quoted identifier as a string literal, so a filter on a misspelled column matches nothing instead of erroring.
 - [reference/insert-default-values](reference/insert-default-values.md) — Dialect Note — `DEFAULT VALUES` vs. MySQL's empty column list for an INSERT that names no columns.
+- [reference/sql-literal-escaping](reference/sql-literal-escaping.md) — Dialect Note — backslash escapes in MySQL string literals but not in PostgreSQL/SQLite/DuckDB, plus per-engine boolean and timestamp literal spellings.

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -119,3 +119,38 @@ Chronological history of wiki changes, newest last.
   an INSERT that names no columns is `DEFAULT VALUES` in PostgreSQL,
   SQLite and DuckDB and `() VALUES ()` in MySQL/MariaDB, and each form is
   a syntax error in the other family.
+- Added [design/copy-and-export](design/copy-and-export.md) with the copy
+  menu and the file export (issue #9): a new `internal/export` package
+  holds a three-method incremental `Writer` (`Begin`/`Row`/`End`) per
+  format and a `Stream` that walks `Driver.QueryPage` a page at a time,
+  so a 100k-row export costs one page of memory and inherits the grid's
+  filter and sort for free. `y` opens a context-aware menu (cell, row as
+  CSV/JSON/INSERT, table as CSV/JSON/INSERTs/CREATE+INSERTs, DDL); `E`
+  prompts for a path and infers the format from `.csv`/`.json`/`.sql`.
+- Recorded the decisions that were not obvious while implementing it:
+  NULL is an empty CSV field (not MySQL's unportable `\N`), JSON `null`
+  and SQL `NULL`; a whole-table *clipboard* copy is capped at 5000 rows
+  because the clipboard cannot be streamed, and reaching the cap is
+  logged rather than silent; `.sql` exports INSERTs only, with
+  `CREATE TABLE + INSERTs` left as a copy-menu entry so one extension
+  never means two things; and the copy menu's JSON entry is `o`, not
+  `j`, because `menuModal` moves its own cursor with `j`/`k`.
+- Added [reference/sql-literal-escaping](reference/sql-literal-escaping.md):
+  generated INSERTs inline their values, so MySQL/MariaDB need the
+  backslash doubled (`NO_BACKSLASH_ESCAPES` off by default) while
+  PostgreSQL/SQLite/DuckDB must not have it touched; booleans are `1`/`0`
+  on MySQL and `TRUE`/`FALSE` elsewhere; and a `DATETIME` literal rejects
+  the RFC 3339 `T` and zone suffix. Everything lazysql *executes* stays
+  parameterized — `db.QuoteLiteral` exists only for text handed to the
+  user.
+- A copy now degrades instead of failing: with no clipboard (SSH, a bare
+  tty, a container) `copyOut` spills the text to a temp file and the log
+  names the path. The export worker streams progress through an
+  unbuffered channel with `X` cancelling its context between pages and
+  between rows, and a cancelled or failed export removes its partial
+  file. `X` is bound with `key.WithDisabled()` and enabled only while an
+  export runs, so the options bar and `?` never advertise a dead key.
+- Deepened the `send` test driver from three hard-coded rounds to a
+  queue that runs a key press's message cascade to a standstill: the
+  export flow is four rounds deep (prompt → worker start → progress →
+  done) and the old driver silently dropped the last one.

--- a/wiki/reference/sql-literal-escaping.md
+++ b/wiki/reference/sql-literal-escaping.md
@@ -1,0 +1,73 @@
+---
+type: Dialect Note
+title: Per-dialect SQL literal escaping for generated INSERTs
+description: MySQL and MariaDB read a backslash inside a string literal as an escape character while PostgreSQL, SQLite and DuckDB do not; booleans and timestamps also need per-engine spellings.
+tags: [db, dialects, sql, escaping, export, security]
+generated:
+  by: claude-code/opus-5
+  at: 2026-08-09T00:00:00Z
+---
+
+# SQL literal escaping
+
+Everything lazysql *executes* is parameterized, so this note applies
+only to the SQL text lazysql *generates* for the user: the `INSERT`
+statements produced by the copy menu and by a `.sql` export. See
+[design/copy-and-export](../design/copy-and-export.md).
+
+`db.QuoteLiteral(dialect, value)` in `internal/db/literal.go` is the one
+place these rules live.
+
+## Strings: the backslash is not universal
+
+Doubling the single quote (`'` → `''`) is standard and works everywhere.
+The backslash is not:
+
+| engine | `C:\tmp` renders as | why |
+| --- | --- | --- |
+| MySQL, MariaDB | `'C:\\tmp'` | `NO_BACKSLASH_ESCAPES` is off by default, so `\t` inside a literal is a tab |
+| PostgreSQL | `'C:\tmp'` | `standard_conforming_strings` is on by default, so the backslash is data |
+| SQLite, DuckDB | `'C:\tmp'` | no backslash escapes at all |
+
+Escaping the backslash unconditionally would corrupt every Windows path
+exported from PostgreSQL; not escaping it would corrupt every one
+exported from MySQL. Hence the per-dialect branch.
+
+The two passes are order-independent in either direction — doubling a
+quote never introduces a backslash, and doubling a backslash never
+introduces a quote — but the backslash pass runs first anyway, because
+the reverse reads like a bug even when it is not.
+
+A MySQL server started with `sql_mode=NO_BACKSLASH_ESCAPES` will read
+the doubled backslash as two characters. lazysql does not probe for it:
+the setting is rare, and the export is text a human reviews before
+running.
+
+## Booleans
+
+MySQL and MariaDB have no real boolean type — `TRUE`/`FALSE` are
+accepted as aliases for `1`/`0` — and the underlying `TINYINT(1)` column
+round-trips more predictably as the number it actually stores. Every
+other engine gets `TRUE`/`FALSE`.
+
+## Timestamps
+
+MySQL and MariaDB reject the RFC 3339 `T` separator and the zone suffix
+in a `DATETIME` literal, so timestamps are converted to UTC and written
+`'2026-08-09 12:34:56'`. PostgreSQL, SQLite and DuckDB all parse RFC
+3339, so they keep the offset: `'2026-08-09T12:34:56Z'`.
+
+## Non-finite floats
+
+Neither `Infinity` nor `NaN` is a portable numeric literal. Every engine
+that accepts them at all accepts the quoted spelling (`'NaN'`), so that
+is what is emitted; on an engine that does not, the statement fails
+loudly rather than inserting a silently wrong number.
+
+## A nil dialect is allowed
+
+`QuoteLiteral`, `QualifiedTable` and `QuoteIdentifier` are all nil-safe,
+falling back to the standard-conforming spelling with unquoted
+identifiers. That is what a preview built without a live connection
+wants, and it keeps the serializers in `internal/export` usable in tests
+that have no driver.


### PR DESCRIPTION
Streaming export package (CSV/JSON/SQL INSERT) with correct quoting, typed literals, and NULL handling per format. Copy menu on `y` for cell/row/table/DDL; table exports stream page-wise so large tables never load into memory. Clipboard failures fall back to a temp file.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139rhNA79AoksWw97zoxwWA