### PR TITLE
Build SQL query editor with persistent history panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ In the data grid (`enter` on a table, `esc` back):
 | `f` | Quick `WHERE` filter |
 | `v` | Show the full cell value (JSON pretty-printed) |
 
+In the query editor (`:` from anywhere):
+
+| Key | Action |
+|-----|--------|
+| `ctrl+r` | Run the script |
+| `enter` | New line |
+| `esc` | Close, keeping the draft |
+| `ctrl+c` | Cancel the running query |
+
+Several statements separated by `;` run in order; the result of the last
+`SELECT` is what the Data tab shows, and anything that changes data asks
+first. Every executed statement is appended to `[4] Query history`, which
+persists in `${XDG_STATE_HOME:-~/.local/state}/lazysql/history` with the
+engine it ran on and when. There, `enter` loads an entry back into the
+editor, `x` runs it, `d` deletes it, `D` clears the history and `/` filters.
+
 ## Install
 
 ```sh

--- a/internal/db/conn.go
+++ b/internal/db/conn.go
@@ -249,13 +249,18 @@ func (c *conn) ExecTx(ctx context.Context, stmts []Statement) ([]ExecResult, err
 }
 
 func (c *conn) Query(ctx context.Context, query string, args ...any) (*ResultSet, error) {
+	rs, _, err := c.QueryLimit(ctx, query, 0, args...)
+	return rs, err
+}
+
+func (c *conn) QueryLimit(ctx context.Context, query string, max int, args ...any) (*ResultSet, bool, error) {
 	if c.db == nil {
-		return nil, errNotConnected
+		return nil, false, errNotConnected
 	}
 	rows, err := c.db.QueryContext(ctx, query, args...)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	defer rows.Close()
-	return scanResultSet(ctx, rows)
+	return scanResultSetLimit(ctx, rows, max)
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -188,6 +188,13 @@ type Driver interface {
 	ExecTx(ctx context.Context, stmts []Statement) ([]ExecResult, error)
 	// Query runs an arbitrary SQL query with parameters.
 	Query(ctx context.Context, query string, args ...any) (*ResultSet, error)
+	// QueryLimit is Query with a cap on how many rows it materializes;
+	// max <= 0 means unlimited. The second result reports that the
+	// server had more rows than the cap, so a capped result is never
+	// mistaken for a complete one. Free-form queries from the editor go
+	// through it: an unbounded `SELECT *` on a large table would
+	// otherwise be read entirely into memory.
+	QueryLimit(ctx context.Context, query string, max int, args ...any) (*ResultSet, bool, error)
 }
 
 // Dialect captures everything engine-specific: identifier quoting,

--- a/internal/db/scan.go
+++ b/internal/db/scan.go
@@ -7,13 +7,23 @@ import (
 )
 
 // scanResultSet materializes *sql.Rows into a driver-agnostic ResultSet.
+func scanResultSet(ctx context.Context, rows *sql.Rows) (*ResultSet, error) {
+	rs, _, err := scanResultSetLimit(ctx, rows, 0)
+	return rs, err
+}
+
+// scanResultSetLimit is scanResultSet with a cap on how many rows are
+// materialized; max <= 0 means unlimited. truncated reports that the
+// server still had rows when the cap was reached — the caller needs to
+// say so, because a silently short result reads as a complete one.
+//
 // Every cell is scanned into `any` and then normalized so the UI never
 // sees driver-private types. The context is checked between rows so a
 // cancelled query stops promptly even if the driver keeps yielding.
-func scanResultSet(ctx context.Context, rows *sql.Rows) (*ResultSet, error) {
+func scanResultSetLimit(ctx context.Context, rows *sql.Rows, max int) (*ResultSet, bool, error) {
 	types, err := rows.ColumnTypes()
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	cols := make([]Column, len(types))
 	for i, t := range types {
@@ -28,7 +38,10 @@ func scanResultSet(ctx context.Context, rows *sql.Rows) (*ResultSet, error) {
 	rs := &ResultSet{Columns: cols, Rows: [][]any{}}
 	for rows.Next() {
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return nil, false, err
+		}
+		if max > 0 && len(rs.Rows) >= max {
+			return rs, true, rows.Err()
 		}
 		raw := make([]any, len(cols))
 		ptrs := make([]any, len(cols))
@@ -36,7 +49,7 @@ func scanResultSet(ctx context.Context, rows *sql.Rows) (*ResultSet, error) {
 			ptrs[i] = &raw[i]
 		}
 		if err := rows.Scan(ptrs...); err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		row := make([]any, len(cols))
 		for i, v := range raw {
@@ -45,9 +58,9 @@ func scanResultSet(ctx context.Context, rows *sql.Rows) (*ResultSet, error) {
 		rs.Rows = append(rs.Rows, row)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return rs, nil
+	return rs, false, nil
 }
 
 // normalizeValue maps whatever the driver produced onto the small set of

--- a/internal/db/statements.go
+++ b/internal/db/statements.go
@@ -1,0 +1,261 @@
+package db
+
+import "strings"
+
+// Free-form SQL arrives from the query editor as one script that may hold
+// several statements. Splitting it on `;` needs a lexer rather than
+// strings.Split: a semicolon inside a string literal, an identifier or a
+// comment is data, not a separator. The lexer is dialect-aware because the
+// three constructs that carry a semicolon differ per engine — backticked
+// identifiers and `#` comments are MySQL's, dollar-quoted bodies are
+// PostgreSQL's, and only MySQL reads a backslash as an escape inside a
+// string literal.
+
+// SplitStatements splits a SQL script into its statements. Comments and
+// surrounding whitespace are kept inside the statement they belong to;
+// empty statements (a stray `;`, a trailing newline) are dropped, so
+// running an empty script yields no statements at all.
+//
+// The final statement does not need a trailing semicolon.
+func SplitStatements(engine Engine, script string) []string {
+	r := []rune(script)
+	mysqlish := engine == EngineMySQL || engine == EngineMariaDB
+	dollar := engine == EnginePostgres
+
+	var out []string
+	start, i := 0, 0
+	push := func(end int) {
+		if s := strings.TrimSpace(string(r[start:end])); s != "" {
+			out = append(out, s)
+		}
+	}
+	for i < len(r) {
+		switch c := r[i]; {
+		case c == '-' && i+1 < len(r) && r[i+1] == '-':
+			i = skipToEOL(r, i)
+		case mysqlish && c == '#':
+			i = skipToEOL(r, i)
+		case c == '/' && i+1 < len(r) && r[i+1] == '*':
+			i = skipBlockComment(r, i)
+		case c == '\'':
+			i = skipQuoted(r, i, '\'', mysqlish)
+		case c == '"':
+			// Standard quoted identifier everywhere lazysql supports;
+			// MySQL only reads it as a string in ANSI_QUOTES mode, and
+			// either way a `"` pairs with the next unescaped `"`.
+			i = skipQuoted(r, i, '"', false)
+		case mysqlish && c == '`':
+			i = skipQuoted(r, i, '`', false)
+		case dollar && c == '$':
+			i = skipDollarQuoted(r, i)
+		case c == ';':
+			push(i)
+			i++
+			start = i
+		default:
+			i++
+		}
+	}
+	push(len(r))
+	return out
+}
+
+func skipToEOL(r []rune, i int) int {
+	for i < len(r) && r[i] != '\n' {
+		i++
+	}
+	return i
+}
+
+// skipBlockComment steps over `/* … */`. Nesting is not honoured: only
+// PostgreSQL nests block comments, and an unterminated one runs to the
+// end of the script either way.
+func skipBlockComment(r []rune, i int) int {
+	for i += 2; i+1 < len(r); i++ {
+		if r[i] == '*' && r[i+1] == '/' {
+			return i + 2
+		}
+	}
+	return len(r)
+}
+
+// skipQuoted steps over a quoted run starting at the opening quote. A
+// doubled quote is the portable escape; backslash escapes are MySQL's
+// and are only honoured when the caller asks for them. An unterminated
+// run consumes the rest of the script, which keeps a half-typed literal
+// from splitting into nonsense statements.
+func skipQuoted(r []rune, i int, quote rune, backslash bool) int {
+	for i++; i < len(r); {
+		switch {
+		case backslash && r[i] == '\\':
+			i += 2
+		case r[i] == quote:
+			if i+1 < len(r) && r[i+1] == quote {
+				i += 2
+				continue
+			}
+			return i + 1
+		default:
+			i++
+		}
+	}
+	return len(r)
+}
+
+// skipDollarQuoted steps over a PostgreSQL `$tag$ … $tag$` body. A `$`
+// that does not open a valid tag is an ordinary character (it starts a
+// positional parameter such as `$1`), so the caller advances by one.
+func skipDollarQuoted(r []rune, i int) int {
+	tag, after, ok := dollarTag(r, i)
+	if !ok {
+		return i + 1
+	}
+	for j := after; j < len(r); j++ {
+		if r[j] != '$' {
+			continue
+		}
+		if closeTag, end, ok := dollarTag(r, j); ok && closeTag == tag {
+			return end
+		}
+	}
+	return len(r)
+}
+
+// dollarTag reads a `$tag$` delimiter at i, returning the tag text and
+// the index just after the closing `$`.
+func dollarTag(r []rune, i int) (tag string, after int, ok bool) {
+	j := i + 1
+	for j < len(r) && isTagRune(r[j]) {
+		j++
+	}
+	if j >= len(r) || r[j] != '$' {
+		return "", 0, false
+	}
+	return string(r[i+1 : j]), j + 1, true
+}
+
+func isTagRune(c rune) bool {
+	return c == '_' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+// StatementKind says whether a statement gives rows back or changes
+// something. The query editor routes on it twice: a read goes through
+// Query and renders in the grid, a write goes through Exec and needs the
+// user to confirm it first.
+type StatementKind int
+
+const (
+	StatementRead StatementKind = iota
+	StatementWrite
+)
+
+// readKeywords are the leading keywords that only ever produce rows.
+// EXPLAIN is one of them by convention even though `EXPLAIN ANALYZE`
+// really does execute its statement on PostgreSQL — see the wiki note.
+var readKeywords = map[string]bool{
+	"SELECT":   true,
+	"WITH":     true,
+	"SHOW":     true,
+	"EXPLAIN":  true,
+	"DESCRIBE": true,
+	"DESC":     true,
+	"VALUES":   true,
+	"TABLE":    true,
+	"PRAGMA":   true,
+}
+
+// writeInCTE are the keywords that turn a `WITH` into a writing
+// statement: PostgreSQL allows data-modifying CTEs, so the leading
+// keyword alone does not settle it.
+var writeInCTE = []string{"INSERT", "UPDATE", "DELETE", "MERGE"}
+
+// ClassifyStatement decides whether a statement reads or writes. It errs
+// towards StatementWrite: an unrecognized statement is confirmed before
+// it runs and executed through Exec, which is the safe way to be wrong.
+func ClassifyStatement(sql string) StatementKind {
+	body := TrimLeadingComments(sql)
+	kw := strings.ToUpper(firstWord(body))
+	if !readKeywords[kw] {
+		return StatementWrite
+	}
+	switch kw {
+	case "WITH":
+		if containsKeyword(body, writeInCTE...) {
+			return StatementWrite
+		}
+	case "PRAGMA":
+		// `PRAGMA x = y` sets, `PRAGMA x` reads.
+		if strings.Contains(body, "=") {
+			return StatementWrite
+		}
+	}
+	return StatementRead
+}
+
+// TrimLeadingComments strips whitespace and leading `--`, `#` and `/* */`
+// comments so the caller sees the statement's first real keyword.
+func TrimLeadingComments(sql string) string {
+	s := strings.TrimSpace(sql)
+	for {
+		switch {
+		case strings.HasPrefix(s, "--"), strings.HasPrefix(s, "#"):
+			if i := strings.IndexByte(s, '\n'); i >= 0 {
+				s = strings.TrimSpace(s[i+1:])
+				continue
+			}
+			return ""
+		case strings.HasPrefix(s, "/*"):
+			i := strings.Index(s[2:], "*/")
+			if i < 0 {
+				return ""
+			}
+			s = strings.TrimSpace(s[2+i+2:])
+			continue
+		default:
+			return s
+		}
+	}
+}
+
+// FirstKeyword is the statement's leading keyword, upper-cased, for log
+// lines and modal titles. It is empty for a statement that is only
+// comments.
+func FirstKeyword(sql string) string {
+	return strings.ToUpper(firstWord(TrimLeadingComments(sql)))
+}
+
+func firstWord(s string) string {
+	for i, c := range s {
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '(' || c == ';' {
+			return s[:i]
+		}
+	}
+	return s
+}
+
+// containsKeyword reports whether any of the words appears in sql as a
+// whole word, ignoring case. It is a heuristic over statement text, used
+// only to decide whether a CTE writes.
+func containsKeyword(sql string, words ...string) bool {
+	up := strings.ToUpper(sql)
+	for _, w := range words {
+		for i := 0; ; {
+			j := strings.Index(up[i:], w)
+			if j < 0 {
+				break
+			}
+			at := i + j
+			before := at == 0 || !isWordRune(rune(up[at-1]))
+			afterAt := at + len(w)
+			after := afterAt >= len(up) || !isWordRune(rune(up[afterAt]))
+			if before && after {
+				return true
+			}
+			i = at + len(w)
+		}
+	}
+	return false
+}
+
+func isWordRune(c rune) bool { return isTagRune(c) }

--- a/internal/db/statements_test.go
+++ b/internal/db/statements_test.go
@@ -1,0 +1,141 @@
+package db
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSplitStatements(t *testing.T) {
+	cases := []struct {
+		name   string
+		engine Engine
+		script string
+		want   []string
+	}{
+		{"empty", EngineSQLite, "   \n\t ", nil},
+		{"one, no terminator", EngineSQLite, "SELECT 1", []string{"SELECT 1"}},
+		{"one, terminated", EngineSQLite, "SELECT 1;", []string{"SELECT 1"}},
+		{"stray separators", EngineSQLite, ";;SELECT 1;;", []string{"SELECT 1"}},
+		{"two", EngineSQLite, "SELECT 1;\nSELECT 2;", []string{"SELECT 1", "SELECT 2"}},
+		{
+			"semicolon in a string literal", EngineSQLite,
+			`SELECT ';'; SELECT 2`,
+			[]string{`SELECT ';'`, "SELECT 2"},
+		},
+		{
+			"doubled quote inside a literal", EnginePostgres,
+			`SELECT 'it''s; fine'; SELECT 2`,
+			[]string{`SELECT 'it''s; fine'`, "SELECT 2"},
+		},
+		{
+			"semicolon in a quoted identifier", EnginePostgres,
+			`SELECT "a;b" FROM t; SELECT 2`,
+			[]string{`SELECT "a;b" FROM t`, "SELECT 2"},
+		},
+		{
+			"semicolon in a line comment", EngineSQLite,
+			"SELECT 1 -- ; not a separator\n; SELECT 2",
+			[]string{"SELECT 1 -- ; not a separator", "SELECT 2"},
+		},
+		{
+			"semicolon in a block comment", EngineSQLite,
+			"SELECT /* ; */ 1; SELECT 2",
+			[]string{"SELECT /* ; */ 1", "SELECT 2"},
+		},
+		{
+			"mysql backtick identifier", EngineMySQL,
+			"SELECT `a;b` FROM t; SELECT 2",
+			[]string{"SELECT `a;b` FROM t", "SELECT 2"},
+		},
+		{
+			"mysql hash comment", EngineMariaDB,
+			"SELECT 1 # ; nope\n; SELECT 2",
+			[]string{"SELECT 1 # ; nope", "SELECT 2"},
+		},
+		{
+			"mysql backslash escape", EngineMySQL,
+			`SELECT 'a\'; b'; SELECT 2`,
+			[]string{`SELECT 'a\'; b'`, "SELECT 2"},
+		},
+		{
+			// Without backslash escapes the literal ends at the second
+			// quote, so the semicolon after it does separate.
+			"postgres has no backslash escape", EnginePostgres,
+			`SELECT 'a\'; SELECT 2`,
+			[]string{`SELECT 'a\'`, "SELECT 2"},
+		},
+		{
+			"postgres dollar-quoted body", EnginePostgres,
+			"CREATE FUNCTION f() RETURNS int AS $$ BEGIN; RETURN 1; END; $$ LANGUAGE plpgsql; SELECT 2",
+			[]string{
+				"CREATE FUNCTION f() RETURNS int AS $$ BEGIN; RETURN 1; END; $$ LANGUAGE plpgsql",
+				"SELECT 2",
+			},
+		},
+		{
+			"postgres positional parameters are not tags", EnginePostgres,
+			"SELECT $1; SELECT $2",
+			[]string{"SELECT $1", "SELECT $2"},
+		},
+		{
+			"unterminated literal swallows the rest", EngineSQLite,
+			"SELECT 'oops; SELECT 2",
+			[]string{"SELECT 'oops; SELECT 2"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := SplitStatements(c.engine, c.script)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Fatalf("SplitStatements() = %q, want %q", got, c.want)
+			}
+		})
+	}
+}
+
+func TestClassifyStatement(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want StatementKind
+	}{
+		{"SELECT 1", StatementRead},
+		{"  select * from t", StatementRead},
+		{"-- a comment\nSELECT 1", StatementRead},
+		{"/* lead */ SELECT 1", StatementRead},
+		{"(SELECT 1) UNION (SELECT 2)", StatementWrite}, // starts with "(" — unknown, so confirmed
+		{"WITH x AS (SELECT 1) SELECT * FROM x", StatementRead},
+		{"WITH x AS (DELETE FROM t RETURNING *) SELECT * FROM x", StatementWrite},
+		{"SHOW TABLES", StatementRead},
+		{"EXPLAIN SELECT 1", StatementRead},
+		{"DESCRIBE users", StatementRead},
+		{"VALUES (1)", StatementRead},
+		{"PRAGMA table_info(t)", StatementRead},
+		{"PRAGMA journal_mode = WAL", StatementWrite},
+		{"INSERT INTO t VALUES (1)", StatementWrite},
+		{"UPDATE t SET a = 1", StatementWrite},
+		{"DELETE FROM t", StatementWrite},
+		{"CREATE TABLE t (id int)", StatementWrite},
+		{"DROP TABLE t", StatementWrite},
+		{"-- only a comment", StatementWrite},
+	}
+	for _, c := range cases {
+		if got := ClassifyStatement(c.sql); got != c.want {
+			t.Errorf("ClassifyStatement(%q) = %v, want %v", c.sql, got, c.want)
+		}
+	}
+}
+
+func TestFirstKeyword(t *testing.T) {
+	cases := map[string]string{
+		"select * from t":       "SELECT",
+		"  /* x */ update t":    "UPDATE",
+		"DELETE FROM t":         "DELETE",
+		"insert into t values(": "INSERT",
+		"":                      "",
+	}
+	for sql, want := range cases {
+		if got := FirstKeyword(sql); got != want {
+			t.Errorf("FirstKeyword(%q) = %q, want %q", sql, got, want)
+		}
+	}
+}

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -1,0 +1,223 @@
+// Package history persists the SQL statements lazysql has executed to
+// ${XDG_STATE_HOME:-~/.local/state}/lazysql/history, so panel [4] survives
+// a restart.
+//
+// The file is JSON Lines, oldest first: one self-describing record per
+// line, appended in O(1) and readable with `tail`. A statement is stored
+// verbatim, newlines included, because the editor reloads it as typed —
+// JSON encoding is what keeps a multi-line statement on one line.
+//
+// The file is written owner-only: a statement can carry data that the
+// config file deliberately never holds.
+package history
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	// AppDir is the lazysql subdirectory under the user state home.
+	AppDir = "lazysql"
+	// FileName is the history file inside AppDir.
+	FileName = "history"
+	// MaxEntries bounds the file. Loading compacts anything above it:
+	// the history is a convenience, not an audit log, and the command
+	// log already carries the full session.
+	MaxEntries = 1000
+)
+
+// Entry is one executed statement.
+type Entry struct {
+	SQL string `json:"sql"`
+	// Engine is the engine the statement ran against ("postgres",
+	// "sqlite", …), kept because the same SQL is not portable between
+	// them and the panel annotates each entry with it.
+	Engine string    `json:"engine"`
+	At     time.Time `json:"at"`
+}
+
+// writeMu serializes writers. Appends run in tea.Cmd goroutines, so two
+// statements finishing at once would otherwise interleave their lines.
+var writeMu sync.Mutex
+
+// ---------- file location ----------
+
+// Dir returns the lazysql state directory, honouring XDG_STATE_HOME.
+func Dir() (string, error) {
+	if x := os.Getenv("XDG_STATE_HOME"); x != "" {
+		return filepath.Join(x, AppDir), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("history: locate home directory: %w", err)
+	}
+	return filepath.Join(home, ".local", "state", AppDir), nil
+}
+
+// Path returns the full path of the history file.
+func Path() (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, FileName), nil
+}
+
+// ---------- load ----------
+
+// Load reads the history newest first. A missing file is not an error:
+// a first run has no history.
+func Load() ([]Entry, error) {
+	path, err := Path()
+	if err != nil {
+		return nil, err
+	}
+	return LoadFrom(path)
+}
+
+// LoadFrom reads a history file from an explicit path and returns its
+// entries newest first. A file grown past MaxEntries is compacted on the
+// spot, which is the only moment lazysql knows it is too long; a failed
+// compaction is not reported, because the entries were read fine.
+//
+// Unparsable lines are skipped rather than failing the load: a truncated
+// last line after a crash must not cost the whole history.
+func LoadFrom(path string) ([]Entry, error) {
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("history: read %s: %w", path, err)
+	}
+	defer f.Close()
+
+	var oldestFirst []Entry
+	sc := bufio.NewScanner(f)
+	// A statement can be long; the default 64 KiB token limit is not
+	// enough for a generated INSERT.
+	sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var e Entry
+		if err := json.Unmarshal([]byte(line), &e); err != nil || strings.TrimSpace(e.SQL) == "" {
+			continue
+		}
+		oldestFirst = append(oldestFirst, e)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("history: read %s: %w", path, err)
+	}
+
+	compact := len(oldestFirst) > MaxEntries
+	if compact {
+		oldestFirst = oldestFirst[len(oldestFirst)-MaxEntries:]
+	}
+	out := make([]Entry, len(oldestFirst))
+	for i, e := range oldestFirst {
+		out[len(out)-1-i] = e
+	}
+	if compact {
+		_ = SaveTo(path, out)
+	}
+	return out, nil
+}
+
+// ---------- write ----------
+
+// Append adds one entry to the end of the history file.
+func Append(e Entry) error {
+	path, err := Path()
+	if err != nil {
+		return err
+	}
+	return AppendTo(path, e)
+}
+
+// AppendTo adds one entry to an explicit path, creating the directory
+// and the file if needed.
+func AppendTo(path string, e Entry) error {
+	line, err := json.Marshal(e)
+	if err != nil {
+		return fmt.Errorf("history: encode entry: %w", err)
+	}
+	writeMu.Lock()
+	defer writeMu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("history: create %s: %w", filepath.Dir(path), err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("history: open %s: %w", path, err)
+	}
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		f.Close()
+		return fmt.Errorf("history: write %s: %w", path, err)
+	}
+	return f.Close()
+}
+
+// Save rewrites the whole history from entries given newest first. It is
+// what a deletion and a clear go through.
+func Save(entries []Entry) error {
+	path, err := Path()
+	if err != nil {
+		return err
+	}
+	return SaveTo(path, entries)
+}
+
+// SaveTo rewrites the history at an explicit path. The write is atomic
+// (temp file + rename) so an interrupted delete cannot truncate the
+// history it was pruning.
+func SaveTo(path string, entries []Entry) error {
+	writeMu.Lock()
+	defer writeMu.Unlock()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("history: create %s: %w", filepath.Dir(path), err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".history-*")
+	if err != nil {
+		return fmt.Errorf("history: create temp file: %w", err)
+	}
+	defer os.Remove(tmp.Name())
+
+	if err := tmp.Chmod(0o600); err != nil {
+		tmp.Close()
+		return fmt.Errorf("history: chmod temp file: %w", err)
+	}
+	w := bufio.NewWriter(tmp)
+	// entries arrive newest first; the file is oldest first.
+	for i := len(entries) - 1; i >= 0; i-- {
+		line, err := json.Marshal(entries[i])
+		if err != nil {
+			tmp.Close()
+			return fmt.Errorf("history: encode entry: %w", err)
+		}
+		if _, err := w.Write(append(line, '\n')); err != nil {
+			tmp.Close()
+			return fmt.Errorf("history: write temp file: %w", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		tmp.Close()
+		return fmt.Errorf("history: write temp file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("history: close temp file: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return fmt.Errorf("history: write %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -1,0 +1,171 @@
+package history
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func tempPath(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "history")
+}
+
+func entry(sql string, min int) Entry {
+	return Entry{
+		SQL:    sql,
+		Engine: "sqlite",
+		At:     time.Date(2026, 8, 9, 12, min, 0, 0, time.UTC),
+	}
+}
+
+func TestLoadMissingFileIsEmpty(t *testing.T) {
+	got, err := LoadFrom(filepath.Join(t.TempDir(), "nope"))
+	if err != nil {
+		t.Fatalf("LoadFrom() error = %v, want nil for a missing file", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("LoadFrom() = %v, want empty", got)
+	}
+}
+
+func TestAppendThenLoadIsNewestFirst(t *testing.T) {
+	path := tempPath(t)
+	for i, sql := range []string{"SELECT 1", "SELECT 2", "SELECT 3"} {
+		if err := AppendTo(path, entry(sql, i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"SELECT 3", "SELECT 2", "SELECT 1"}
+	if len(got) != len(want) {
+		t.Fatalf("loaded %d entries, want %d", len(got), len(want))
+	}
+	for i, w := range want {
+		if got[i].SQL != w {
+			t.Errorf("entry %d = %q, want %q", i, got[i].SQL, w)
+		}
+		if got[i].Engine != "sqlite" {
+			t.Errorf("entry %d engine = %q, want the engine it ran on", i, got[i].Engine)
+		}
+		if got[i].At.IsZero() {
+			t.Errorf("entry %d lost its timestamp", i)
+		}
+	}
+}
+
+func TestMultilineStatementSurvivesRoundTrip(t *testing.T) {
+	path := tempPath(t)
+	sql := "SELECT a,\n       b\n  FROM t\n WHERE a = 'x;y'"
+	if err := AppendTo(path, entry(sql, 0)); err != nil {
+		t.Fatal(err)
+	}
+	got, err := LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].SQL != sql {
+		t.Fatalf("round trip = %#v, want the statement verbatim", got)
+	}
+}
+
+func TestSaveRewritesOldestFirst(t *testing.T) {
+	path := tempPath(t)
+	// Entries are handed over newest first, the order the model keeps.
+	if err := SaveTo(path, []Entry{entry("SELECT 2", 1), entry("SELECT 1", 0)}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 || !strings.Contains(lines[0], "SELECT 1") {
+		t.Fatalf("file = %q, want the oldest statement first", data)
+	}
+	got, err := LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].SQL != "SELECT 2" {
+		t.Fatalf("reload = %#v, want newest first", got)
+	}
+}
+
+func TestSaveIsOwnerOnly(t *testing.T) {
+	path := tempPath(t)
+	if err := SaveTo(path, []Entry{entry("SELECT 1", 0)}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("history file mode = %o, want 600 — statements can carry data", perm)
+	}
+}
+
+func TestLoadSkipsUnparsableLines(t *testing.T) {
+	path := tempPath(t)
+	if err := AppendTo(path, entry("SELECT 1", 0)); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A crash mid-write leaves a truncated last line.
+	if _, err := f.WriteString(`{"sql":"SELECT 2","eng`); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	got, err := LoadFrom(path)
+	if err != nil {
+		t.Fatalf("LoadFrom() error = %v, want the readable entries back", err)
+	}
+	if len(got) != 1 || got[0].SQL != "SELECT 1" {
+		t.Fatalf("LoadFrom() = %#v, want the one intact entry", got)
+	}
+}
+
+func TestLoadCompactsOverlongFile(t *testing.T) {
+	path := tempPath(t)
+	for i := 0; i < MaxEntries+10; i++ {
+		if err := AppendTo(path, entry("SELECT "+strings.Repeat("x", 1), i)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got, err := LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != MaxEntries {
+		t.Fatalf("loaded %d entries, want the cap of %d", len(got), MaxEntries)
+	}
+	// The compaction is written back, so the next load reads the cap.
+	again, err := LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(again) != MaxEntries {
+		t.Fatalf("reload has %d entries, want the file compacted to %d", len(again), MaxEntries)
+	}
+}
+
+func TestDirHonoursXDGStateHome(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "/tmp/state")
+	dir, err := Dir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := filepath.Join("/tmp/state", AppDir); dir != want {
+		t.Fatalf("Dir() = %q, want %q", dir, want)
+	}
+}

--- a/internal/ui/copy.go
+++ b/internal/ui/copy.go
@@ -43,7 +43,7 @@ type copiedMsg struct{ line string }
 // row under it, and the metadata tabs have no row at all.
 func (m *Model) copyMenu() tea.Cmd {
 	if !m.data.open() {
-		return logCmd("-- copy skipped: no relation open")
+		return logCmd("-- copy skipped: nothing open")
 	}
 	var entries []menuEntry
 	add := func(k, label string, id actionID) {
@@ -60,16 +60,24 @@ func (m *Model) copyMenu() tea.Cmd {
 		add("c", "cell — raw value", actCopyCell)
 		add("r", "row — CSV line", actCopyRowCSV)
 		add("o", "row — JSON object", actCopyRowJSON)
-		add("i", "row — INSERT statement", actCopyRowInsert)
+		// An INSERT needs a table to insert into, which a free-form
+		// result set does not have.
+		if m.data.browsing() {
+			add("i", "row — INSERT statement", actCopyRowInsert)
+		}
 	}
-	add("C", "table — CSV", actCopyTableCSV)
-	add("O", "table — JSON array", actCopyTableJSON)
-	add("I", "table — INSERT statements", actCopyTableInsert)
-	add("A", "table — CREATE TABLE + INSERTs", actCopyTableSchema)
-	add("d", "DDL statement", actCopyDDL)
+	// The table scopes re-read the relation through the server; a query
+	// result has no relation behind it, only the rows already on screen.
+	if m.data.browsing() {
+		add("C", "table — CSV", actCopyTableCSV)
+		add("O", "table — JSON array", actCopyTableJSON)
+		add("I", "table — INSERT statements", actCopyTableInsert)
+		add("A", "table — CREATE TABLE + INSERTs", actCopyTableSchema)
+		add("d", "DDL statement", actCopyDDL)
+	}
 	entries = append(entries, menuEntry{key: "esc", label: "cancel"})
 
-	m.modal = &menuModal{title: "Copy — " + m.data.table, entries: entries}
+	m.modal = &menuModal{title: "Copy — " + m.dataSubject(), entries: entries}
 	return nil
 }
 
@@ -122,12 +130,12 @@ func (m Model) copyCell() tea.Cmd {
 	}
 	name := m.data.cols[m.data.col].Name
 	v := values[m.data.col]
-	subject := fmt.Sprintf("cell %s.%s", m.data.table, name)
+	subject := fmt.Sprintf("cell %s.%s", m.dataSubject(), name)
 	if v == nil {
 		subject += " (NULL → empty)"
 	}
 	text := db.FormatValue(v, "")
-	return copyTextCmd(subject, m.data.table+"-"+name+".txt", text)
+	return copyTextCmd(subject, m.dataSubject()+"-"+name+".txt", text)
 }
 
 // copyRow copies the row under the cursor in one of the three row
@@ -142,10 +150,20 @@ func (m Model) copyRow(f export.Format) tea.Cmd {
 		return logCmd("-- copy row FAILED: %v", err)
 	}
 	return copyTextCmd(
-		fmt.Sprintf("row of %s as %s", m.data.table, strings.ToUpper(string(f))),
-		fmt.Sprintf("%s-row.%s", m.data.table, f),
+		fmt.Sprintf("row of %s as %s", m.dataSubject(), strings.ToUpper(string(f))),
+		fmt.Sprintf("%s-row.%s", m.dataSubject(), f),
 		text,
 	)
+}
+
+// dataSubject names what the Data tab is showing, for log lines, copy
+// labels and file names: the open relation, or "query" for a result the
+// editor produced.
+func (m Model) dataSubject() string {
+	if m.data.browsing() {
+		return m.data.table
+	}
+	return "query"
 }
 
 // exportOptions is what the serializers need about the open relation.
@@ -173,7 +191,7 @@ func copyTextCmd(subject, filename, text string) tea.Cmd {
 // so the cap is what keeps `y` from trying to hold a 100k-row table in
 // memory. Reaching it is reported, never silent.
 func (m *Model) copyTable(f export.Format, withDDL bool) tea.Cmd {
-	if !m.data.open() {
+	if !m.data.browsing() {
 		return logCmd("-- copy table skipped: no relation open")
 	}
 	if m.driver == nil {

--- a/internal/ui/data.go
+++ b/internal/ui/data.go
@@ -22,7 +22,8 @@ const dataPageSize = 100
 const queryTimeout = 30 * time.Second
 
 // dataView is the state of the main view's Data tab: one page of one
-// relation plus everything that shaped the query behind it.
+// relation, or one result of the query editor, plus everything that
+// shaped the query behind it.
 //
 // The cell cursor (row, col) is deliberately part of this state rather
 // than of the renderer: inline editing reuses it.
@@ -32,6 +33,22 @@ type dataView struct {
 	conn     string
 	database string
 	table    string
+
+	// query is the statement behind the page when the tab is showing a
+	// query-editor result instead of a relation; table is then empty.
+	// The two are mutually exclusive, which is what tells every
+	// table-only action (edit, insert, export, introspection) that it
+	// has nothing to work on.
+	query string
+	// all holds every row a query returned. A table page comes from the
+	// server one page at a time, but a free-form result cannot be
+	// re-queried by offset, so it is materialized once and paged here.
+	all [][]any
+	// truncated marks a result the row cap cut short.
+	truncated bool
+	// notice replaces the grid for a statement that returned no result
+	// set, e.g. "UPDATE — 3 rows affected".
+	notice string
 
 	cols []db.Column
 	rows [][]any
@@ -65,8 +82,36 @@ type dataView struct {
 	req int
 }
 
-// open reports whether a relation is being browsed at all.
-func (d dataView) open() bool { return d.table != "" }
+// open reports whether the Data tab has anything to show — a browsed
+// relation or a query result.
+func (d dataView) open() bool { return d.table != "" || d.query != "" || d.notice != "" }
+
+// browsing reports whether the page belongs to a relation. Everything
+// that needs a table to act on — editing, staging, introspection,
+// export, server-side filter and sort — asks this rather than open().
+func (d dataView) browsing() bool { return d.table != "" }
+
+// isQuery reports whether the page is a materialized query result.
+func (d dataView) isQuery() bool { return d.query != "" }
+
+// setPage cuts page p out of a materialized query result. Table pages
+// come from the server instead and never go through here.
+func (d *dataView) setPage(p int) {
+	if p < 0 {
+		p = 0
+	}
+	d.page = p
+	start := p * dataPageSize
+	if start > len(d.all) {
+		start = len(d.all)
+	}
+	end := start + dataPageSize
+	if end > len(d.all) {
+		end = len(d.all)
+	}
+	d.rows = d.all[start:end]
+	d.row = 0
+}
 
 // offset is the row offset of the current page in the full result.
 func (d dataView) offset() int { return d.page * dataPageSize }
@@ -198,7 +243,7 @@ func (m *Model) openTable(name string) tea.Cmd {
 // reloadPage re-runs the page query and the count for the current
 // filter/sort/page, and logs the exact SQL both of them execute.
 func (m *Model) reloadPage() tea.Cmd {
-	if m.driver == nil || !m.data.open() {
+	if m.driver == nil || !m.data.browsing() {
 		return nil
 	}
 	m.data.req++
@@ -220,7 +265,7 @@ func (m *Model) reloadPage() tea.Cmd {
 	cmds = append(cmds,
 		logCmd("%s", sqlLogLine(pageSQL, d.filter)),
 		logCmd("%s", sqlLogLine(countSQL, d.filter)),
-		func() tea.Msg { return historyEntryMsg{statement: pageSQL + ";"} },
+		historyCmd(pageSQL),
 		loadPageCmd(m.driver, d, m.data.req),
 		countRowsCmd(m.driver, d, m.data.req),
 	)
@@ -244,7 +289,7 @@ func (m Model) fresh(req int, conn, table string) bool {
 // setDataFilter applies a new WHERE fragment and returns to page one.
 // An empty fragment clears the filter.
 func (m *Model) setDataFilter(raw string) tea.Cmd {
-	if !m.data.open() || m.driver == nil {
+	if !m.data.browsing() || m.driver == nil {
 		return nil
 	}
 	m.data.filter = db.ParseFilter(m.driver.Dialect(), raw)
@@ -256,7 +301,7 @@ func (m *Model) setDataFilter(raw string) tea.Cmd {
 // toggleSort cycles the column under the cursor through ASC, DESC and
 // unsorted. The filter is untouched, so the two compose.
 func (m *Model) toggleSort() tea.Cmd {
-	if !m.data.open() || m.data.col >= len(m.data.cols) {
+	if !m.data.browsing() || m.data.col >= len(m.data.cols) {
 		return nil
 	}
 	name := m.data.cols[m.data.col].Name
@@ -282,6 +327,19 @@ func (m *Model) turnPage(delta int) tea.Cmd {
 	}
 	next := m.data.page + delta
 	if next < 0 {
+		return nil
+	}
+	// A query result is already in memory: paging it is a slice, not a
+	// round trip.
+	if m.data.isQuery() {
+		if next > m.data.page && next*dataPageSize >= len(m.data.all) {
+			return logCmd("-- already on the last page")
+		}
+		if next == m.data.page {
+			return nil
+		}
+		m.data.setPage(next)
+		m.clampCursor()
 		return nil
 	}
 	if next > m.data.page {
@@ -328,6 +386,10 @@ func (m Model) updateData(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// data.
 		if m.tab.metadata() {
 			cmd := m.reloadMeta()
+			return m, cmd
+		}
+		if m.data.isQuery() {
+			cmd := m.rerunQuery()
 			return m, cmd
 		}
 		cmd := m.reloadPage()

--- a/internal/ui/datagrid.go
+++ b/internal/ui/datagrid.go
@@ -225,6 +225,10 @@ func (m Model) dataContent(w, h int) string {
 		lines = append(lines, "", m.style.pending.Render("running query…"))
 	case d.err != "":
 		lines = append(lines, "", m.style.danger.Render(truncate(d.err, w)))
+	case len(d.cols) == 0 && d.notice != "":
+		// A statement that returns no result set: the affected-row
+		// count is the whole outcome.
+		lines = append(lines, "", m.style.pending.Render(truncate(d.notice, w)))
 	case len(d.cols) == 0:
 		lines = append(lines, "", m.style.muted.Render("no columns"))
 	default:
@@ -329,6 +333,10 @@ func (m Model) dataStatus() string {
 	d := m.data
 	var parts []string
 
+	if d.notice != "" && len(d.cols) == 0 {
+		return m.style.pending.Render(d.notice)
+	}
+
 	switch {
 	case len(d.rows) == 0 && d.hasTotal && d.total == 0:
 		parts = append(parts, "rows 0 of 0")
@@ -337,7 +345,14 @@ func (m Model) dataStatus() string {
 	default:
 		span := fmt.Sprintf("rows %d–%d", d.offset()+1, d.offset()+len(d.rows))
 		if d.hasTotal {
-			span += fmt.Sprintf(" of ~%d", d.total)
+			// A browsed table's total is a separate COUNT(*) round trip
+			// that may already be stale; a query result is fully in
+			// memory, so its total is exact.
+			if d.isQuery() {
+				span += fmt.Sprintf(" of %d", d.total)
+			} else {
+				span += fmt.Sprintf(" of ~%d", d.total)
+			}
 		}
 		parts = append(parts, span)
 	}
@@ -348,6 +363,11 @@ func (m Model) dataStatus() string {
 	parts = append(parts, page+")")
 
 	line := m.style.muted.Render(strings.Join(parts, " "))
+	if d.truncated {
+		// A capped result looks exactly like a complete one, so the
+		// status line has to say it is not.
+		line += m.style.danger.Render(fmt.Sprintf("  capped at %d rows", maxQueryRows))
+	}
 	if n := m.changes.Len(); n > 0 {
 		line += m.style.pending.Render("  " + countChanges(n))
 	}

--- a/internal/ui/edit.go
+++ b/internal/ui/edit.go
@@ -46,7 +46,7 @@ func commitChangesCmd(drv db.Driver, stmts []db.Statement) tea.Cmd {
 // cached metadata; when no tab has fetched it yet the fetch is started
 // and the modal opens when the reply lands, like `y` does for the DDL.
 func (m *Model) startEdit() tea.Cmd {
-	if !m.data.open() || m.tab.metadata() || m.driver == nil {
+	if !m.data.browsing() || m.tab.metadata() || m.driver == nil {
 		return nil
 	}
 	if m.onPhantomRow() {
@@ -176,7 +176,7 @@ func (m *Model) stageChange(c db.CellChange) tea.Cmd {
 // the row-level operations come first because on those rows there is no
 // cell change to remove anyway.
 func (m *Model) unstageAtCursor() tea.Cmd {
-	if !m.data.open() || m.tab.metadata() {
+	if !m.data.browsing() || m.tab.metadata() {
 		return nil
 	}
 	if ins, ok := m.phantomAtCursor(); ok {

--- a/internal/ui/export.go
+++ b/internal/ui/export.go
@@ -68,7 +68,7 @@ type exportDoneMsg struct {
 // pre-filled with a plausible name so the common case is one keystroke
 // plus enter.
 func (m *Model) startExport() tea.Cmd {
-	if !m.data.open() {
+	if !m.data.browsing() {
 		return logCmd("-- export skipped: no relation open")
 	}
 	if m.driver == nil {
@@ -113,7 +113,7 @@ func (m *Model) runExport(path string) tea.Cmd {
 	if err != nil {
 		return logCmd("-- export %s FAILED: %v", full, err)
 	}
-	if !m.data.open() || m.driver == nil {
+	if !m.data.browsing() || m.driver == nil {
 		return logCmd("-- export skipped: nothing open")
 	}
 

--- a/internal/ui/history.go
+++ b/internal/ui/history.go
@@ -1,0 +1,191 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/history"
+)
+
+// Panel [4] Query history is the on-disk history rendered newest first.
+// Every statement lazysql executes — a browsing page, a committed
+// changeset, a script from the editor — lands here through
+// historyEntryMsg, so the panel is a record of the session and of every
+// session before it.
+//
+// The model keeps the entries themselves and derives the panel's rows
+// from them: the panel is a list of strings, but `enter` has to reload
+// the statement exactly as it was typed, newlines included.
+
+// ---------- messages ----------
+
+// historyLoadedMsg carries the history read at startup.
+type historyLoadedMsg struct {
+	entries []history.Entry
+	err     error
+}
+
+// historyWrittenMsg reports a failed history write. A successful one
+// says nothing: the panel already shows the entry.
+type historyWrittenMsg struct{ err error }
+
+// ---------- commands ----------
+
+func loadHistoryCmd() tea.Cmd {
+	return func() tea.Msg {
+		entries, err := history.Load()
+		return historyLoadedMsg{entries: entries, err: err}
+	}
+}
+
+func appendHistoryCmd(e history.Entry) tea.Cmd {
+	return func() tea.Msg { return historyWrittenMsg{err: history.Append(e)} }
+}
+
+// saveHistoryCmd rewrites the file after a delete or a clear. entries
+// are newest first, the order the model holds them in.
+func saveHistoryCmd(entries []history.Entry) tea.Cmd {
+	saved := append([]history.Entry(nil), entries...)
+	return func() tea.Msg { return historyWrittenMsg{err: history.Save(saved)} }
+}
+
+// ---------- model wiring ----------
+
+// recordHistory adds one executed statement to the front of the history
+// and persists it. Re-running the newest entry does not duplicate it:
+// `enter` on the history panel would otherwise grow the list by one on
+// every replay, and the timestamp is the only thing that would differ.
+func (m *Model) recordHistory(sql string) tea.Cmd {
+	sql = trimStatement(sql)
+	if sql == "" {
+		return nil
+	}
+	engine := ""
+	if m.driver != nil {
+		engine = string(m.driver.Engine())
+	}
+	if len(m.history) > 0 && m.history[0].SQL == sql && m.history[0].Engine == engine {
+		return nil
+	}
+	e := history.Entry{SQL: sql, Engine: engine, At: time.Now()}
+	m.history = append([]history.Entry{e}, m.history...)
+	if len(m.history) > history.MaxEntries {
+		m.history = m.history[:history.MaxEntries]
+	}
+	m.refreshHistory()
+	return appendHistoryCmd(e)
+}
+
+// refreshHistory repaints panel [4] from m.history, keeping the cursor
+// on the entry it was on when that entry is still there.
+func (m *Model) refreshHistory() {
+	p := m.panels[panelHistory]
+	labels := make([]string, len(m.history))
+	for i, e := range m.history {
+		labels[i] = historyLabel(e)
+	}
+	// A new entry goes to the front, so index-based restoration would
+	// drift; setItems restores by name, which is what the panel already
+	// does everywhere else.
+	p.setItems(labels)
+}
+
+// historyLabel is one row of the panel: when it ran, then the statement
+// on one line. The engine is deliberately not in the row — the side
+// column is narrow and the statement is what the eye scans for — it is
+// in the main view's detail for the selected entry instead.
+func historyLabel(e history.Entry) string {
+	return e.At.Local().Format("15:04") + "  " + flatten(e.SQL)
+}
+
+// selectedHistory returns the entry under the cursor of panel [4]. The
+// panel indexes into its filtered rows, so the position is translated
+// back through the filter rather than matched by text: two runs of the
+// same statement produce the same row.
+func (m Model) selectedHistory() (history.Entry, bool) {
+	i := m.panels[panelHistory].sourceIndex(m.panels[panelHistory].cursor)
+	if i < 0 || i >= len(m.history) {
+		return history.Entry{}, false
+	}
+	return m.history[i], true
+}
+
+// deleteHistoryEntry is `d` on panel [4]. One line is cheap to lose and
+// cheap to recreate, so it goes without a confirmation; `D` clears the
+// whole history and does ask.
+func (m *Model) deleteHistoryEntry() tea.Cmd {
+	p := m.panels[panelHistory]
+	i := p.sourceIndex(p.cursor)
+	if i < 0 || i >= len(m.history) {
+		return logCmd("-- no history entry under the cursor")
+	}
+	e := m.history[i]
+	row := p.cursor
+	m.history = append(m.history[:i:i], m.history[i+1:]...)
+	m.refreshHistory()
+	// setItems restores the selection by name, and the name just went
+	// away; deleting a run of entries should walk down the list rather
+	// than jump back to the top after every keystroke.
+	p.cursor = row
+	p.move(0)
+	return tea.Batch(
+		saveHistoryCmd(m.history),
+		logCmd("-- delete history entry: %s", truncate(flatten(e.SQL), 60)),
+	)
+}
+
+// clearHistory is `D`: drop every entry, on disk too.
+func (m *Model) clearHistory() tea.Cmd {
+	n := len(m.history)
+	m.history = nil
+	m.panels[panelHistory].clearFilter()
+	m.refreshHistory()
+	return tea.Batch(
+		saveHistoryCmd(nil),
+		logCmd("-- clear query history (%d entries)", n),
+	)
+}
+
+// historyDetail is the main view while panel [4] is focused: the
+// selected statement in full, with the engine and timestamp the row has
+// no room for.
+func (m Model) historyDetail(w, h int) string {
+	lines := []string{
+		m.style.titleFocused.Render(panelTitles[panelHistory]) + m.style.muted.Render(" — main view"),
+		"",
+	}
+	e, ok := m.selectedHistory()
+	if !ok {
+		lines = append(lines, m.style.muted.Render(
+			"no history yet — press : to open the query editor"))
+		return joinTruncated(lines, w, h)
+	}
+	engine := e.Engine
+	if engine == "" {
+		engine = "(unknown)"
+	}
+	lines = append(lines,
+		"engine  "+engine,
+		"ran at  "+e.At.Local().Format(time.RFC1123),
+		fmt.Sprintf("entry   %d of %d", m.panels[panelHistory].cursor+1, len(m.history)),
+		"",
+	)
+	lines = append(lines, strings.Split(e.SQL, "\n")...)
+	lines = append(lines, "",
+		m.style.muted.Render("enter loads it into the editor · x runs it · d deletes it"))
+	return joinTruncated(lines, w, h)
+}
+
+// trimStatement normalizes a statement before it is stored: trailing
+// whitespace and a trailing `;` are noise the editor re-adds anyway, and
+// keeping them would make the same statement look like two entries.
+func trimStatement(sql string) string {
+	s := strings.TrimSpace(sql)
+	for strings.HasSuffix(s, ";") {
+		s = strings.TrimSpace(strings.TrimSuffix(s, ";"))
+	}
+	return s
+}

--- a/internal/ui/history_test.go
+++ b/internal/ui/history_test.go
@@ -1,0 +1,195 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/history"
+)
+
+// withHistory returns a model whose panel [4] holds three entries and is
+// focused, with its own history file so the assertions are not disturbed
+// by what other tests recorded.
+func withHistory(t *testing.T) Model {
+	t.Helper()
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+
+	m := sized(120, 40)
+	at := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	m.history = []history.Entry{
+		{SQL: "SELECT 3", Engine: "sqlite", At: at.Add(2 * time.Minute)},
+		{SQL: "UPDATE t SET a = 1", Engine: "postgres", At: at.Add(time.Minute)},
+		{SQL: "SELECT 1", Engine: "sqlite", At: at},
+	}
+	m.refreshHistory()
+	return send(t, m, press('4'))
+}
+
+func TestHistoryPanelListsNewestFirst(t *testing.T) {
+	m := withHistory(t)
+	items := m.panels[panelHistory].items
+	if len(items) != 3 {
+		t.Fatalf("panel has %d rows, want 3", len(items))
+	}
+	if !strings.Contains(items[0], "SELECT 3") || !strings.Contains(items[2], "SELECT 1") {
+		t.Fatalf("rows = %q, want newest first", items)
+	}
+}
+
+func TestHistoryEnterLoadsIntoTheEditor(t *testing.T) {
+	m := withHistory(t)
+	m = send(t, m, press('j'), special(tea.KeyEnter, 0))
+	qm, ok := m.modal.(*queryModal)
+	if !ok {
+		t.Fatalf("enter opened %T, want the query editor", m.modal)
+	}
+	if qm.area.Value() != "UPDATE t SET a = 1" {
+		t.Fatalf("editor holds %q, want the selected entry", qm.area.Value())
+	}
+	if m.draft != "UPDATE t SET a = 1" {
+		t.Fatalf("draft = %q, want the loaded statement", m.draft)
+	}
+	// Loading is not running.
+	if logContains(m, "rows affected") {
+		t.Fatalf("enter executed the statement: %v", m.commandLog)
+	}
+}
+
+func TestHistoryDeleteRemovesOneEntryAndPersists(t *testing.T) {
+	m := withHistory(t)
+	m = send(t, m, press('j'), press('d'))
+
+	if len(m.history) != 2 {
+		t.Fatalf("history = %#v, want the middle entry gone", m.history)
+	}
+	for _, e := range m.history {
+		if e.SQL == "UPDATE t SET a = 1" {
+			t.Fatalf("the deleted entry is still there: %#v", m.history)
+		}
+	}
+	// The cursor walks down the list rather than snapping back to the top.
+	if m.panels[panelHistory].cursor != 1 {
+		t.Fatalf("cursor = %d, want to stay where the deleted row was",
+			m.panels[panelHistory].cursor)
+	}
+	path, err := history.Path()
+	if err != nil {
+		t.Fatal(err)
+	}
+	saved, err := history.LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(saved) != 2 {
+		t.Fatalf("the file holds %d entries, want the delete written through", len(saved))
+	}
+}
+
+func TestHistoryClearAsksAndEmptiesTheFile(t *testing.T) {
+	m := withHistory(t)
+	m = send(t, m, press('D'))
+	if _, ok := m.modal.(*confirmModal); !ok {
+		t.Fatalf("D opened %T, want a confirm modal", m.modal)
+	}
+	if len(m.history) != 3 {
+		t.Fatal("D cleared the history before it was confirmed")
+	}
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if len(m.history) != 0 || len(m.panels[panelHistory].items) != 0 {
+		t.Fatalf("history = %#v, want it empty", m.history)
+	}
+	path, err := history.Path()
+	if err != nil {
+		t.Fatal(err)
+	}
+	saved, err := history.LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(saved) != 0 {
+		t.Fatalf("the file still holds %d entries", len(saved))
+	}
+}
+
+func TestHistoryFuzzyFilterAndDeleteAgree(t *testing.T) {
+	m := withHistory(t)
+	m = send(t, m, press('/'), press('u'), press('p'), press('d'))
+	items := m.panels[panelHistory].items
+	if len(items) != 1 || !strings.Contains(items[0], "UPDATE") {
+		t.Fatalf("filtered rows = %q, want only the UPDATE", items)
+	}
+	// enter leaves `/` input mode and keeps the narrowing, so `d` acts on
+	// the filtered row and not on the one at that index in the full list.
+	m = send(t, m, special(tea.KeyEnter, 0))
+	m = send(t, m, press('d'))
+	if len(m.history) != 2 {
+		t.Fatalf("history = %#v, want one entry deleted", m.history)
+	}
+	for _, e := range m.history {
+		if strings.HasPrefix(e.SQL, "UPDATE") {
+			t.Fatalf("d deleted the wrong entry through the filter: %#v", m.history)
+		}
+	}
+}
+
+func TestHistoryPersistsAcrossRestart(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
+
+	m := sized(120, 40)
+	m = send(t, m, historyEntryMsg{statement: "SELECT persisted"})
+	if len(m.history) != 1 {
+		t.Fatalf("history = %#v, want the recorded statement", m.history)
+	}
+
+	// A fresh model loads it back through Init, the way a restart does.
+	next := sized(120, 40)
+	next = send(t, next, drainInit(t, next)...)
+	if len(next.history) != 1 || next.history[0].SQL != "SELECT persisted" {
+		t.Fatalf("reloaded history = %#v, want the statement from the previous run", next.history)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// drainInit runs Init and returns the messages it produced.
+func drainInit(t *testing.T, m Model) []tea.Msg {
+	t.Helper()
+	return drain(m.Init())
+}
+
+func TestHistoryDetailShowsEngineAndTimestamp(t *testing.T) {
+	m := withHistory(t)
+	m = send(t, m, press('j'))
+	out := m.historyDetail(80, 20)
+	if !strings.Contains(out, "postgres") {
+		t.Fatalf("detail is missing the engine:\n%s", out)
+	}
+	if !strings.Contains(out, "UPDATE t SET a = 1") {
+		t.Fatalf("detail is missing the statement:\n%s", out)
+	}
+	if !strings.Contains(out, "2026") {
+		t.Fatalf("detail is missing the timestamp:\n%s", out)
+	}
+}
+
+func TestTrimStatement(t *testing.T) {
+	cases := map[string]string{
+		"SELECT 1;":        "SELECT 1",
+		"  SELECT 1 ;; ":   "SELECT 1",
+		"SELECT 1":         "SELECT 1",
+		"SELECT ';'":       "SELECT ';'",
+		"   ":              "",
+		"SELECT a\nFROM t": "SELECT a\nFROM t",
+	}
+	for in, want := range cases {
+		if got := trimStatement(in); got != want {
+			t.Errorf("trimStatement(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -20,8 +20,12 @@ type keyMap struct {
 	// Screen modes and app-level keys.
 	ScreenNext key.Binding
 	ScreenPrev key.Binding
-	Help       key.Binding
-	Quit       key.Binding
+	OpenEditor key.Binding
+	// CancelQuery is only meaningful while a query runs and is enabled
+	// only then, so `ctrl+c` keeps meaning quit the rest of the time.
+	CancelQuery key.Binding
+	Help        key.Binding
+	Quit        key.Binding
 
 	// Context actions, keyed by panel.
 	NewConnection  key.Binding
@@ -33,7 +37,9 @@ type keyMap struct {
 	Actions        key.Binding
 	Filter         key.Binding
 	ToggleTab      key.Binding
+	LoadQuery      key.Binding
 	RunQuery       key.Binding
+	DeleteHistory  key.Binding
 	ClearHistory   key.Binding
 
 	// Data grid (the focusable main view).
@@ -77,8 +83,11 @@ func newKeyMap() keyMap {
 
 		ScreenNext: key.NewBinding(key.WithKeys("+"), key.WithHelp("+", "next screen mode")),
 		ScreenPrev: key.NewBinding(key.WithKeys("_"), key.WithHelp("_", "prev screen mode")),
-		Help:       key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
-		Quit:       key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
+		OpenEditor: key.NewBinding(key.WithKeys(":"), key.WithHelp(":", "query editor")),
+		CancelQuery: key.NewBinding(
+			key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "cancel query"), key.WithDisabled()),
+		Help: key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+		Quit: key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
 
 		NewConnection:  key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new connection")),
 		EditConnection: key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit connection")),
@@ -89,7 +98,9 @@ func newKeyMap() keyMap {
 		Actions:        key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "actions")),
 		Filter:         key.NewBinding(key.WithKeys("/"), key.WithHelp("/", "fuzzy filter")),
 		ToggleTab:      key.NewBinding(key.WithKeys("[", "]"), key.WithHelp("[/]", "tables/views")),
+		LoadQuery:      key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "load into editor")),
 		RunQuery:       key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "run query")),
+		DeleteHistory:  key.NewBinding(key.WithKeys("d"), key.WithHelp("d", "delete entry")),
 		ClearHistory:   key.NewBinding(key.WithKeys("D"), key.WithHelp("D", "clear history")),
 
 		ColLeft:     key.NewBinding(key.WithKeys("h", "left"), key.WithHelp("h/←", "prev column")),
@@ -127,7 +138,10 @@ func (k keyMap) navigation() []key.Binding {
 
 // global returns the bindings handled by the root model.
 func (k keyMap) global() []key.Binding {
-	return []key.Binding{k.Jump, k.NextPanel, k.PrevPanel, k.ScreenNext, k.ScreenPrev, k.Help, k.Quit}
+	return []key.Binding{
+		k.Jump, k.NextPanel, k.PrevPanel, k.ScreenNext, k.ScreenPrev,
+		k.OpenEditor, k.CancelQuery, k.Help, k.Quit,
+	}
 }
 
 // actionID names a context action so that a key press and the `a` actions
@@ -146,7 +160,9 @@ const (
 	actRefresh
 	actFilter
 	actToggleTab
+	actLoadQuery
 	actRunQuery
+	actDeleteHistory
 	actClearHistory
 	actColLeft
 	actColRight
@@ -213,8 +229,11 @@ func (k keyMap) panelActions(id panelID) []action {
 		}
 	case panelHistory:
 		return []action{
+			{actLoadQuery, k.LoadQuery},
 			{actRunQuery, k.RunQuery},
+			{actDeleteHistory, k.DeleteHistory},
 			{actClearHistory, k.ClearHistory},
+			{actFilter, k.Filter},
 		}
 	case panelMain:
 		return []action{
@@ -261,7 +280,7 @@ func (k keyMap) actions(id panelID) []key.Binding {
 // panel's own actions first, then the most useful universal keys.
 func (k keyMap) optionsBarBindings(id panelID) []key.Binding {
 	out := append([]key.Binding{}, k.actions(id)...)
-	return append(out, k.Jump, k.NextPanel, k.Help, k.Quit)
+	return append(out, k.Jump, k.NextPanel, k.OpenEditor, k.CancelQuery, k.Help, k.Quit)
 }
 
 // helpGroups is the full `?` listing for the focused panel, drawn from the

--- a/internal/ui/meta.go
+++ b/internal/ui/meta.go
@@ -134,7 +134,7 @@ func (m *Model) resetMeta() {
 // and nothing has loaded it yet. It is a no-op on the Data tab, on an
 // in-flight load and on already-loaded metadata.
 func (m *Model) ensureMeta() tea.Cmd {
-	if !m.tab.metadata() || m.driver == nil || !m.data.open() {
+	if !m.tab.metadata() || m.driver == nil || !m.data.browsing() {
 		return nil
 	}
 	if m.meta.loaded || m.meta.loading {
@@ -146,7 +146,7 @@ func (m *Model) ensureMeta() tea.Cmd {
 // startMetaLoad fires the fetch unconditionally. Callers decide whether
 // the cache made it unnecessary.
 func (m *Model) startMetaLoad() tea.Cmd {
-	if m.driver == nil || !m.data.open() {
+	if m.driver == nil || !m.data.browsing() {
 		return nil
 	}
 	m.meta.req++
@@ -176,6 +176,12 @@ func (m Model) freshMeta(msg metaLoadedMsg) bool {
 
 // setMainTab switches tabs and loads the metadata the new one needs.
 func (m *Model) setMainTab(t mainTab) tea.Cmd {
+	// The three introspection tabs describe a relation. A query result
+	// has none, so there is nothing to cycle to.
+	if m.data.isQuery() {
+		m.tab = mainTabData
+		return nil
+	}
 	m.tab = (t + mainTabCount) % mainTabCount
 	return m.ensureMeta()
 }
@@ -200,7 +206,7 @@ func (m Model) metaActions(id actionID) (Model, tea.Cmd, bool) {
 // copyDDL copies the open relation's DDL, fetching it first when no tab
 // has needed it yet.
 func (m *Model) copyDDL() tea.Cmd {
-	if !m.data.open() {
+	if !m.data.browsing() {
 		return logCmd("-- copy DDL skipped: no relation open")
 	}
 	if m.meta.loaded {

--- a/internal/ui/metaview.go
+++ b/internal/ui/metaview.go
@@ -30,7 +30,13 @@ func (m Model) mainTabBar(w int) string {
 	line := m.style.muted.Render("‹") +
 		strings.Join(parts, m.style.muted.Render("|")) +
 		m.style.muted.Render("›")
-	line += m.style.muted.Render(" "+displayDatabase(m.data.database)+".") + m.data.table
+	if m.data.isQuery() {
+		// A query result belongs to no relation, so the bar names the
+		// statement instead of a table.
+		line += m.style.muted.Render(" query ") + truncate(flatten(m.data.query), maxInt(w/2, 20))
+	} else {
+		line += m.style.muted.Render(" "+displayDatabase(m.data.database)+".") + m.data.table
+	}
 	if m.tab == mainTabData && m.data.loading || m.tab.metadata() && m.meta.loading {
 		line += " " + m.style.pending.Render("loading…")
 	}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -10,6 +10,7 @@ import (
 
 	"lazysql/internal/config"
 	"lazysql/internal/db"
+	"lazysql/internal/history"
 )
 
 // Minimum usable terminal. Below this the layout math produces negative
@@ -52,8 +53,17 @@ func focusCmd(id panelID) tea.Cmd {
 	return func() tea.Msg { return focusPanelMsg{id: id} }
 }
 
-// historyEntryMsg records a statement in the query history panel.
+// historyEntryMsg records a statement in the query history: panel [4]
+// and the on-disk history behind it. Everything lazysql executes emits
+// one — a browsing page, a committed changeset, a script from the
+// editor — so there is a single way into the history.
 type historyEntryMsg struct{ statement string }
+
+// historyCmd is the message as a command, for callers that only build
+// tea.Cmds.
+func historyCmd(statement string) tea.Cmd {
+	return func() tea.Msg { return historyEntryMsg{statement: statement} }
+}
 
 // ---------- root model ----------
 
@@ -104,6 +114,13 @@ type Model struct {
 	// a time; `X` cancels it.
 	export exportState
 
+	// history is the persistent query history behind panel [4], newest
+	// first. draft is the query editor's text, kept across closes, and
+	// run is the script currently executing, if any.
+	history []history.Entry
+	draft   string
+	run     queryRun
+
 	startupErr string
 
 	keys  keyMap
@@ -139,10 +156,11 @@ func New() Model {
 }
 
 func (m Model) Init() tea.Cmd {
+	cmds := []tea.Cmd{loadHistoryCmd()}
 	if m.startupErr != "" {
-		return logCmd("-- config error: %s", m.startupErr)
+		cmds = append(cmds, logCmd("-- config error: %s", m.startupErr))
 	}
-	return nil
+	return tea.Batch(cmds...)
 }
 
 // refreshConnections rebuilds the [1] Connections panel from the config plus
@@ -196,6 +214,10 @@ func (m *Model) resetBrowse() {
 	// An export reads through the driver that is about to be closed.
 	if m.export.running && m.export.cancel != nil {
 		m.export.cancel()
+	}
+	// So does a running script.
+	if m.run.running && m.run.cancel != nil {
+		m.run.cancel()
 	}
 	m.database = ""
 	m.table = ""
@@ -267,6 +289,9 @@ func (m *Model) reloadFocused() tea.Cmd {
 		if m.tab.metadata() {
 			return m.reloadMeta()
 		}
+		if m.data.isQuery() {
+			return m.rerunQuery()
+		}
 		return m.reloadPage()
 	}
 	return logCmd("-- refresh %s", panelTitles[m.focus])
@@ -305,9 +330,40 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case historyEntryMsg:
-		h := m.panels[panelHistory]
-		h.setItems(append(h.items, msg.statement))
+		cmd := m.recordHistory(msg.statement)
+		return m, cmd
+
+	case historyLoadedMsg:
+		if msg.err != nil {
+			// A broken history file costs the panel its contents and
+			// nothing else; the session keeps recording into it.
+			return m, logCmd("-- read query history FAILED: %v", msg.err)
+		}
+		m.history = msg.entries
+		m.refreshHistory()
 		return m, nil
+
+	case historyWrittenMsg:
+		if msg.err != nil {
+			return m, logCmd("-- write query history FAILED: %v", msg.err)
+		}
+		return m, nil
+
+	case queryStmtMsg:
+		if msg.id != m.run.id || !m.run.running {
+			return m, nil
+		}
+		// Bind the command first: applyQueryStmt mutates m, and Go may
+		// otherwise copy the pre-call model into the return value.
+		cmd := m.applyQueryStmt(msg)
+		return m, tea.Batch(cmd, waitQueryCmd(m.run.ch))
+
+	case queryDoneMsg:
+		if msg.id != m.run.id {
+			return m, nil
+		}
+		cmd := m.finishQuery(msg)
+		return m, cmd
 
 	case focusPanelMsg:
 		m.setFocus(msg.id)
@@ -449,7 +505,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			stmt := s
 			cmds = append(cmds,
 				logCmd("%s;  -- args %v", stmt.SQL, stmt.Args),
-				func() tea.Msg { return historyEntryMsg{statement: stmt.SQL + ";"} },
+				historyCmd(stmt.SQL),
 			)
 		}
 		m.changes.Clear()
@@ -521,6 +577,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m Model) updateGlobal(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
 	k := m.keys
 	switch {
+	// While a script runs, ctrl+c aborts it instead of quitting. The
+	// binding is disabled the rest of the time, so key.Matches only
+	// takes this branch during a run.
+	case key.Matches(msg, k.CancelQuery):
+		cmd := m.cancelQuery()
+		return true, m, cmd
+
+	case key.Matches(msg, k.OpenEditor):
+		cmd := m.openQueryEditor()
+		return true, m, cmd
+
 	case key.Matches(msg, k.Quit):
 		return true, m, tea.Quit
 
@@ -707,20 +774,32 @@ func (m Model) runAction(id actionID) (Model, tea.Cmd) {
 		m.panels[panelTables].clearFilter()
 		m.refreshRelations()
 
-	case actRunQuery:
-		if sel := m.panels[panelHistory].selected(); sel != "" {
-			return m, logCmd("%s", sel)
+	case actLoadQuery:
+		if e, ok := m.selectedHistory(); ok {
+			cmd := m.loadIntoEditor(e.SQL)
+			return m, cmd
 		}
 
+	case actRunQuery:
+		if e, ok := m.selectedHistory(); ok {
+			cmd := m.submitQuery(e.SQL)
+			return m, cmd
+		}
+
+	case actDeleteHistory:
+		cmd := m.deleteHistoryEntry()
+		return m, cmd
+
 	case actClearHistory:
+		if len(m.history) == 0 {
+			return m, logCmd("-- query history is already empty")
+		}
 		m.modal = &confirmModal{
-			title:  "Clear history",
-			body:   "Discard every entry in the query history?",
-			danger: true,
-			onConfirm: func(m *Model) tea.Cmd {
-				m.panels[panelHistory].setItems(nil)
-				return logCmd("-- clear query history")
-			},
+			title: "Clear history",
+			body: fmt.Sprintf(
+				"Discard all %d entries of the query history, on disk too?", len(m.history)),
+			danger:    true,
+			onConfirm: func(m *Model) tea.Cmd { return m.clearHistory() },
 		}
 	}
 	return m, nil
@@ -766,7 +845,12 @@ func (m *Model) drillIn() tea.Cmd {
 		// grid; `esc` there comes straight back here.
 		return tea.Batch(m.openTable(sel), focusCmd(panelMain))
 	case panelHistory:
-		return logCmd("%s", sel)
+		// `enter` loads the statement into the editor rather than
+		// running it: history is full of statements that were fine once
+		// and would be a surprise now. `x` runs it.
+		if e, ok := m.selectedHistory(); ok {
+			return m.loadIntoEditor(e.SQL)
+		}
 	}
 	return nil
 }

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -25,6 +25,9 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	os.Setenv("XDG_CONFIG_HOME", dir)
+	// The query history is persistent; point it at the temp home too so
+	// no test can append to the developer's own history file.
+	os.Setenv("XDG_STATE_HOME", dir)
 	keyring.MockInit()
 	code := m.Run()
 	os.RemoveAll(dir)
@@ -466,8 +469,10 @@ func TestDrillInLogsAndRecordsHistory(t *testing.T) {
 	if m.focus != panelMain {
 		t.Fatalf("focus = %v, want the data grid", m.focus)
 	}
+	// The panel row is the timestamp plus the statement; the entry
+	// behind it holds the statement as it ran.
 	hist := m.panels[panelHistory].items
-	if len(hist) != 1 || !strings.HasPrefix(hist[0], "SELECT * FROM ") {
+	if len(hist) != 1 || !strings.Contains(hist[0], "SELECT * FROM ") {
 		t.Fatalf("history = %v, want one SELECT entry", hist)
 	}
 	if !logContains(m, `SELECT * FROM "drill" LIMIT 100 OFFSET 0;`) {

--- a/internal/ui/panel.go
+++ b/internal/ui/panel.go
@@ -61,6 +61,10 @@ type sidePanel struct {
 	// whether `/` input mode is still capturing keys.
 	filter    string
 	filtering bool
+	// idx maps a visible row back to its position in all. It is nil
+	// while no filter narrows the list, where the mapping is the
+	// identity.
+	idx []int
 
 	// tabs are the sub-tab labels drawn next to the title ([3] Tables).
 	tabs []string
@@ -139,17 +143,19 @@ func (p *sidePanel) clearFilter() {
 // applyFilter recomputes items/status from all/allStatus.
 func (p *sidePanel) applyFilter() {
 	if p.filter == "" {
-		p.items, p.status = p.all, p.allStatus
+		p.items, p.status, p.idx = p.all, p.allStatus, nil
 		p.move(0)
 		return
 	}
 	items := make([]string, 0, len(p.all))
+	idx := make([]int, 0, len(p.all))
 	var status []itemStatus
 	for i, it := range p.all {
 		if !fuzzyMatch(p.filter, it) {
 			continue
 		}
 		items = append(items, it)
+		idx = append(idx, i)
 		if len(p.allStatus) > 0 {
 			st := statusIdle
 			if i < len(p.allStatus) {
@@ -158,9 +164,23 @@ func (p *sidePanel) applyFilter() {
 			status = append(status, st)
 		}
 	}
-	p.items, p.status = items, status
+	p.items, p.status, p.idx = items, status, idx
 	p.cursor, p.offset = 0, 0
 	p.move(0)
+}
+
+// sourceIndex maps a visible row back onto the unfiltered list, so a
+// caller holding the data behind the panel can find the record the
+// cursor is on even when two records render identically. It returns -1
+// when the row does not exist.
+func (p *sidePanel) sourceIndex(i int) int {
+	if i < 0 || i >= len(p.items) {
+		return -1
+	}
+	if p.idx == nil {
+		return i
+	}
+	return p.idx[i]
 }
 
 // selectByName moves the cursor onto the named row and reports whether the

--- a/internal/ui/query.go
+++ b/internal/ui/query.go
@@ -1,0 +1,495 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"charm.land/bubbles/v2/textarea"
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"lazysql/internal/db"
+)
+
+// The query editor: `:` opens a multi-line textarea, ctrl+r runs it, and
+// the result lands in the main view's Data tab next to the browsing
+// pages. Three rules shape the flow:
+//
+//   - Nothing that changes data runs unasked. A script holding DML or
+//     DDL goes through a confirm modal that shows the exact statements.
+//   - A run is always interruptible. The statements execute in one
+//     goroutine under a cancellable context and ctrl+c aborts it without
+//     touching the connection or the app.
+//   - A result set is materialized once and paged in memory. An
+//     arbitrary statement cannot be re-issued with a different OFFSET —
+//     rewriting user SQL to page it would change what it means — so the
+//     rows are read once, capped, and the grid pages the slice.
+
+// maxQueryRows caps what one statement materializes. It is far above any
+// result a terminal grid can usefully show and far below what would put
+// the process at risk on a `SELECT *` over a large table. Hitting it is
+// reported in the grid and in the log, never silently.
+const maxQueryRows = 10000
+
+// ---------- in-flight state ----------
+
+// queryRun is the one script a Model may have executing. Only one runs
+// at a time: two concurrent runs would race over which result the Data
+// tab shows, and nothing about the flow wants a queue.
+type queryRun struct {
+	running bool
+	// id distinguishes the run a message belongs to, so a cancelled
+	// run's late reply cannot overwrite its successor's result.
+	id     int
+	total  int
+	cancel context.CancelFunc
+	// ch carries one message per finished statement plus the final
+	// outcome. Unbuffered, like the export channel: a UI that stopped
+	// reading should block the worker rather than let it run ahead.
+	ch chan tea.Msg
+	// gotRows records that some statement in this run returned a result
+	// set, so a trailing DML notice cannot replace it. The issue's rule
+	// is that the last SELECT is what stays on screen.
+	gotRows bool
+	// affected accumulates the rows changed by the run's write
+	// statements, for the closing log line.
+	affected int64
+}
+
+// ---------- messages ----------
+
+// queryStmtMsg reports one finished statement of a run.
+type queryStmtMsg struct {
+	id        int
+	index     int // 1-based, for "statement 2 of 3"
+	total     int
+	sql       string
+	read      bool
+	rs        *db.ResultSet
+	truncated bool
+	affected  int64
+	took      time.Duration
+	err       error
+}
+
+// queryDoneMsg closes a run, successfully or not.
+type queryDoneMsg struct {
+	id  int
+	ran int
+	err error
+}
+
+// ---------- the worker ----------
+
+// queryJob is everything the worker goroutine needs. It is a value, so
+// the goroutine shares nothing mutable with the Model.
+type queryJob struct {
+	id    int
+	ctx   context.Context
+	drv   db.Driver
+	stmts []string
+	ch    chan tea.Msg
+}
+
+// startQueryCmd launches the worker and blocks until its first message.
+// Later messages are pulled by waitQueryCmd, which the root re-issues
+// after each one — the same streaming shape the file export uses.
+func startQueryCmd(job queryJob) tea.Cmd {
+	return func() tea.Msg {
+		go job.run()
+		return <-job.ch
+	}
+}
+
+func waitQueryCmd(ch chan tea.Msg) tea.Cmd {
+	if ch == nil {
+		return nil
+	}
+	return func() tea.Msg { return <-ch }
+}
+
+// run executes the statements in order and stops at the first failure:
+// a script is written top to bottom, so running the rest after an error
+// would apply changes the user never got to react to.
+func (j queryJob) run() {
+	var runErr error
+	ran := 0
+	for i, sql := range j.stmts {
+		if err := j.ctx.Err(); err != nil {
+			runErr = err
+			break
+		}
+		out := queryStmtMsg{
+			id:    j.id,
+			index: i + 1,
+			total: len(j.stmts),
+			sql:   sql,
+			read:  db.ClassifyStatement(sql) == db.StatementRead,
+		}
+		start := time.Now()
+		if out.read {
+			out.rs, out.truncated, out.err = j.drv.QueryLimit(j.ctx, sql, maxQueryRows)
+		} else {
+			var res db.ExecResult
+			res, out.err = j.drv.Exec(j.ctx, sql)
+			out.affected = res.RowsAffected
+		}
+		out.took = time.Since(start)
+		ran++
+		// A plain send, not a select on ctx.Done(): the root drains this
+		// channel until queryDoneMsg arrives, so there is always a
+		// reader, and guarding the send would drop exactly the message
+		// that reports the cancelled statement.
+		j.ch <- out
+		if out.err != nil {
+			runErr = out.err
+			break
+		}
+	}
+	j.ch <- queryDoneMsg{id: j.id, ran: ran, err: runErr}
+}
+
+// ---------- opening the editor ----------
+
+// openQueryEditor is `:`. The draft survives every close, so an `esc` to
+// look something up in a panel costs nothing.
+func (m *Model) openQueryEditor() tea.Cmd {
+	m.modal = newQueryModal(m.draft)
+	return nil
+}
+
+// loadIntoEditor opens the editor on a statement from the history panel,
+// replacing whatever draft was there. The old draft is not worth a
+// confirm: it is one keystroke away in the history too.
+func (m *Model) loadIntoEditor(sql string) tea.Cmd {
+	m.draft = sql
+	m.modal = newQueryModal(sql)
+	return nil
+}
+
+// ---------- running ----------
+
+// submitQuery is what ctrl+r hands over: split the script, and either
+// run it or ask first. Everything that can be decided without the server
+// is decided here, so the worker only ever reports database problems.
+func (m *Model) submitQuery(script string) tea.Cmd {
+	m.draft = script
+	if m.driver == nil {
+		return logCmd("-- run query skipped: not connected")
+	}
+	if m.run.running {
+		return logCmd("-- run query skipped: a query is still running (ctrl+c cancels it)")
+	}
+	stmts := db.SplitStatements(m.driver.Engine(), script)
+	if len(stmts) == 0 {
+		return logCmd("-- run query skipped: nothing to run")
+	}
+
+	var writes []string
+	for _, s := range stmts {
+		if db.ClassifyStatement(s) == db.StatementWrite {
+			writes = append(writes, s)
+		}
+	}
+	if len(writes) == 0 {
+		return m.startQuery(stmts)
+	}
+	// Staged edits go through the changeset and its commit modal; this
+	// path bypasses both, so it says so.
+	body := strings.Join(writes, ";\n") + ";"
+	if len(writes) != len(stmts) {
+		body += fmt.Sprintf("\n\n(%d of %d statements; the rest only read.)", len(writes), len(stmts))
+	}
+	body += "\n\nThese execute immediately against " + m.active +
+		" — they are not staged and there is nothing to roll back."
+	m.modal = &confirmModal{
+		title:     "Run " + countStatements(len(writes)) + " that change data",
+		body:      body,
+		danger:    true,
+		onConfirm: func(mm *Model) tea.Cmd { return mm.startQuery(stmts) },
+	}
+	return nil
+}
+
+// startQuery launches the worker for an already-vetted statement list.
+func (m *Model) startQuery(stmts []string) tea.Cmd {
+	if m.driver == nil || len(stmts) == 0 {
+		return nil
+	}
+	// A new result replaces whatever the tab showed; the notice and the
+	// old rows belong to the previous run.
+	m.data.notice = ""
+
+	ctx, cancel := context.WithCancel(context.Background())
+	m.run = queryRun{
+		running: true,
+		id:      m.run.id + 1,
+		total:   len(stmts),
+		cancel:  cancel,
+		ch:      make(chan tea.Msg),
+	}
+	m.keys.CancelQuery.SetEnabled(true)
+
+	job := queryJob{id: m.run.id, ctx: ctx, drv: m.driver, stmts: stmts, ch: m.run.ch}
+	return tea.Batch(
+		logCmd("-- run %s on %s…", countStatements(len(stmts)), m.active),
+		startQueryCmd(job),
+	)
+}
+
+// rerunQuery is `enter`/`R` on a query result: execute the same script
+// again. It goes through submitQuery so a re-run of DML asks again.
+func (m *Model) rerunQuery() tea.Cmd {
+	if !m.data.isQuery() {
+		return nil
+	}
+	return m.submitQuery(m.data.query)
+}
+
+// cancelQuery is ctrl+c while a run is in flight. The context reaches
+// the driver, which aborts the statement server-side where the engine
+// supports it; the connection itself stays open.
+func (m *Model) cancelQuery() tea.Cmd {
+	if !m.run.running {
+		return nil
+	}
+	m.run.cancel()
+	return logCmd("-- cancelling the running query…")
+}
+
+// ---------- reducing the worker's messages ----------
+
+// applyQueryStmt reduces one finished statement: it logs the statement,
+// records it in the history and routes its outcome into the Data tab.
+func (m *Model) applyQueryStmt(msg queryStmtMsg) tea.Cmd {
+	cmds := []tea.Cmd{
+		logCmd("%s;", flattenSQL(msg.sql)),
+		m.recordHistory(msg.sql),
+	}
+	where := ""
+	if msg.total > 1 {
+		where = fmt.Sprintf(" [%d/%d]", msg.index, msg.total)
+	}
+	switch {
+	case errors.Is(msg.err, context.Canceled):
+		cmds = append(cmds, logCmd("-- cancelled%s after %s", where, formatTook(msg.took)))
+	case msg.err != nil:
+		cmds = append(cmds, logCmd("-- FAILED%s: %v", where, msg.err))
+		m.showQueryError(msg.sql, msg.err)
+	case msg.read:
+		rows := 0
+		if msg.rs != nil {
+			rows = len(msg.rs.Rows)
+		}
+		note := ""
+		if msg.truncated {
+			note = fmt.Sprintf(" (capped at %d)", maxQueryRows)
+		}
+		cmds = append(cmds, logCmd("-- %d rows%s%s in %s",
+			rows, note, where, formatTook(msg.took)))
+		if msg.rs != nil {
+			m.showQueryResult(msg.sql, msg.rs, msg.truncated)
+			m.run.gotRows = true
+		}
+	default:
+		m.run.affected += msg.affected
+		cmds = append(cmds, logCmd("-- %s%s in %s",
+			countAffected(msg.affected), where, formatTook(msg.took)))
+		// A run that only writes still has to show something; a run
+		// that already produced rows keeps them, because the last
+		// SELECT is what the user asked to see.
+		if !m.run.gotRows {
+			m.showQueryNotice(msg.sql, msg.affected)
+		}
+	}
+	return tea.Batch(cmds...)
+}
+
+// finishQuery clears the in-flight state and renders the outcome.
+func (m *Model) finishQuery(msg queryDoneMsg) tea.Cmd {
+	m.run.running = false
+	m.run.cancel = nil
+	m.run.ch = nil
+	m.keys.CancelQuery.SetEnabled(false)
+
+	switch {
+	case errors.Is(msg.err, context.Canceled):
+		return logCmd("-- query cancelled after %s", countStatements(msg.ran))
+	case msg.err != nil:
+		// The per-statement message already named the error; this line
+		// says how much of the script got as far as running.
+		return logCmd("-- query stopped at statement %d of %d", msg.ran, m.run.total)
+	case m.run.total > 1:
+		return logCmd("-- %s ok, %s total", countStatements(msg.ran), countAffected(m.run.affected))
+	default:
+		return nil
+	}
+}
+
+// showQueryResult puts a result set in the Data tab. It replaces the
+// browsed relation: the tab has one grid, and a query result is not a
+// relation, so nothing table-scoped (editing, export, introspection)
+// applies to it afterwards.
+func (m *Model) showQueryResult(sql string, rs *db.ResultSet, truncated bool) {
+	m.table = ""
+	m.resetMeta()
+	m.tab = mainTabData
+	// The result is the point of running the query, so the grid takes
+	// focus; `esc` walks back to whatever panel the user came from.
+	m.setFocus(panelMain)
+	m.data = dataView{
+		conn:      m.active,
+		database:  m.database,
+		query:     sql,
+		all:       rs.Rows,
+		truncated: truncated,
+		cols:      rs.Columns,
+		total:     int64(len(rs.Rows)),
+		hasTotal:  true,
+		// A bumped req invalidates any page or count still in flight
+		// for the relation this result replaced.
+		req: m.data.req + 1,
+	}
+	m.data.setPage(0)
+	m.clampCursor()
+}
+
+// showQueryError puts a failed statement's message in the Data tab. It
+// replaces whatever was there, result or relation: the error is the news
+// and leaving stale rows under it invites reading them as the answer.
+func (m *Model) showQueryError(sql string, err error) {
+	m.table = ""
+	m.resetMeta()
+	m.tab = mainTabData
+	m.setFocus(panelMain)
+	m.data = dataView{
+		conn:     m.active,
+		database: m.database,
+		query:    sql,
+		err:      err.Error(),
+		req:      m.data.req + 1,
+	}
+}
+
+// showQueryNotice puts a rows-affected notice in the Data tab for a
+// statement that returns no result set.
+func (m *Model) showQueryNotice(sql string, affected int64) {
+	m.table = ""
+	m.resetMeta()
+	m.tab = mainTabData
+	m.setFocus(panelMain)
+	m.data = dataView{
+		conn:     m.active,
+		database: m.database,
+		query:    sql,
+		notice:   db.FirstKeyword(sql) + " — " + countAffected(affected),
+		req:      m.data.req + 1,
+	}
+}
+
+// formatTook renders how long a statement took. Sub-millisecond runs
+// are rounded to microseconds rather than to a bare "0s", which reads
+// like the statement never ran.
+func formatTook(d time.Duration) string {
+	if d < time.Millisecond {
+		return d.Round(time.Microsecond).String()
+	}
+	return d.Round(time.Millisecond).String()
+}
+
+// countStatements spells "1 statement" / "3 statements".
+func countStatements(n int) string {
+	if n == 1 {
+		return "1 statement"
+	}
+	return fmt.Sprintf("%d statements", n)
+}
+
+// countAffected spells the rows-affected notice.
+func countAffected(n int64) string {
+	if n == 1 {
+		return "1 row affected"
+	}
+	return fmt.Sprintf("%d rows affected", n)
+}
+
+// flattenSQL collapses a multi-line statement onto the single line the
+// command log has room for.
+func flattenSQL(sql string) string { return flatten(sql) }
+
+// ---------- the editor modal ----------
+
+// queryModal is the `:` popup: a textarea and nothing else. It never
+// touches the database itself — ctrl+r hands the text to submitQuery,
+// which decides whether it needs a confirmation first.
+type queryModal struct {
+	area textarea.Model
+}
+
+func newQueryModal(initial string) *queryModal {
+	ta := textarea.New()
+	ta.Placeholder = "SELECT * FROM …"
+	ta.ShowLineNumbers = true
+	ta.CharLimit = 0
+	ta.SetValue(initial)
+	ta.MoveToEnd()
+	ta.Focus()
+	return &queryModal{area: ta}
+}
+
+func (q *queryModal) update(msg tea.KeyPressMsg, m *Model) (bool, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		// The draft is kept: `esc` means "get out of my way", not
+		// "throw away what I typed".
+		m.draft = q.area.Value()
+		return true, nil
+	case "ctrl+c":
+		// In the editor ctrl+c is the run's abort key, never the app's
+		// quit key. With nothing running it closes the editor, which is
+		// the closest thing to "stop" it can mean here.
+		if m.run.running {
+			return false, m.cancelQuery()
+		}
+		m.draft = q.area.Value()
+		return true, nil
+	case "ctrl+r", "ctrl+enter":
+		return true, m.submitQuery(q.area.Value())
+	}
+	var cmd tea.Cmd
+	q.area, cmd = q.area.Update(msg)
+	return false, cmd
+}
+
+func (q *queryModal) view(s styles, maxW, maxH int) string {
+	w := min(maxW-10, 80)
+	if w < 20 {
+		w = 20
+	}
+	// The box grows with the script instead of always claiming its
+	// maximum: a one-line query should not open a half-screen modal.
+	h := min(maxH-9, 14)
+	if lines := q.area.LineCount() + 1; lines < h {
+		h = lines
+	}
+	if h < 3 {
+		h = 3
+	}
+	q.area.SetWidth(w)
+	q.area.SetHeight(h)
+
+	footer := "ctrl+r run · enter newline · esc close (draft kept)"
+	if q.area.Value() == "" {
+		footer = "ctrl+r run · esc cancel"
+	}
+	return s.modal.Render(lipgloss.JoinVertical(lipgloss.Left,
+		s.modalTitle.Render("Query editor"),
+		"",
+		q.area.View(),
+		"",
+		s.muted.Render(footer),
+	))
+}

--- a/internal/ui/query_test.go
+++ b/internal/ui/query_test.go
@@ -1,0 +1,350 @@
+package ui
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+
+	"lazysql/internal/db"
+)
+
+// queryable is a connected model with a small table to query.
+func queryable(t *testing.T) Model {
+	t.Helper()
+	m := browsing(t)
+	if _, err := m.driver.Exec(context.Background(),
+		`CREATE TABLE IF NOT EXISTS q (id INTEGER PRIMARY KEY, name TEXT)`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.driver.Exec(context.Background(), `DELETE FROM q`); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 3; i++ {
+		if _, err := m.driver.Exec(context.Background(),
+			`INSERT INTO q (id, name) VALUES (?, ?)`, i, "row"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Start from an empty history so the assertions below count only
+	// what the test itself ran.
+	m.history = nil
+	m.refreshHistory()
+	m.commandLog = nil
+	return m
+}
+
+// runQuery types a script into the editor and runs it.
+func runQuery(t *testing.T, m Model, script string) Model {
+	t.Helper()
+	m = send(t, m, press(':'))
+	qm, ok := m.modal.(*queryModal)
+	if !ok {
+		t.Fatalf("`:` opened %T, want the query editor", m.modal)
+	}
+	qm.area.SetValue(script)
+	return send(t, m, tea.KeyPressMsg{Code: 'r', Mod: tea.ModCtrl})
+}
+
+func TestColonOpensTheQueryEditorWithTheDraft(t *testing.T) {
+	m := sized(120, 40)
+	m.draft = "SELECT 1"
+	m = send(t, m, press(':'))
+	qm, ok := m.modal.(*queryModal)
+	if !ok {
+		t.Fatalf("`:` opened %T, want *queryModal", m.modal)
+	}
+	if qm.area.Value() != "SELECT 1" {
+		t.Fatalf("editor opened on %q, want the kept draft", qm.area.Value())
+	}
+}
+
+func TestEscKeepsTheDraft(t *testing.T) {
+	m := sized(120, 40)
+	m = send(t, m, press(':'))
+	m.modal.(*queryModal).area.SetValue("SELECT 42")
+	m = send(t, m, special(tea.KeyEscape, 0))
+	if m.modal != nil {
+		t.Fatalf("esc left %T open", m.modal)
+	}
+	if m.draft != "SELECT 42" {
+		t.Fatalf("draft = %q, want the text esc was pressed on", m.draft)
+	}
+}
+
+func TestSelectRendersInTheDataTab(t *testing.T) {
+	m := runQuery(t, queryable(t), "SELECT id, name FROM q ORDER BY id")
+
+	if !m.data.isQuery() {
+		t.Fatal("the Data tab is not showing a query result")
+	}
+	if m.data.browsing() {
+		t.Fatal("a query result must not look like a browsed relation")
+	}
+	if len(m.data.rows) != 3 || len(m.data.cols) != 2 {
+		t.Fatalf("result = %d rows x %d cols, want 3x2", len(m.data.rows), len(m.data.cols))
+	}
+	if !logContains(m, "SELECT id, name FROM q ORDER BY id;") {
+		t.Fatalf("the statement is missing from the command log: %v", m.commandLog)
+	}
+	if !logContains(m, "3 rows") {
+		t.Fatalf("the row count is missing from the command log: %v", m.commandLog)
+	}
+	// The grid renders it with the browsing renderer.
+	if out := m.dataContent(100, 20); !strings.Contains(out, "name") {
+		t.Fatalf("grid did not render the result columns:\n%s", out)
+	}
+}
+
+func TestQueryResultPaginatesInMemory(t *testing.T) {
+	m := queryable(t)
+	// A result wider than one page, without touching the server again.
+	m = runQuery(t, m, "WITH RECURSIVE n(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM n WHERE i < 250) SELECT i FROM n")
+	if len(m.data.all) != 250 {
+		t.Fatalf("materialized %d rows, want 250", len(m.data.all))
+	}
+	if len(m.data.rows) != dataPageSize {
+		t.Fatalf("page 1 has %d rows, want %d", len(m.data.rows), dataPageSize)
+	}
+	if got := m.data.pageCount(); got != 3 {
+		t.Fatalf("pageCount() = %d, want 3", got)
+	}
+	m = send(t, m, tea.KeyPressMsg{Code: 'f', Mod: tea.ModCtrl})
+	if m.data.page != 1 || m.data.rows[0][0] != int64(dataPageSize+1) {
+		t.Fatalf("after ctrl+f: page %d starting at %v, want page 1 starting at 101",
+			m.data.page, m.data.rows[0][0])
+	}
+	m = send(t, m, tea.KeyPressMsg{Code: 'f', Mod: tea.ModCtrl},
+		tea.KeyPressMsg{Code: 'f', Mod: tea.ModCtrl})
+	if m.data.page != 2 {
+		t.Fatalf("page = %d, want to stop on the last page", m.data.page)
+	}
+	if !logContains(m, "already on the last page") {
+		t.Fatalf("paging past the end said nothing: %v", m.commandLog)
+	}
+	m = send(t, m, tea.KeyPressMsg{Code: 'b', Mod: tea.ModCtrl})
+	if m.data.page != 1 {
+		t.Fatalf("after ctrl+b: page = %d, want 1", m.data.page)
+	}
+}
+
+func TestDMLAsksBeforeItRuns(t *testing.T) {
+	m := queryable(t)
+	m = runQuery(t, m, "DELETE FROM q WHERE id = 3")
+
+	cm, ok := m.modal.(*confirmModal)
+	if !ok {
+		t.Fatalf("DML opened %T, want a confirm modal", m.modal)
+	}
+	if !cm.danger || !strings.Contains(cm.body, "DELETE FROM q WHERE id = 3") {
+		t.Fatalf("the confirm modal does not show the statement: %#v", cm)
+	}
+	// Nothing ran yet.
+	if logContains(m, "rows affected") {
+		t.Fatalf("the statement executed before the confirmation: %v", m.commandLog)
+	}
+
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if !logContains(m, "1 row affected") {
+		t.Fatalf("the confirmed DELETE did not report its row count: %v", m.commandLog)
+	}
+	if m.data.notice == "" || !strings.Contains(m.data.notice, "1 row affected") {
+		t.Fatalf("data notice = %q, want the affected-row count", m.data.notice)
+	}
+	if !logContains(m, "DELETE FROM q WHERE id = 3;") {
+		t.Fatalf("the statement is missing from the command log: %v", m.commandLog)
+	}
+}
+
+func TestCancelledDMLDoesNotRun(t *testing.T) {
+	m := queryable(t)
+	m = runQuery(t, m, "DELETE FROM q")
+	m = send(t, m, special(tea.KeyEscape, 0))
+	if m.modal != nil {
+		t.Fatalf("esc left %T open", m.modal)
+	}
+	if m.run.running || logContains(m, "rows affected") {
+		t.Fatalf("the declined statement ran anyway: %v", m.commandLog)
+	}
+}
+
+func TestMultipleStatementsRunInOrderAndAllAreLogged(t *testing.T) {
+	m := queryable(t)
+	m = runQuery(t, m,
+		"UPDATE q SET name = 'a' WHERE id = 1;\nSELECT id FROM q WHERE id = 1;\nSELECT name FROM q WHERE id = 1;")
+	m = send(t, m, special(tea.KeyEnter, 0)) // confirm the UPDATE
+
+	for _, want := range []string{
+		"UPDATE q SET name = 'a' WHERE id = 1;",
+		"SELECT id FROM q WHERE id = 1;",
+		"SELECT name FROM q WHERE id = 1;",
+	} {
+		if !logContains(m, want) {
+			t.Fatalf("statement %q missing from the command log: %v", want, m.commandLog)
+		}
+	}
+	// The last SELECT is the one on screen.
+	if len(m.data.cols) != 1 || m.data.cols[0].Name != "name" {
+		t.Fatalf("Data tab shows %v, want the last SELECT's columns", m.data.cols)
+	}
+	// The write did not replace the rows.
+	if m.data.notice != "" {
+		t.Fatalf("notice = %q, want the SELECT result to win", m.data.notice)
+	}
+	if len(m.history) != 3 {
+		t.Fatalf("history has %d entries, want one per statement: %v", len(m.history), m.history)
+	}
+}
+
+func TestFailingStatementStopsTheScript(t *testing.T) {
+	m := queryable(t)
+	m = runQuery(t, m, "SELECT * FROM nope; SELECT 1")
+	if logContains(m, "SELECT 1;") {
+		t.Fatalf("the script continued past a failure: %v", m.commandLog)
+	}
+	if !logContains(m, "FAILED") {
+		t.Fatalf("the failure was not reported: %v", m.commandLog)
+	}
+	if m.run.running {
+		t.Fatal("the run is still marked as in flight")
+	}
+}
+
+func TestCancelKeyIsOnlyBoundWhileAQueryRuns(t *testing.T) {
+	m := queryable(t)
+	if m.keys.CancelQuery.Enabled() {
+		t.Fatal("ctrl+c is bound to cancel with nothing running — it must still quit")
+	}
+	// Enter the running state without a worker, then cancel it the way
+	// the key handler does.
+	m.run.running = true
+	m.run.cancel = func() {}
+	m.keys.CancelQuery.SetEnabled(true)
+	handled, next, _ := m.updateGlobal(tea.KeyPressMsg{Code: 'c', Mod: tea.ModCtrl})
+	if !handled {
+		t.Fatal("ctrl+c was not handled while a query was running")
+	}
+	if _, ok := next.(Model); !ok {
+		t.Fatalf("updateGlobal returned %T", next)
+	}
+	// finishQuery clears it again.
+	mm := next.(Model)
+	mm.finishQuery(queryDoneMsg{id: mm.run.id})
+	if mm.keys.CancelQuery.Enabled() {
+		t.Fatal("ctrl+c stayed bound to cancel after the run finished")
+	}
+}
+
+// longQuery counts far enough that the engine is still working when the
+// test cancels it. The driver honours the context mid-statement, which
+// is what makes a runaway query interruptible.
+const longQuery = `WITH RECURSIVE n(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM n WHERE i < 200000000) SELECT count(*) FROM n`
+
+func TestWorkerAbortsAStatementInFlight(t *testing.T) {
+	m := queryable(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ch := make(chan tea.Msg)
+	go queryJob{id: 1, ctx: ctx, drv: m.driver, stmts: []string{longQuery}, ch: ch}.run()
+
+	// Cancel while the statement is running, not before it starts.
+	time.AfterFunc(300*time.Millisecond, cancel)
+
+	deadline := time.After(20 * time.Second)
+	var sawStmt bool
+	for {
+		select {
+		case msg := <-ch:
+			switch msg := msg.(type) {
+			case queryStmtMsg:
+				sawStmt = true
+				if !errors.Is(msg.err, context.Canceled) {
+					t.Fatalf("statement error = %v, want context.Canceled", msg.err)
+				}
+			case queryDoneMsg:
+				if !errors.Is(msg.err, context.Canceled) {
+					t.Fatalf("run error = %v, want context.Canceled", msg.err)
+				}
+				if !sawStmt {
+					t.Fatal("the run closed without reporting the aborted statement")
+				}
+				return
+			}
+		case <-deadline:
+			t.Fatal("the worker did not stop after its context was cancelled")
+		}
+	}
+}
+
+func TestQueryRunIsCancellable(t *testing.T) {
+	m := queryable(t)
+	// A long recursive scan the SQLite driver checks the context in.
+	script := "WITH RECURSIVE n(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM n WHERE i < 20000000) SELECT count(*) FROM n"
+	stmts := db.SplitStatements(m.driver.Engine(), script)
+	cmd := m.startQuery(stmts)
+	if !m.run.running {
+		t.Fatal("startQuery did not mark the run as in flight")
+	}
+	// Cancel before draining, so the worker sees a dead context.
+	m.cancelQuery()
+	for _, msg := range drain(cmd) {
+		next, c := m.Update(msg)
+		m = next.(Model)
+		for _, msg := range drain(c) {
+			next, _ := m.Update(msg)
+			m = next.(Model)
+		}
+	}
+	if m.run.running {
+		t.Fatal("the cancelled run is still in flight")
+	}
+	if m.driver == nil {
+		t.Fatal("cancelling a query closed the connection")
+	}
+	// The app is still usable: a plain query works afterwards.
+	m = runQuery(t, m, "SELECT 1")
+	if len(m.data.rows) != 1 {
+		t.Fatalf("the model did not recover from a cancellation: %#v", m.data)
+	}
+}
+
+func TestQueryResultHasNoTableActions(t *testing.T) {
+	m := runQuery(t, queryable(t), "SELECT id FROM q")
+	m = send(t, m, press('E')) // export
+	if m.modal != nil {
+		t.Fatalf("export opened %T for a query result", m.modal)
+	}
+	if !logContains(m, "export skipped") {
+		t.Fatalf("export said nothing: %v", m.commandLog)
+	}
+	// The introspection tabs describe a relation, so they stay away.
+	m = send(t, m, press(']'))
+	if m.tab != mainTabData {
+		t.Fatalf("tab = %v, want the Data tab to stay", m.tab)
+	}
+}
+
+func TestQueryStatementsLandInTheHistory(t *testing.T) {
+	m := runQuery(t, queryable(t), "SELECT id FROM q")
+	if len(m.history) != 1 {
+		t.Fatalf("history = %#v, want the statement", m.history)
+	}
+	e := m.history[0]
+	if e.SQL != "SELECT id FROM q" {
+		t.Fatalf("stored %q, want the statement without its terminator", e.SQL)
+	}
+	if e.Engine != string(db.EngineSQLite) {
+		t.Fatalf("engine = %q, want the engine it ran on", e.Engine)
+	}
+	if e.At.IsZero() {
+		t.Fatal("the entry has no timestamp")
+	}
+	// Re-running the newest entry does not duplicate it.
+	m = runQuery(t, m, "SELECT id FROM q")
+	if len(m.history) != 1 {
+		t.Fatalf("history = %#v, want the replay folded into the newest entry", m.history)
+	}
+}

--- a/internal/ui/rowops.go
+++ b/internal/ui/rowops.go
@@ -22,7 +22,7 @@ import (
 // stagedInserts are the pending INSERTs of the open table, in staging
 // order. The grid renders them after the last real row of the page.
 func (m Model) stagedInserts() []db.RowInsert {
-	if !m.data.open() {
+	if !m.data.browsing() {
 		return nil
 	}
 	return m.changes.InsertsFor(m.data.database, m.data.table)
@@ -58,7 +58,7 @@ func (m *Model) clampCursor() {
 // startDelete is `d` on the Data tab. Like `e` it needs the primary key
 // from the metadata, and waits for the fetch when nothing cached it yet.
 func (m *Model) startDelete() tea.Cmd {
-	if !m.data.open() || m.tab.metadata() || m.driver == nil {
+	if !m.data.browsing() || m.tab.metadata() || m.driver == nil {
 		return nil
 	}
 	if m.onPhantomRow() {
@@ -102,7 +102,7 @@ func (m *Model) stageDeleteAtCursor() tea.Cmd {
 // Unlike delete, neither needs a primary key: a PK-less table can still
 // be inserted into.
 func (m *Model) startInsert(duplicate bool) tea.Cmd {
-	if !m.data.open() || m.tab.metadata() || m.driver == nil {
+	if !m.data.browsing() || m.tab.metadata() || m.driver == nil {
 		return nil
 	}
 	if duplicate {

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -152,6 +152,12 @@ func (m Model) mainContent(w, h int) string {
 	if m.focus == panelConnections {
 		return m.connectionDetail(w, h)
 	}
+	// Panel [4] shows the selected statement in full: the side column
+	// has room for one line of it and the engine and timestamp have to
+	// live somewhere.
+	if m.focus == panelHistory {
+		return m.historyDetail(w, h)
+	}
 	if m.data.open() {
 		if m.tab.metadata() {
 			return m.metaContent(w, h)
@@ -183,7 +189,7 @@ func (m Model) mainContent(w, h int) string {
 		lines = append(lines, "opened: "+m.table)
 	}
 	lines = append(lines, "",
-		m.style.muted.Render("no result set yet — the data preview lands with the query view"))
+		m.style.muted.Render("nothing open — pick a relation in [3] Tables, or press : to run a query"))
 	return joinTruncated(lines, w, h)
 }
 

--- a/wiki/design/query-editor-and-history.md
+++ b/wiki/design/query-editor-and-history.md
@@ -1,0 +1,204 @@
+---
+type: Design Decision
+title: Query editor, result routing and the persistent history
+description: Why free-form results are materialized and paged in memory instead of rewritten with LIMIT/OFFSET, how a script is split and classified without a parser, why DML from the editor is confirmed but never staged, how a run is cancelled, and why the history is JSON Lines under XDG_STATE_HOME.
+tags: [tui, query, sql, history, cancellation, persistence, xdg]
+generated:
+  by: claude-code/opus-5
+  at: 2026-08-09T00:00:00Z
+---
+
+# Query editor and query history
+
+## Decision
+
+`:` opens a centered modal holding a Bubbles `textarea`. `ctrl+r` (and
+`ctrl+enter`, for the terminals that send it) runs the script, `esc`
+closes it and keeps the draft on the model, and `ctrl+c` aborts a run.
+Results land in the existing main-view **Data** tab, next to the browsing
+pages, and every executed statement is appended to `[4] Query history`,
+which is backed by a file so it survives a restart.
+
+Four things about the flow needed a decision.
+
+## 1. A free-form result is materialized once and paged in memory
+
+Table browsing re-issues its query with a new `OFFSET` for every page —
+`db.PageSQL` builds the statement, so lazysql knows its shape. A
+statement the user typed has no known shape. Paging it would mean either
+wrapping it (`SELECT * FROM (<user sql>) LIMIT … OFFSET …`, which is not
+portable, breaks on multi-statement scripts and changes what `EXPLAIN`,
+`SHOW` and DML mean) or re-running it per page (which re-executes side
+effects). Both are worse than reading it once.
+
+So a query result is read once into `dataView.all` and the grid slices a
+page out of it (`dataView.setPage`). `ctrl+f`/`ctrl+b` then cost nothing
+and the row total is exact rather than a separate `COUNT(*)` — which is
+why the status line drops the `~` for query results and keeps it for
+browsed tables.
+
+The price is memory, so the read is capped. `Driver.QueryLimit` stops
+materializing at `maxQueryRows` (10 000) and reports whether the server
+still had rows; the grid says `capped at 10000 rows` in red and the
+command log repeats it. `Driver.Query` is `QueryLimit` with no cap, which
+is what the internal callers (pages, counts, introspection) keep using.
+
+### `dataView` carries both, and they are mutually exclusive
+
+`dataView.table` and `dataView.query` are never both set. That single
+invariant is what tells every table-scoped action it has nothing to work
+on:
+
+- `open()` — the tab has something to render (a relation, a result, or a
+  rows-affected notice).
+- `browsing()` — a relation is open. **Editing, staging, inserting,
+  introspection, `E` export and the table-scope copies ask this**, not
+  `open()`.
+- `isQuery()` — the page is a materialized result.
+
+Getting that wrong is how a `DELETE` gets staged against a table named
+`""`, so the guards were converted deliberately rather than left on
+`open()`.
+
+## 2. Splitting and classifying a script without a SQL parser
+
+`db.SplitStatements(engine, script)` is a small dialect-aware lexer, not
+`strings.Split(script, ";")`. A semicolon inside a string literal, a
+quoted identifier or a comment is data. The dialect matters for exactly
+three constructs:
+
+| Construct | Engines |
+|---|---|
+| `` `backtick` `` identifiers | MySQL, MariaDB |
+| `#` line comments | MySQL, MariaDB |
+| `\'` backslash escape inside `'…'` | MySQL, MariaDB (not PostgreSQL/SQLite/DuckDB — see [sql-literal-escaping](../reference/sql-literal-escaping.md)) |
+| `$tag$ … $tag$` bodies | PostgreSQL |
+
+An unterminated literal swallows the rest of the script rather than
+splitting into nonsense — a half-typed quote should produce one failing
+statement, not five.
+
+`db.ClassifyStatement` decides read vs. write from the first keyword
+after any leading comments, and **errs towards write**: an unrecognized
+statement is confirmed before it runs and executed through `Exec`. Two
+cases are not decided by the leading keyword alone:
+
+- `WITH` is a read *unless* the script contains `INSERT`/`UPDATE`/
+  `DELETE`/`MERGE` as a whole word — PostgreSQL allows data-modifying
+  CTEs.
+- `PRAGMA x` reads, `PRAGMA x = y` writes.
+
+`EXPLAIN` is classified as a read by convention even though PostgreSQL's
+`EXPLAIN ANALYZE` really executes its statement. Treating every `EXPLAIN`
+as a write would put a confirm modal in front of the most common
+read-only debugging tool; the narrower case is documented here instead.
+
+## 3. Editor DML is confirmed, never staged
+
+The changeset ([staged-changeset](staged-changeset.md)) exists because
+lazysql refuses to guess row identity. A statement the user wrote already
+*is* the identity — there is nothing to stage and nothing to reconstruct.
+So editor DML/DDL bypasses the changeset entirely and instead goes
+through a `confirmModal` that prints the exact write statements, says how
+many of the script's statements they are, and says plainly that they run
+immediately and cannot be rolled back.
+
+A run stops at the first failing statement. A script is written top to
+bottom; continuing past an error would apply changes the user never got
+to react to.
+
+## 4. Cancellation, and the one place a `select` on `ctx.Done()` is wrong
+
+Statements run in one goroutine under a `context.WithCancel`, streaming
+one `queryStmtMsg` per finished statement plus a closing `queryDoneMsg` —
+the same shape as the file export worker. `ctrl+c` calls the cancel func;
+the driver aborts the statement server-side where the engine supports it
+(`modernc.org/sqlite` honours the context mid-statement), and the
+connection stays open.
+
+The export worker guards its progress sends with
+`select { case ch <- msg: case <-ctx.Done(): }`, because a progress line
+is optional. The query worker must **not**: the message that reports the
+cancelled statement is produced *after* the context is already dead, so
+the guard would swallow exactly the message the user needs. A plain
+blocking send is correct here because the root drains the channel until
+`queryDoneMsg` — it re-issues `waitQueryCmd` after every statement, and
+`startQuery` refuses to begin a second run while one is in flight, so
+there is always a reader.
+
+`ctrl+c` is also the quit key. `keyMap.CancelQuery` is bound with
+`key.WithDisabled()` and enabled only while a run is in flight, and its
+case sits *before* `Quit` in `updateGlobal` — so `key.Matches` picks
+cancel during a run and quit the rest of the time, with no extra state
+check. The options bar and `?` skip disabled bindings, so the key is
+advertised only when it means something.
+
+## 5. The history is JSON Lines under `XDG_STATE_HOME`
+
+`internal/history` writes to
+`${XDG_STATE_HOME:-~/.local/state}/lazysql/history`. It is state, not
+configuration, which is why it is not next to `config.toml`.
+
+One JSON object per line, oldest first:
+
+```json
+{"sql":"SELECT * FROM users","engine":"sqlite","at":"2026-08-09T12:00:00Z"}
+```
+
+- **JSON, so a multi-line statement stays on one line.** `enter` on the
+  panel has to reload the statement exactly as it was typed.
+- **Append-only, so recording a statement is O(1).** A delete or a clear
+  rewrites the file atomically (temp file + rename). Loading compacts
+  anything past `MaxEntries` (1000).
+- **Unparsable lines are skipped, not fatal.** A crash mid-write leaves a
+  truncated last line; that must not cost the whole history.
+- **Mode 0600, directory 0700.** A statement can carry data that
+  `config.toml` deliberately never holds.
+- **Writes are mutex-guarded.** Appends run in `tea.Cmd` goroutines and
+  would otherwise interleave their lines.
+
+Everything lazysql executes goes in through one message,
+`historyEntryMsg` — a browsing page, a committed changeset statement, an
+editor script. Re-running the newest entry does not duplicate it; only
+the timestamp would differ, and `enter`-and-run would otherwise grow the
+list on every replay.
+
+### The panel row is not the entry
+
+The panel is a `[]string`, but `enter` needs the statement verbatim, so
+the model keeps `[]history.Entry` and derives the rows
+(`time  flattened SQL`). The engine goes in the main view's detail pane
+rather than the row: the side column is ~24–40 cells wide and the
+statement is what the eye scans for.
+
+Mapping a row back to an entry cannot go by text — two runs of the same
+statement render identically. `sidePanel.applyFilter` therefore records
+`idx`, mapping each visible row onto its position in the unfiltered list,
+and `sidePanel.sourceIndex` reads it. That is what makes `d` delete the
+entry under the cursor and not the one at that index in the full list
+while a `/` filter is active.
+
+## Consequences
+
+- A query result is not a relation: no `e`/`d`/`n`/`D`, no `E` export, no
+  Structure/Indexes/DDL tabs, no server-side `f`/`s`. `[`/`]` keeps the
+  Data tab instead of cycling to tabs with nothing behind them.
+- The copy menu still offers cell and row scopes on a query result; the
+  `INSERT` and table scopes need a table and are hidden.
+- A result yanks focus to the main view. It is what the user asked to
+  look at, and `esc` walks back through the focus stack.
+- Adding `QueryLimit` widened the `Driver` interface. There is one
+  implementation (`db.conn`) and no fakes, so the cost was a single
+  method; a `Query`-plus-manual-truncation approach would have
+  materialized the rows it was trying not to materialize.
+
+## See also
+
+- [data-grid](data-grid.md) — the renderer and the page/cursor model the
+  results reuse.
+- [staged-changeset](staged-changeset.md) — the path editor DML
+  deliberately does not take.
+- [copy-and-export](copy-and-export.md) — the worker/channel shape this
+  one mirrors, and the one place it diverges.
+- [tui-shell-architecture](tui-shell-architecture.md) — the update
+  routing order the `ctrl+c` case slots into.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -17,6 +17,7 @@ concept with YAML frontmatter. Concept IDs are bundle-relative paths without
 - [design/main-view-tabs](design/main-view-tabs.md) — Design Decision — Data/Structure/Indexes/DDL tabs behind one metadata fetch, `[`/`]` cycling instead of digits, and what survives a relation change.
 - [design/staged-changeset](design/staged-changeset.md) — Design Decision — cell edits, row deletes and row inserts stage into one engine-agnostic changeset, rows are identified only by their primary key, and the commit runs every statement in one transaction.
 - [design/copy-and-export](design/copy-and-export.md) — Design Decision — one incremental serializer package behind both the `y` copy menu and the `E` file export, why a clipboard copy is capped while a file export streams, how NULL is spelled per format, and how the export reports progress and cancels.
+- [design/query-editor-and-history](design/query-editor-and-history.md) — Design Decision — `:` editor, why free-form results are materialized and paged in memory, dialect-aware statement splitting and read/write classification, confirmed-not-staged DML, run cancellation, and the JSON Lines history under `XDG_STATE_HOME`.
 
 ## reference
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -154,3 +154,37 @@ Chronological history of wiki changes, newest last.
   queue that runs a key press's message cascade to a standstill: the
   export flow is four rounds deep (prompt → worker start → progress →
   done) and the old driver silently dropped the last one.
+- Added [design/query-editor-and-history](design/query-editor-and-history.md)
+  with the query editor (issue #10): `:` opens a `textarea` modal, `ctrl+r`
+  runs, `esc` keeps the draft. Free-form results cannot be re-issued with a
+  different `OFFSET` without rewriting user SQL, so they are materialized once
+  through the new `Driver.QueryLimit` (capped at 10 000 rows, truncation
+  reported) and paged in memory; `dataView.table` and `dataView.query` are
+  mutually exclusive, and every table-scoped guard moved from `open()` to the
+  new `browsing()`.
+- `db.SplitStatements` is a dialect-aware lexer rather than a split on `;`:
+  backticks and `#` comments are MySQL's, `$tag$` bodies PostgreSQL's, and only
+  MySQL reads `\'` as an escape. `db.ClassifyStatement` errs towards write, with
+  `WITH` demoted when the script modifies data and `PRAGMA x = y` counted as a
+  write; `EXPLAIN` stays a read despite PostgreSQL's `EXPLAIN ANALYZE`.
+- Editor DML bypasses the changeset — a statement the user wrote already carries
+  its own row identity — and is gated by a confirm modal that prints the exact
+  write statements. A run stops at the first failure.
+- Discovered while testing cancellation: the query worker must *not* guard its
+  per-statement send with `select … case <-ctx.Done()` the way the export worker
+  guards progress. The message reporting the cancelled statement is produced
+  after the context is already dead, so the guard swallowed exactly that
+  message. A plain blocking send is safe because the root drains until
+  `queryDoneMsg`.
+- `ctrl+c` cancels a run instead of quitting: `CancelQuery` is bound with
+  `key.WithDisabled()`, enabled only while a run is in flight, and its case sits
+  before `Quit` in `updateGlobal`, so `key.Matches` resolves the conflict with
+  no extra state check.
+- Added `internal/history`: JSON Lines at
+  `${XDG_STATE_HOME:-~/.local/state}/lazysql/history`, mode 0600, append-only
+  with atomic rewrites for delete/clear, unparsable lines skipped, compacted to
+  1000 entries on load. Panel [4] now renders it newest-first with `enter` (load
+  into the editor), `x` (run), `d` (delete), `D` (clear) and `/`. `sidePanel`
+  gained `sourceIndex` so `d` targets the right entry while a filter is active —
+  two runs of the same statement render as identical rows.
+


### PR DESCRIPTION
Adds a query editor modal (`:`) with sequential multi-statement execution, cancellable mid-flight, and a danger confirm for write statements. New `internal/history` package persists every executed statement (JSONL, 0600, compacted at 1000 entries); panel `[4]` supports load, run, delete, clear, and fuzzy filter. Query results page in memory with exact totals.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0139rhNA79AoksWw97zoxwWA