### PR TITLE
Add command log panel sourced from a driver logger

### DIFF
--- a/internal/db/conn.go
+++ b/internal/db/conn.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // conn is the one Driver implementation; all engine differences are
@@ -14,7 +15,10 @@ import (
 type conn struct {
 	dialect Dialect
 	db      *sql.DB
+	logger  *Logger
 }
+
+func (c *conn) Logger() *Logger { return c.logger }
 
 var errNotConnected = errors.New("db: not connected")
 
@@ -47,17 +51,26 @@ func (c *conn) Engine() Engine   { return c.dialect.Engine() }
 func (c *conn) Dialect() Dialect { return c.dialect }
 
 // querierAdapter narrows *sql.DB to the querier interface the dialects use.
-type querierAdapter struct{ db *sql.DB }
+// It logs through the same Logger as every other call the conn makes, so
+// introspection (columns, indexes, foreign keys, DDL) shows up in the
+// command log exactly like a browsed page or an edited row does.
+type querierAdapter struct {
+	db     *sql.DB
+	logger *Logger
+}
 
 func (q querierAdapter) QueryContext(ctx context.Context, query string, args ...any) (rowsScanner, error) {
-	return q.db.QueryContext(ctx, query, args...)
+	start := time.Now()
+	rows, err := q.db.QueryContext(ctx, query, args...)
+	q.logger.record(query, args, start, err)
+	return rows, err
 }
 
 func (c *conn) q() (querier, error) {
 	if c.db == nil {
 		return nil, errNotConnected
 	}
-	return querierAdapter{c.db}, nil
+	return querierAdapter{c.db, c.logger}, nil
 }
 
 func (c *conn) ListDatabases(ctx context.Context) ([]string, error) {
@@ -203,7 +216,9 @@ func (c *conn) Exec(ctx context.Context, query string, args ...any) (ExecResult,
 	if c.db == nil {
 		return ExecResult{}, errNotConnected
 	}
+	start := time.Now()
 	res, err := c.db.ExecContext(ctx, query, args...)
+	c.logger.record(query, args, start, err)
 	if err != nil {
 		return ExecResult{}, err
 	}
@@ -222,13 +237,17 @@ func (c *conn) ExecTx(ctx context.Context, stmts []Statement) ([]ExecResult, err
 	if c.db == nil {
 		return nil, errNotConnected
 	}
+	beginStart := time.Now()
 	tx, err := c.db.BeginTx(ctx, nil)
+	c.logger.record("BEGIN", nil, beginStart, err)
 	if err != nil {
 		return nil, err
 	}
 	out := make([]ExecResult, 0, len(stmts))
 	for i, s := range stmts {
+		start := time.Now()
 		res, err := tx.ExecContext(ctx, s.SQL, s.Args...)
+		c.logger.record(s.SQL, s.Args, start, err)
 		if err != nil {
 			tx.Rollback()
 			return nil, fmt.Errorf("statement %d of %d: %w", i+1, len(stmts), err)
@@ -242,7 +261,10 @@ func (c *conn) ExecTx(ctx context.Context, stmts []Statement) ([]ExecResult, err
 		}
 		out = append(out, r)
 	}
-	if err := tx.Commit(); err != nil {
+	commitStart := time.Now()
+	err = tx.Commit()
+	c.logger.record("COMMIT", nil, commitStart, err)
+	if err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -257,10 +279,14 @@ func (c *conn) QueryLimit(ctx context.Context, query string, max int, args ...an
 	if c.db == nil {
 		return nil, false, errNotConnected
 	}
+	start := time.Now()
 	rows, err := c.db.QueryContext(ctx, query, args...)
 	if err != nil {
+		c.logger.record(query, args, start, err)
 		return nil, false, err
 	}
 	defer rows.Close()
-	return scanResultSetLimit(ctx, rows, max)
+	rs, capped, err := scanResultSetLimit(ctx, rows, max)
+	c.logger.record(query, args, start, err)
+	return rs, capped, err
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -158,6 +158,10 @@ type Driver interface {
 	Engine() Engine
 	Dialect() Dialect
 
+	// Logger is the ring buffer every statement this Driver runs lands
+	// in, for the command log panel. Never nil.
+	Logger() *Logger
+
 	// ListDatabases returns the browsable namespaces: databases for
 	// MySQL/MariaDB, schemas of the connected database for PostgreSQL,
 	// attached databases for SQLite and DuckDB.
@@ -268,7 +272,7 @@ func Open(engine Engine) (Driver, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &conn{dialect: d}, nil
+	return &conn{dialect: d, logger: NewLogger()}, nil
 }
 
 // FormatValue renders a normalized cell value for display. NULL renders

--- a/internal/db/logger.go
+++ b/internal/db/logger.go
@@ -1,0 +1,74 @@
+package db
+
+import (
+	"sync"
+	"time"
+)
+
+// LogCapacity bounds the Logger's ring buffer.
+const LogCapacity = 500
+
+// LogEntry is one statement a Driver sent to the server: a page/count
+// query, a staged edit's UPDATE/INSERT/DELETE, a query-editor statement,
+// a transaction boundary (SQL is "BEGIN"/"COMMIT"), or an introspection
+// query. Err is the failure it returned, nil on success.
+type LogEntry struct {
+	SQL      string
+	Args     []any
+	At       time.Time
+	Duration time.Duration
+	Err      error
+}
+
+// Logger is a fixed-capacity ring buffer of every statement a conn runs.
+// It is appended to from the small number of places conn touches
+// database/sql — Exec, ExecTx, QueryLimit (which Query and the page/count
+// helpers funnel through) and the querier introspection queries — so
+// every statement is captured exactly once no matter which UI code path
+// triggered it, and nothing outside this package has to remember to log
+// anything.
+//
+// A nil *Logger is valid and every method on it is a no-op: conn always
+// has one, but the zero value is convenient for tests that build a conn
+// by hand.
+type Logger struct {
+	mu      sync.Mutex
+	entries []LogEntry
+	start   int // index of the oldest live entry
+	count   int
+}
+
+// NewLogger returns an empty Logger with room for LogCapacity entries.
+func NewLogger() *Logger {
+	return &Logger{entries: make([]LogEntry, LogCapacity)}
+}
+
+// record appends one entry, evicting the oldest once the buffer is full.
+func (l *Logger) record(sql string, args []any, start time.Time, err error) {
+	if l == nil {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	idx := (l.start + l.count) % len(l.entries)
+	l.entries[idx] = LogEntry{SQL: sql, Args: args, At: start, Duration: time.Since(start), Err: err}
+	if l.count < len(l.entries) {
+		l.count++
+	} else {
+		l.start = (l.start + 1) % len(l.entries)
+	}
+}
+
+// Entries returns the logged statements, oldest first.
+func (l *Logger) Entries() []LogEntry {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]LogEntry, l.count)
+	for i := range out {
+		out[i] = l.entries[(l.start+i)%len(l.entries)]
+	}
+	return out
+}

--- a/internal/db/logger_test.go
+++ b/internal/db/logger_test.go
@@ -1,0 +1,119 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestLoggerRingBufferWraps drops the oldest entry once the buffer is
+// full, keeping only the most recent LogCapacity statements.
+func TestLoggerRingBufferWraps(t *testing.T) {
+	l := &Logger{entries: make([]LogEntry, 3)}
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		l.record("SELECT "+string(rune('a'+i)), nil, now, nil)
+	}
+	got := l.Entries()
+	if len(got) != 3 {
+		t.Fatalf("len(Entries()) = %d, want 3", len(got))
+	}
+	want := []string{"SELECT c", "SELECT d", "SELECT e"}
+	for i, e := range got {
+		if e.SQL != want[i] {
+			t.Fatalf("entry %d = %q, want %q", i, e.SQL, want[i])
+		}
+	}
+}
+
+// TestLoggerCapturesDurationAndError checks the two fields the command
+// log panel colors and sorts by.
+func TestLoggerCapturesDurationAndError(t *testing.T) {
+	l := NewLogger()
+	start := time.Now().Add(-5 * time.Millisecond)
+	failure := errors.New("boom")
+	l.record("SELECT 1", []any{42}, start, nil)
+	l.record("SELECT 2", nil, start, failure)
+
+	got := l.Entries()
+	if len(got) != 2 {
+		t.Fatalf("len(Entries()) = %d, want 2", len(got))
+	}
+	if got[0].Err != nil {
+		t.Fatalf("entry 0 Err = %v, want nil", got[0].Err)
+	}
+	if got[0].Duration < 5*time.Millisecond {
+		t.Fatalf("entry 0 Duration = %v, want >= 5ms", got[0].Duration)
+	}
+	if len(got[0].Args) != 1 || got[0].Args[0] != 42 {
+		t.Fatalf("entry 0 Args = %v, want [42]", got[0].Args)
+	}
+	if !errors.Is(got[1].Err, failure) {
+		t.Fatalf("entry 1 Err = %v, want %v", got[1].Err, failure)
+	}
+}
+
+// A nil *Logger is what a hand-built conn has before Open sets one up;
+// every method must tolerate it instead of panicking.
+func TestNilLoggerIsSafe(t *testing.T) {
+	var l *Logger
+	l.record("SELECT 1", nil, time.Now(), nil)
+	if got := l.Entries(); got != nil {
+		t.Fatalf("Entries() on nil Logger = %v, want nil", got)
+	}
+}
+
+// TestConnLogsExactlyOnce is the acceptance criterion from end to end:
+// a page query, a count, a staged commit (ExecTx) and introspection each
+// append exactly one entry per statement to the same Driver.Logger(),
+// regardless of which method the UI called.
+func TestConnLogsExactlyOnce(t *testing.T) {
+	drv := openTest(t, EngineSQLite, "")
+	seed(t, drv)
+	ctx := context.Background()
+
+	before := len(drv.Logger().Entries())
+
+	if _, err := drv.QueryPage(ctx, "", "users", nil, nil, 10, 0); err != nil {
+		t.Fatalf("QueryPage: %v", err)
+	}
+	if _, err := drv.CountRows(ctx, "", "users", nil); err != nil {
+		t.Fatalf("CountRows: %v", err)
+	}
+	if _, err := drv.ExecTx(ctx, []Statement{{SQL: "UPDATE users SET name = 'ALICE' WHERE id = 1"}}); err != nil {
+		t.Fatalf("ExecTx: %v", err)
+	}
+	if _, err := drv.TableColumns(ctx, "", "users"); err != nil {
+		t.Fatalf("TableColumns: %v", err)
+	}
+
+	entries := drv.Logger().Entries()[before:]
+	// QueryPage(1) + CountRows(1) + ExecTx(BEGIN, statement, COMMIT = 3),
+	// then whatever introspection queries the dialect needs for
+	// TableColumns (at least 1) — every one of them a single entry, never
+	// duplicated and never dropped.
+	if len(entries) < 6 {
+		t.Fatalf("len(entries) = %d, want at least 6: %+v", len(entries), entries)
+	}
+	for _, e := range entries {
+		if e.Err != nil {
+			t.Fatalf("entry %q logged an error: %v", e.SQL, e.Err)
+		}
+	}
+	if entries[2].SQL != "BEGIN" || entries[4].SQL != "COMMIT" {
+		t.Fatalf("ExecTx entries = %q, %q, %q, want BEGIN, <stmt>, COMMIT",
+			entries[2].SQL, entries[3].SQL, entries[4].SQL)
+	}
+
+	// A failing statement is logged too, with its error attached.
+	_, err := drv.Exec(ctx, "UPDATE no_such_table SET x = 1")
+	if err == nil {
+		t.Fatal("Exec against a missing table did not fail")
+	}
+	last := drv.Logger().Entries()
+	got := last[len(last)-1]
+	if got.Err == nil {
+		t.Fatal("the failing statement's entry has no Err")
+	}
+}

--- a/internal/ui/commandlog_test.go
+++ b/internal/ui/commandlog_test.go
@@ -1,0 +1,56 @@
+package ui
+
+import (
+	"context"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// `@` opens the expanded, scrollable command log; `esc` returns to the
+// normal layout, like every other modal.
+func TestCommandLogExpandsAndCollapses(t *testing.T) {
+	m := browsing(t)
+	m = send(t, m, press('@'))
+	if _, ok := m.modal.(*commandLogModal); !ok {
+		t.Fatalf("modal = %T, want *commandLogModal", m.modal)
+	}
+	m = send(t, m, special(tea.KeyEscape, 0))
+	if m.modal != nil {
+		t.Fatalf("modal = %T, want nil after esc", m.modal)
+	}
+}
+
+// A statement the Driver's Logger caught as a failure must render red in
+// both the slim panel and the expanded view — the merged feed is where
+// both read from, so this only has to check the feed.
+func TestCommandLogColorsFailedStatement(t *testing.T) {
+	m := browsing(t)
+	if _, err := m.driver.Exec(context.Background(), "UPDATE no_such_table SET x = 1"); err == nil {
+		t.Fatal("expected the statement against a missing table to fail")
+	}
+	var found bool
+	for _, e := range m.commandLogEntries() {
+		if e.err {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("no failed entry in the merged command log: %+v", m.commandLogEntries())
+	}
+}
+
+// The Driver's Logger, not hand-formatted UI strings, is what the panel
+// renders a statement from: a page load appears in the merged log with
+// its duration attached, even though nothing in the UI layer logged it.
+func TestCommandLogEntriesCarryDuration(t *testing.T) {
+	m := dataBrowsing(t)
+	for _, e := range m.commandLogEntries() {
+		if e.err {
+			t.Fatalf("unexpected failed entry: %s", e.text)
+		}
+	}
+	if !logContains(m, "LIMIT 100 OFFSET 0") {
+		t.Fatalf("command log = %v", m.commandLogEntries())
+	}
+}

--- a/internal/ui/data.go
+++ b/internal/ui/data.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"charm.land/bubbles/v2/key"
@@ -241,7 +240,8 @@ func (m *Model) openTable(name string) tea.Cmd {
 }
 
 // reloadPage re-runs the page query and the count for the current
-// filter/sort/page, and logs the exact SQL both of them execute.
+// filter/sort/page. Both land in the command log through the Driver's
+// Logger as QueryPage/CountRows run them.
 func (m *Model) reloadPage() tea.Cmd {
 	if m.driver == nil || !m.data.browsing() {
 		return nil
@@ -250,10 +250,8 @@ func (m *Model) reloadPage() tea.Cmd {
 	m.data.loading = true
 	m.data.err = ""
 	d := m.data
-	dialect := m.driver.Dialect()
 
-	pageSQL := db.PageSQL(dialect, d.database, d.table, d.filter, d.sort, dataPageSize, d.offset())
-	countSQL := db.CountSQL(dialect, d.database, d.table, d.filter)
+	pageSQL := db.PageSQL(m.driver.Dialect(), d.database, d.table, d.filter, d.sort, dataPageSize, d.offset())
 
 	var cmds []tea.Cmd
 	// The warning goes first so it is not lost above the statement it
@@ -263,22 +261,11 @@ func (m *Model) reloadPage() tea.Cmd {
 			"-- WARNING: filter %q could not be parameterized — appended verbatim", d.filter.Raw))
 	}
 	cmds = append(cmds,
-		logCmd("%s", sqlLogLine(pageSQL, d.filter)),
-		logCmd("%s", sqlLogLine(countSQL, d.filter)),
 		historyCmd(pageSQL),
 		loadPageCmd(m.driver, d, m.data.req),
 		countRowsCmd(m.driver, d, m.data.req),
 	)
 	return tea.Batch(cmds...)
-}
-
-// sqlLogLine renders a statement for the command log, with its bound
-// arguments spelled out after it.
-func sqlLogLine(query string, f *db.Filter) string {
-	if f == nil || len(f.Args) == 0 {
-		return query + ";"
-	}
-	return fmt.Sprintf("%s;  -- args %v", query, f.Args)
 }
 
 // fresh reports whether a reply still belongs to the page on screen.

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -24,6 +24,7 @@ type keyMap struct {
 	// CancelQuery is only meaningful while a query runs and is enabled
 	// only then, so `ctrl+c` keeps meaning quit the rest of the time.
 	CancelQuery key.Binding
+	CommandLog  key.Binding
 	Help        key.Binding
 	Quit        key.Binding
 
@@ -86,7 +87,8 @@ func newKeyMap() keyMap {
 		OpenEditor: key.NewBinding(key.WithKeys(":"), key.WithHelp(":", "query editor")),
 		CancelQuery: key.NewBinding(
 			key.WithKeys("ctrl+c"), key.WithHelp("ctrl+c", "cancel query"), key.WithDisabled()),
-		Help: key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
+		CommandLog: key.NewBinding(key.WithKeys("@"), key.WithHelp("@", "expand command log")),
+		Help:       key.NewBinding(key.WithKeys("?"), key.WithHelp("?", "help")),
 		Quit: key.NewBinding(key.WithKeys("q", "ctrl+c"), key.WithHelp("q", "quit")),
 
 		NewConnection:  key.NewBinding(key.WithKeys("n"), key.WithHelp("n", "new connection")),
@@ -140,7 +142,7 @@ func (k keyMap) navigation() []key.Binding {
 func (k keyMap) global() []key.Binding {
 	return []key.Binding{
 		k.Jump, k.NextPanel, k.PrevPanel, k.ScreenNext, k.ScreenPrev,
-		k.OpenEditor, k.CancelQuery, k.Help, k.Quit,
+		k.OpenEditor, k.CancelQuery, k.CommandLog, k.Help, k.Quit,
 	}
 }
 

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -332,3 +332,78 @@ func (hm *helpModal) view(s styles, maxW, maxH int) string {
 		s.muted.Render("esc close"),
 	))
 }
+
+// ---------- command log ----------
+
+// commandLogModal is `@`'s expanded, scrollable view of the command log:
+// a snapshot of every entry taken when it opened, full untruncated SQL
+// text and all — the slim strip under the main view truncates to fit,
+// this does not. Like every other modal it renders from its own state,
+// so a statement that lands while it is open shows up the next time `@`
+// reopens it, not live.
+type commandLogModal struct {
+	lines  []logLine
+	offset int
+}
+
+func newCommandLogModal(lines []logLine) *commandLogModal {
+	return &commandLogModal{lines: lines, offset: max(len(lines)-1, 0)}
+}
+
+func (c *commandLogModal) update(msg tea.KeyPressMsg, m *Model) (bool, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "q", "@":
+		return true, nil
+	case "down", "j":
+		c.offset++
+	case "up", "k":
+		c.offset--
+	case "pgdown", "ctrl+f":
+		c.offset += 10
+	case "pgup", "ctrl+b":
+		c.offset -= 10
+	case "g", "home":
+		c.offset = 0
+	case "G", "end":
+		c.offset = len(c.lines)
+	}
+	return false, nil
+}
+
+func (c *commandLogModal) view(s styles, maxW, maxH int) string {
+	width := min(maxW-8, 160)
+	if width < 20 {
+		width = 20
+	}
+	rows := maxH - 6
+	if rows < 1 {
+		rows = 1
+	}
+	if rows > len(c.lines) {
+		rows = len(c.lines)
+	}
+	if maxOff := len(c.lines) - rows; c.offset > maxOff {
+		c.offset = maxOff
+	}
+	if c.offset < 0 {
+		c.offset = 0
+	}
+
+	var b strings.Builder
+	b.WriteString(s.modalTitle.Render("Command log") + "\n\n")
+	for _, line := range c.lines[c.offset : c.offset+rows] {
+		text := truncate(line.render(), width)
+		if line.err {
+			b.WriteString(s.danger.Render(text) + "\n")
+		} else {
+			b.WriteString(text + "\n")
+		}
+	}
+	footer := "esc close"
+	if len(c.lines) > rows {
+		footer = fmt.Sprintf("lines %d–%d of %d · ↑/↓ scroll · esc close",
+			c.offset+1, c.offset+rows, len(c.lines))
+	}
+	b.WriteString("\n" + s.muted.Render(footer))
+	return s.modal.Render(b.String())
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/help"
@@ -46,6 +48,58 @@ func logCmd(format string, a ...any) tea.Cmd {
 	return func() tea.Msg { return commandLogMsg{line: line} }
 }
 
+// logLine is one line the command log panel renders: either a UI note
+// (skip reasons, connect status, export progress — logCmd's own text) or
+// an executed statement pulled from the Driver's Logger. at orders the
+// two streams into one timeline; err colors the line red.
+type logLine struct {
+	text string
+	at   time.Time
+	err  bool
+}
+
+func (l logLine) render() string {
+	return l.at.Format("15:04:05") + "  " + l.text
+}
+
+// commandLogEntries merges the UI's own notes with the connected
+// Driver's Logger — the single choke point every Exec/Query runs
+// through — into one chronological feed for the slim panel and its `@`
+// expanded view. The Logger, not this slice, is what guarantees a
+// statement from browsing, editing or the query editor shows up exactly
+// once: nothing here re-formats SQL by hand.
+func (m Model) commandLogEntries() []logLine {
+	out := append([]logLine(nil), m.commandLog...)
+	if m.driver != nil {
+		for _, e := range m.driver.Logger().Entries() {
+			out = append(out, logLine{text: sqlEntryText(e), at: e.At, err: e.Err != nil})
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].at.Before(out[j].at) })
+	if n := len(out); n > db.LogCapacity {
+		out = out[n-db.LogCapacity:]
+	}
+	return out
+}
+
+// sqlEntryText spells one Logger entry the way the log already renders a
+// statement: the SQL, its bound args if any, how long it took, and the
+// error if it failed.
+func sqlEntryText(e db.LogEntry) string {
+	text := e.SQL
+	if !strings.HasSuffix(text, ";") {
+		text += ";"
+	}
+	if len(e.Args) > 0 {
+		text += fmt.Sprintf("  -- args %v", e.Args)
+	}
+	text += "  (" + formatTook(e.Duration) + ")"
+	if e.Err != nil {
+		text += fmt.Sprintf("  -- FAILED: %v", e.Err)
+	}
+	return text
+}
+
 // focusPanelMsg moves focus to a panel.
 type focusPanelMsg struct{ id panelID }
 
@@ -80,7 +134,7 @@ type Model struct {
 	modal  modal
 	screen screenMode
 
-	commandLog []string
+	commandLog []logLine
 
 	// Connection manager state. cfg is the on-disk connection list; connState
 	// is the transient per-connection status the panel colors itself by.
@@ -323,9 +377,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case commandLogMsg:
-		m.commandLog = append(m.commandLog, msg.line)
-		if n := len(m.commandLog); n > 200 {
-			m.commandLog = m.commandLog[n-200:]
+		m.commandLog = append(m.commandLog, logLine{
+			text: msg.line,
+			at:   time.Now(),
+			err:  strings.Contains(msg.line, "FAILED"),
+		})
+		if n := len(m.commandLog); n > db.LogCapacity {
+			m.commandLog = m.commandLog[n-db.LogCapacity:]
 		}
 		return m, nil
 
@@ -500,17 +558,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// changeset survives so the user can fix and retry.
 			return m, logCmd("-- COMMIT FAILED — nothing applied, changeset kept: %v", msg.err)
 		}
-		cmds := []tea.Cmd{logCmd("BEGIN;")}
+		// The transaction itself — BEGIN, each statement, COMMIT — is
+		// already in the command log: ExecTx logged it through the
+		// Driver's Logger as it ran. This only feeds the query-recall
+		// history, a separate concern from the audit trail.
+		var cmds []tea.Cmd
 		for _, s := range msg.stmts {
-			stmt := s
-			cmds = append(cmds,
-				logCmd("%s;  -- args %v", stmt.SQL, stmt.Args),
-				historyCmd(stmt.SQL),
-			)
+			cmds = append(cmds, historyCmd(s.SQL))
 		}
 		m.changes.Clear()
 		cmds = append(cmds,
-			logCmd("COMMIT;  -- %s applied", countChanges(len(msg.stmts))),
+			logCmd("-- commit ok: %s applied", countChanges(len(msg.stmts))),
 			m.reloadPage(),
 		)
 		return m, tea.Batch(cmds...)
@@ -587,6 +645,10 @@ func (m Model) updateGlobal(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
 	case key.Matches(msg, k.OpenEditor):
 		cmd := m.openQueryEditor()
 		return true, m, cmd
+
+	case key.Matches(msg, k.CommandLog):
+		m.modal = newCommandLogModal(m.commandLogEntries())
+		return true, m, nil
 
 	case key.Matches(msg, k.Quit):
 		return true, m, tea.Quit

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -422,8 +422,8 @@ func TestAskOnConnectOpensPasswordPrompt(t *testing.T) {
 }
 
 func logContains(m Model, want string) bool {
-	for _, l := range m.commandLog {
-		if strings.Contains(l, want) {
+	for _, l := range m.commandLogEntries() {
+		if strings.Contains(l.text, want) {
 			return true
 		}
 	}

--- a/internal/ui/query.go
+++ b/internal/ui/query.go
@@ -262,11 +262,12 @@ func (m *Model) cancelQuery() tea.Cmd {
 
 // ---------- reducing the worker's messages ----------
 
-// applyQueryStmt reduces one finished statement: it logs the statement,
-// records it in the history and routes its outcome into the Data tab.
+// applyQueryStmt reduces one finished statement: the statement itself is
+// already in the command log — the worker ran it through the Driver,
+// whose Logger caught it — so this only records it in the history and
+// routes its outcome into the Data tab.
 func (m *Model) applyQueryStmt(msg queryStmtMsg) tea.Cmd {
 	cmds := []tea.Cmd{
-		logCmd("%s;", flattenSQL(msg.sql)),
 		m.recordHistory(msg.sql),
 	}
 	where := ""
@@ -415,10 +416,6 @@ func countAffected(n int64) string {
 	}
 	return fmt.Sprintf("%d rows affected", n)
 }
-
-// flattenSQL collapses a multi-line statement onto the single line the
-// command log has room for.
-func flattenSQL(sql string) string { return flatten(sql) }
 
 // ---------- the editor modal ----------
 

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -267,7 +267,9 @@ func joinTruncated(lines []string, w, h int) string {
 	return strings.Join(out, "\n")
 }
 
-// renderCommandLog shows every statement the app executed, newest last.
+// renderCommandLog shows the tail of the command log — every statement
+// the app executed plus its own notes, newest last. `@` expands it into
+// a full scrollable view; this slim strip truncates long SQL to fit.
 func (m Model) renderCommandLog(w, h int) string {
 	cw, ch := maxInt(w-2, 1), maxInt(h-2, 1)
 	rows := ch - 1 // title line
@@ -275,12 +277,17 @@ func (m Model) renderCommandLog(w, h int) string {
 	var b strings.Builder
 	b.WriteString(m.style.title.Render("Command log"))
 	if rows > 0 {
-		start := len(m.commandLog) - rows
+		entries := m.commandLogEntries()
+		start := len(entries) - rows
 		if start < 0 {
 			start = 0
 		}
-		for _, line := range m.commandLog[start:] {
-			b.WriteString("\n" + m.style.muted.Render(truncate(line, cw)))
+		for _, e := range entries[start:] {
+			style := m.style.muted
+			if e.err {
+				style = m.style.danger
+			}
+			b.WriteString("\n" + style.Render(truncate(e.render(), cw)))
 		}
 	}
 	return m.style.blurredBorder.Width(w).Height(h).Render(b.String())

--- a/wiki/design/command-log-panel.md
+++ b/wiki/design/command-log-panel.md
@@ -1,0 +1,68 @@
+---
+type: Design Decision
+title: Command log panel sourced from a single Driver.Logger choke point
+description: Why every executed SQL statement is captured once in internal/db instead of hand-formatted at each UI call site, how the slim panel and the `@` expanded view merge that Logger with the UI's own status notes into one chronological feed, and why the expanded view is a static snapshot like every other modal.
+tags: [tui, db, logging, command-log, keybindings]
+generated:
+  by: claude-code/sonnet-5
+  at: 2026-08-09T00:00:00Z
+---
+
+# Command log panel
+
+## Decision
+
+Every statement lazysql sends to a server is captured exactly once, in
+`internal/db`, not by UI code remembering to log it. `conn` (the one
+`Driver` implementation) touches `database/sql` in exactly four places —
+`Exec`, `ExecTx`, `QueryLimit` (which `Query`, `QueryPage` and
+`CountRows` all funnel through) and `querierAdapter.QueryContext` (the
+introspection queries every dialect shares) — and each one calls
+`Logger.record` with the SQL, its bound args, a start time and the
+resulting error. `Logger` (`internal/db/logger.go`) is a fixed
+`LogCapacity`-entry (500) ring buffer; `Driver.Logger()` exposes it.
+
+This is the fix for a real gap: before this change, roughly ninety UI
+call sites formatted their own log lines, and several of them
+hand-echoed the exact SQL text a driver call was about to run (page/count
+queries in `data.go`, `BEGIN`/each statement/`COMMIT` in `model.go`'s
+commit handler, the query editor's per-statement text in `query.go`).
+Introspection queries (columns, indexes, foreign keys, DDL) were never
+logged at all. Moving the capture into `conn` means a future UI code
+path gets a correct, deduplicated log entry for free, and the four
+introspection queries now show up too.
+
+## Two streams, merged at render time
+
+The UI still has its own `commandLog []logLine` of plain status notes —
+"connect X FAILED", "copy skipped: nothing open", export progress — that
+never touch the database and so have nothing for `Logger` to record.
+`Model.commandLogEntries()` merges that slice with
+`m.driver.Logger().Entries()` by timestamp (`sort.SliceStable`) into one
+feed both the slim panel and the `@` expanded view render from. At
+session scale (≤ ~700 entries total) a sort on every render is not worth
+optimizing away; "no noticeable render slowdown" is trivially satisfied.
+
+A `logLine.err` is true either because a `db.LogEntry.Err` is non-nil or,
+for a UI note, because its text contains `"FAILED"` — the convention
+every existing note already used. Both render in `styles.danger` (red).
+
+## Why the expanded view is a snapshot, not live
+
+`@` opens a `commandLogModal`, matching `cellModal`/`helpModal`: `esc`
+returns, `j/k`/`pgup`/`pgdown`/`g`/`G` scroll. Modals in this codebase
+render from `view(s styles, maxW, maxH int) string` alone — they never
+see the live `Model` — so a statement that lands while the modal is open
+is not reflected until it is closed and reopened. Changing that would
+mean changing the `modal` interface for every existing modal to thread
+the `Model` through `view`, which is a much bigger change than one
+feature needs; `esc` then `@` again is a one-keystroke refresh.
+
+## Ring buffer, not unbounded
+
+`LogCapacity` (500) bounds `Logger` the same way the query history caps
+at 1000 ([query-editor-and-history](query-editor-and-history.md)) and
+the slim panel already capped its old `[]string` at 200: a long session
+should not grow the log forever. The merged `commandLogEntries()` also
+re-caps its combined output to `LogCapacity` after merging, so the UI
+notes half of the feed cannot make the whole thing unbounded either.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -18,6 +18,7 @@ concept with YAML frontmatter. Concept IDs are bundle-relative paths without
 - [design/staged-changeset](design/staged-changeset.md) — Design Decision — cell edits, row deletes and row inserts stage into one engine-agnostic changeset, rows are identified only by their primary key, and the commit runs every statement in one transaction.
 - [design/copy-and-export](design/copy-and-export.md) — Design Decision — one incremental serializer package behind both the `y` copy menu and the `E` file export, why a clipboard copy is capped while a file export streams, how NULL is spelled per format, and how the export reports progress and cancels.
 - [design/query-editor-and-history](design/query-editor-and-history.md) — Design Decision — `:` editor, why free-form results are materialized and paged in memory, dialect-aware statement splitting and read/write classification, confirmed-not-staged DML, run cancellation, and the JSON Lines history under `XDG_STATE_HOME`.
+- [design/command-log-panel](design/command-log-panel.md) — Design Decision — a single `Driver.Logger()` choke point in `internal/db` replaces per-callsite SQL echoing, merged with the UI's own status notes into one feed for the slim panel and the `@` expanded, scrollable view.
 
 ## reference
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -187,4 +187,20 @@ Chronological history of wiki changes, newest last.
   into the editor), `x` (run), `d` (delete), `D` (clear) and `/`. `sidePanel`
   gained `sourceIndex` so `d` targets the right entry while a filter is active —
   two runs of the same statement render as identical rows.
-
+- Added [design/command-log-panel](design/command-log-panel.md) (issue #11):
+  `internal/db/logger.go` adds a `Logger` ring buffer (`LogCapacity` 500) that
+  `conn` records into from its four `database/sql` choke points — `Exec`,
+  `ExecTx`, `QueryLimit` and the introspection `querierAdapter.QueryContext` —
+  so every statement is captured exactly once regardless of which UI path
+  triggered it, including the introspection queries that were never logged
+  before. Removed the ~dozen UI call sites that hand-echoed SQL text
+  (`data.go`'s page/count log lines, `model.go`'s `BEGIN`/statement/`COMMIT`
+  triplet, `query.go`'s per-statement echo) now that the Driver logs them
+  itself.
+- `Model.commandLogEntries()` merges that `Logger` with the UI's own
+  status-note stream (`commandLog []logLine`, timestamped, `err` set by a
+  `"FAILED"` substring) by timestamp into one feed. `@` opens a
+  `commandLogModal` (`esc`/`j`/`k`/`pgup`/`pgdown`/`g`/`G`) that is a snapshot
+  like every other modal — modals render from their own state, not the live
+  `Model`, so a statement logged while it is open needs a close/reopen to
+  show up.


### PR DESCRIPTION
## Summary
- Adds `internal/db.Logger`, a 500-entry ring buffer recorded into from `conn`'s four `database/sql` choke points (`Exec`, `ExecTx`, `QueryLimit`, and the introspection `querierAdapter.QueryContext`), so every statement — browsing, staged commits, the query editor, and introspection — is captured exactly once regardless of which UI path triggered it.
- Removes the ~dozen UI call sites that hand-formatted SQL text into the log (page/count queries, the commit transaction's BEGIN/statement/COMMIT, the query editor's per-statement echo), now redundant with the automatic capture.
- `Model.commandLogEntries()` merges the Logger with the UI's own status notes (connect/skip/export messages) into one chronological, timestamped feed; errors render in red in both the slim panel and the new `@` expanded, scrollable view (`esc` to close).
- Adds a wiki design concept documenting the choke-point/merge design and why the expanded view is a static snapshot like every other modal.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] New unit tests: `internal/db/logger_test.go` (ring buffer wraparound, duration/error capture, nil-safety, exactly-once across QueryPage/CountRows/ExecTx/introspection)
- [x] New UI tests: `internal/ui/commandlog_test.go` (`@` expand / `esc` collapse, failed statement renders red, merged entries carry duration)
- [x] Manual PTY smoke test: connected to a SQLite fixture, browsed a table, confirmed timestamped/duration'd entries in the slim panel, expanded with `@`, collapsed with `esc`, and confirmed a failing query-editor statement renders red in both views

Closes #11