### PR TITLE
Use rounded corners for panel borders

### DIFF
--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -90,7 +90,7 @@ type styles struct {
 }
 
 func newStyles() styles {
-	border := lipgloss.NewStyle().Border(lipgloss.NormalBorder())
+	border := lipgloss.NewStyle().Border(lipgloss.RoundedBorder())
 	return styles{
 		focusedBorder: border.BorderForeground(colorGreen),
 		blurredBorder: border.BorderForeground(colorMuted),


### PR DESCRIPTION
Closes #63

Panel border style switched from `NormalBorder()` to `RoundedBorder()` in `internal/ui/styles.go`; modals already used rounded. Diagram box-drawing in relations.go intentionally untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpyuD3vooiDSsmzE5iQr1u