### PR TITLE
fix: merge multi-column edits of one row into a single UPDATE (#80)

### DIFF
--- a/internal/db/changeset.go
+++ b/internal/db/changeset.go
@@ -316,16 +316,30 @@ type Statement struct {
 // value and every key value travel as parameters, identifiers get the
 // dialect's quoting. Nothing user-supplied reaches the statement text.
 func UpdateSQL(d Dialect, c CellChange) Statement {
+	return multiUpdateSQL(d, []CellChange{c})
+}
+
+// multiUpdateSQL renders every staged cell edit of one row as a single
+// UPDATE with one SET clause per column, in the order cells is given.
+// The caller is responsible for cells all sharing one row (same
+// database, table and primary key) — see Statements.
+func multiUpdateSQL(d Dialect, cells []CellChange) Statement {
+	first := cells[0]
 	var b strings.Builder
-	args := make([]any, 0, 1+len(c.PKVals))
+	args := make([]any, 0, len(cells)+len(first.PKVals))
 	b.WriteString("UPDATE ")
-	b.WriteString(qualifiedTable(d, c.Database, c.Table))
+	b.WriteString(qualifiedTable(d, first.Database, first.Table))
 	b.WriteString(" SET ")
-	b.WriteString(d.QuoteIdent(c.Column))
-	b.WriteString(" = ")
-	b.WriteString(d.Placeholder(1))
-	args = append(args, c.NewValue)
-	args = writeKeyPredicates(&b, d, c.PKCols, c.PKVals, args)
+	for i, c := range cells {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(d.QuoteIdent(c.Column))
+		b.WriteString(" = ")
+		b.WriteString(d.Placeholder(len(args) + 1))
+		args = append(args, c.NewValue)
+	}
+	args = writeKeyPredicates(&b, d, first.PKCols, first.PKVals, args)
 	return Statement{SQL: b.String(), Args: args}
 }
 
@@ -392,11 +406,72 @@ func writeKeyPredicates(b *strings.Builder, d Dialect, cols []string, vals, args
 	return args
 }
 
-// Statements renders the whole changeset in commit order.
+// rowIdentity encodes the database, table and primary-key values that
+// identify one row, for grouping cell changes that target the same row.
+func rowIdentity(database, table string, pkVals []any) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s\x00%s", database, table)
+	writeKeyVals(&b, pkVals)
+	return b.String()
+}
+
+// Statements renders the whole changeset in commit order. Cell edits
+// that target the same row merge into one multi-column UPDATE, columns
+// ordered by when they were first staged; every other change (a row
+// delete, a row insert, or a cell edit that cannot be safely merged)
+// renders on its own, at the position of its first occurrence.
+//
+// Merging is safe under the "no delete/insert for that row" rule: a
+// row's cell edits only combine if no RowDelete targeting the same row
+// appears anywhere in the changeset. That is always true in practice —
+// StageDelete drops a row's staged cell edits when the delete is staged,
+// and the UI refuses to stage a new edit on a row with a pending delete
+// — but Statements does not lean on either of those to hold; it checks
+// directly, so a row with a (theoretically) coexisting delete and cell
+// edits still commits each cell edit as its own UPDATE rather than
+// merging across the delete and risking an order it was never staged
+// in. A RowInsert can never collide with a row identity: it has no
+// primary key of its own until the engine assigns one.
 func (cs *Changeset) Statements(d Dialect) []Statement {
-	out := make([]Statement, 0, len(cs.ops))
+	deletedRows := make(map[string]bool)
 	for _, c := range cs.ops {
-		out = append(out, c.Statement(d))
+		if r, ok := c.(RowDelete); ok {
+			deletedRows[rowIdentity(r.Database, r.Table, r.PKVals)] = true
+		}
 	}
-	return out
+
+	out := make([]Statement, len(cs.ops))
+	kept := make([]bool, len(cs.ops))
+	firstAt := make(map[string]int)
+	cellsFor := make(map[string][]CellChange)
+	for i, c := range cs.ops {
+		cc, ok := c.(CellChange)
+		if !ok {
+			out[i] = c.Statement(d)
+			kept[i] = true
+			continue
+		}
+		rid := rowIdentity(cc.Database, cc.Table, cc.PKVals)
+		if deletedRows[rid] {
+			out[i] = cc.Statement(d)
+			kept[i] = true
+			continue
+		}
+		if _, seen := firstAt[rid]; !seen {
+			firstAt[rid] = i
+			kept[i] = true
+		}
+		cellsFor[rid] = append(cellsFor[rid], cc)
+	}
+	for rid, i := range firstAt {
+		out[i] = multiUpdateSQL(d, cellsFor[rid])
+	}
+
+	result := make([]Statement, 0, len(out))
+	for i, k := range kept {
+		if k {
+			result = append(result, out[i])
+		}
+	}
+	return result
 }

--- a/internal/db/changeset_test.go
+++ b/internal/db/changeset_test.go
@@ -312,6 +312,142 @@ func TestChangesetKeysAreTyped(t *testing.T) {
 	}
 }
 
+// Editing several columns of one row must commit as one UPDATE with one
+// SET clause per column, in the order the columns were first staged —
+// and must not disturb edits of other rows or tables.
+func TestStatementsMergesSameRowEdits(t *testing.T) {
+	cs := NewChangeset()
+	cs.Stage(CellChange{Table: "t", PKCols: []string{"id"}, PKVals: []any{int64(1)}, Column: "b", NewValue: "b1"})
+	cs.Stage(CellChange{Table: "t", PKCols: []string{"id"}, PKVals: []any{int64(1)}, Column: "a", NewValue: "a1"})
+	cs.Stage(CellChange{Table: "t", PKCols: []string{"id"}, PKVals: []any{int64(2)}, Column: "b", NewValue: "b2"})
+	cs.Stage(CellChange{Table: "other", PKCols: []string{"id"}, PKVals: []any{int64(1)}, Column: "b", NewValue: "bx"})
+
+	stmts := cs.Statements(dialect(t, EngineSQLite))
+	wantSQL := []string{
+		`UPDATE "t" SET "b" = ?, "a" = ? WHERE "id" = ?`,
+		`UPDATE "t" SET "b" = ? WHERE "id" = ?`,
+		`UPDATE "other" SET "b" = ? WHERE "id" = ?`,
+	}
+	if len(stmts) != len(wantSQL) {
+		t.Fatalf("statements = %d, want %d: %+v", len(stmts), len(wantSQL), stmts)
+	}
+	for i, want := range wantSQL {
+		if stmts[i].SQL != want {
+			t.Errorf("statement %d = %q, want %q", i, stmts[i].SQL, want)
+		}
+	}
+	if !slices.Equal(stmts[0].Args, []any{any("b1"), any("a1"), any(int64(1))}) {
+		t.Errorf("merged args = %v", stmts[0].Args)
+	}
+}
+
+// A composite primary key merges the same way, and PostgreSQL's
+// positional placeholders keep counting across the merged SET clauses
+// into the WHERE predicates.
+func TestStatementsMergeCompositeKeyPlaceholders(t *testing.T) {
+	cs := NewChangeset()
+	pk := []string{"student", "course"}
+	pv := []any{int64(1), "math"}
+	cs.Stage(CellChange{Table: "grades", PKCols: pk, PKVals: pv, Column: "grade", NewValue: "A"})
+	cs.Stage(CellChange{Table: "grades", PKCols: pk, PKVals: pv, Column: "credit", NewValue: int64(3)})
+
+	stmts := cs.Statements(dialect(t, EnginePostgres))
+	if len(stmts) != 1 {
+		t.Fatalf("statements = %d, want 1 merged UPDATE", len(stmts))
+	}
+	want := `UPDATE "grades" SET "grade" = $1, "credit" = $2 WHERE "student" = $3 AND "course" = $4`
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+	if !slices.Equal(stmts[0].Args, []any{any("A"), any(int64(3)), any(int64(1)), any("math")}) {
+		t.Errorf("args = %v", stmts[0].Args)
+	}
+
+	// MySQL/SQLite use the same "?" placeholder for every parameter.
+	mysqlStmt := cs.Statements(dialect(t, EngineMySQL))[0]
+	wantMySQL := "UPDATE `grades` SET `grade` = ?, `credit` = ? WHERE `student` = ? AND `course` = ?"
+	if mysqlStmt.SQL != wantMySQL {
+		t.Errorf("MySQL SQL = %q, want %q", mysqlStmt.SQL, wantMySQL)
+	}
+}
+
+// Unstaging one of several edits on a row must drop just that column
+// from the merged UPDATE, not the whole statement.
+func TestStatementsUnstageFromMergedRow(t *testing.T) {
+	cs := NewChangeset()
+	pk, pv := []string{"id"}, []any{int64(1)}
+	cs.Stage(CellChange{Table: "t", PKCols: pk, PKVals: pv, Column: "a", NewValue: "a1"})
+	cs.Stage(CellChange{Table: "t", PKCols: pk, PKVals: pv, Column: "b", NewValue: "b1"})
+	cs.Stage(CellChange{Table: "t", PKCols: pk, PKVals: pv, Column: "c", NewValue: "c1"})
+
+	if !cs.Unstage("", "t", pv, "b") {
+		t.Fatal("Unstage missed a staged cell in a merged row")
+	}
+	stmts := cs.Statements(dialect(t, EngineSQLite))
+	if len(stmts) != 1 {
+		t.Fatalf("statements = %d, want 1", len(stmts))
+	}
+	want := `UPDATE "t" SET "a" = ?, "c" = ? WHERE "id" = ?`
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q", stmts[0].SQL, want)
+	}
+}
+
+// edit(rowA.x) -> delete(rowA) -> unstage the delete -> edit(rowA.y)
+// must never apply x and y out of the order they were staged in. Since
+// StageDelete already drops a row's staged cell edits when the delete
+// is staged, x is gone by the time the delete lands, so only y survives
+// to commit — the interleaved delete cannot resurrect it.
+func TestStatementsInterleavedDeleteDoesNotReorder(t *testing.T) {
+	cs := NewChangeset()
+	pk, pv := []string{"id"}, []any{int64(1)}
+	cs.Stage(CellChange{Table: "t", PKCols: pk, PKVals: pv, Column: "x", NewValue: "x1"})
+	cs.StageDelete(RowDelete{Table: "t", PKCols: pk, PKVals: pv})
+	if !cs.UnstageDelete("", "t", pv) {
+		t.Fatal("UnstageDelete missed the staged delete")
+	}
+	cs.Stage(CellChange{Table: "t", PKCols: pk, PKVals: pv, Column: "y", NewValue: "y1"})
+
+	stmts := cs.Statements(dialect(t, EngineSQLite))
+	if len(stmts) != 1 {
+		t.Fatalf("statements = %d, want 1: %+v", len(stmts), stmts)
+	}
+	want := `UPDATE "t" SET "y" = ? WHERE "id" = ?`
+	if stmts[0].SQL != want {
+		t.Errorf("SQL = %q, want %q (x must not resurface)", stmts[0].SQL, want)
+	}
+}
+
+// Statements only merges a row's cell edits when no staged delete of
+// that row exists anywhere in the changeset. Stage cannot itself be
+// reached this way through the UI (it refuses to stage an edit on a
+// row that has a pending delete), but Statements checks directly rather
+// than trust that invariant, so even a changeset built to coexist a
+// delete with cell edits of the same row still renders each edit as
+// its own UPDATE instead of merging across the delete.
+func TestStatementsDoesNotMergeAcrossACoexistingDelete(t *testing.T) {
+	cs := NewChangeset()
+	pk, pv := []string{"id"}, []any{int64(1)}
+	cs.StageDelete(RowDelete{Table: "t", PKCols: pk, PKVals: pv})
+	cs.Stage(CellChange{Table: "t", PKCols: pk, PKVals: pv, Column: "a", NewValue: "a1"})
+	cs.Stage(CellChange{Table: "t", PKCols: pk, PKVals: pv, Column: "b", NewValue: "b1"})
+
+	stmts := cs.Statements(dialect(t, EngineSQLite))
+	wantSQL := []string{
+		`DELETE FROM "t" WHERE "id" = ?`,
+		`UPDATE "t" SET "a" = ? WHERE "id" = ?`,
+		`UPDATE "t" SET "b" = ? WHERE "id" = ?`,
+	}
+	if len(stmts) != len(wantSQL) {
+		t.Fatalf("statements = %d, want %d: %+v", len(stmts), len(wantSQL), stmts)
+	}
+	for i, want := range wantSQL {
+		if stmts[i].SQL != want {
+			t.Errorf("statement %d = %q, want %q", i, stmts[i].SQL, want)
+		}
+	}
+}
+
 // The whole commit is one transaction: a failing statement rolls back
 // the ones before it.
 func TestExecTxRollsBackOnError(t *testing.T) {

--- a/internal/ui/edit.go
+++ b/internal/ui/edit.go
@@ -176,6 +176,9 @@ func (m *Model) stageChange(c db.CellChange) tea.Cmd {
 		return logCmd("-- not staged: %s.%s is unchanged", c.Table, c.Column)
 	}
 	m.changes.Stage(c)
+	// This previews the single-cell edit just staged, not the merged
+	// statement it may end up part of — Changeset.Statements groups it
+	// with any other staged edits of the same row only at commit time.
 	st := db.UpdateSQL(m.driver.Dialect(), c)
 	return logCmd("-- stage: %s;  -- args %v", st.SQL, st.Args)
 }

--- a/wiki/design/staged-changeset.md
+++ b/wiki/design/staged-changeset.md
@@ -95,6 +95,35 @@ columns from any staged change of the table, which is how staged cells
 stay highlighted (yellow, showing the staged value) after the metadata
 cache was reset.
 
+### Multi-column edits of one row merge into one UPDATE at render time
+
+Staging stays per-cell — `Stage`/`Unstage`/`Lookup` and the per-cell
+replace-on-restage rule above are unchanged — but `Changeset.Statements`
+(the single choke point the commit modal and `commitChangesCmd` both go
+through) groups `CellChange`s that target the same row (same database,
+table and typed PK values) into one `UPDATE … SET a = ?, b = ? WHERE …`
+instead of rendering N single-column UPDATEs. Column order in `SET` is
+first-staged order; `multiUpdateSQL` builds it, and `UpdateSQL` (still
+used for the single-cell case, and for the per-edit preview line logged
+at stage time) is now a one-cell call into it. `d.Placeholder(n)` keeps
+counting across the merged `SET` clauses into the `WHERE`, so PostgreSQL
+still gets `$1..$n` in order.
+
+The merge rule is "a row's cell edits combine unless a `RowDelete` for
+that row is anywhere in the changeset" — checked directly in
+`Statements` by pre-scanning `cs.ops` for delete row-identities, not
+inferred from adjacency. That makes it safe regardless of how the ops
+slice is ordered: `StageDelete` already drops a row's pending cell
+edits when the delete lands, and the UI refuses to stage a new edit on
+a row with a pending delete (`openEditModal` checks `DeleteStaged`), so
+in practice a delete and cell edits of the same row never coexist — but
+`Statements` does not lean on either of those holding. If they ever did
+coexist, the affected cells fall back to individual single-column
+UPDATEs (still correct, just unmerged) rather than risk merging across
+a delete into an order that was never staged. A `RowInsert` can never
+collide with a row identity — it has no primary key until the engine
+assigns one — so it never blocks a merge.
+
 ### Commit is one transaction, and failure keeps the changeset
 
 `ExecTx` wraps all statements — UPDATEs, DELETEs and INSERTs alike — in

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -986,3 +986,12 @@ Chronological history of wiki changes, newest last.
   `ListTriggers`/`TriggerDDL` pair; renumbering notes added to
   [design/tui-shell-architecture](design/tui-shell-architecture.md) and the
   concepts that named `[2]`/`[3]` by number.
+
+## 2026-08-10
+
+- Updated [design/staged-changeset](design/staged-changeset.md) (issue #80):
+  `Changeset.Statements` now merges same-row `CellChange`s into one
+  multi-column UPDATE instead of one per cell. Documented the merge rule
+  (blocked only by a coexisting `RowDelete` for that row, checked directly
+  rather than assumed) and why it is safe given `StageDelete`'s existing
+  purge and the UI's edit-on-deleted-row refusal.


### PR DESCRIPTION
Closes #80.

`Changeset.Statements()` now groups staged cell edits by row identity (database+table+PK values) and emits one UPDATE with a combined SET clause per row, placed at the first edit's position so overall op order is preserved. Placeholder numbering carries correctly into WHERE (PostgreSQL `$n`). Cells never merge across a coexisting `RowDelete` for the same row — checked by pre-scanning ops rather than trusting staging invariants. Staging API unchanged; merging is render-time only.

Tests: multi-column merge, separate rows/tables, composite PK + placeholder numbering (Postgres/MySQL), unstage-one-column-from-merged, interleaved delete/unstage/re-edit, defensive no-merge-across-delete.

Verified: `go vet`, `go build`, `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpyuD3vooiDSsmzE5iQr1u