### PR TITLE
feat: show column data type in edit and insert modals

### DIFF
--- a/internal/ui/edit.go
+++ b/internal/ui/edit.go
@@ -146,14 +146,14 @@ func (m *Model) openEditModal() tea.Cmd {
 		initial = staged.NewValue
 	}
 
-	nullable := true
+	col := db.Column{Name: colName, Nullable: true}
 	for _, c := range m.meta.cols {
 		if c.Name == colName {
-			nullable = c.Nullable
+			col = c
 			break
 		}
 	}
-	m.modal = newEditCellModal(change, initial, nullable, rowLabel(pkCols, pkVals))
+	m.modal = newEditCellModal(change, initial, col, rowLabel(pkCols, pkVals))
 	return nil
 }
 
@@ -330,13 +330,13 @@ func convertInput(text string, old any) any {
 // Submitting stages the change; nothing here touches the database.
 type editCellModal struct {
 	change   db.CellChange
+	col      db.Column
 	rowLabel string
 	input    textinput.Model
 	null     bool
-	nullable bool
 }
 
-func newEditCellModal(change db.CellChange, initial any, nullable bool, rowLabel string) *editCellModal {
+func newEditCellModal(change db.CellChange, initial any, col db.Column, rowLabel string) *editCellModal {
 	ti := textinput.New()
 	ti.Placeholder = "value"
 	if initial != nil {
@@ -347,10 +347,10 @@ func newEditCellModal(change db.CellChange, initial any, nullable bool, rowLabel
 	ti.SetWidth(40)
 	return &editCellModal{
 		change:   change,
+		col:      col,
 		rowLabel: rowLabel,
 		input:    ti,
 		null:     initial == nil,
-		nullable: nullable,
 	}
 }
 
@@ -392,17 +392,23 @@ func (e *editCellModal) view(s styles, maxW, maxH int) string {
 	e.input.SetWidth(min(50, maxW-8))
 	title := fmt.Sprintf("Edit %s.%s — %s", e.change.Table, e.change.Column, e.rowLabel)
 
+	typeLine := strings.ToLower(e.col.DataType)
+	if !e.col.Nullable {
+		typeLine += " · NOT NULL"
+	}
+
 	value := e.input.View()
 	if e.null {
 		value = s.pending.Render(nullText) + s.muted.Render("  (ctrl+n for a value)")
 	}
 	lines := []string{
 		s.modalTitle.Render(truncate(title, min(maxW-8, 70))),
+		s.muted.Render(truncate(typeLine, min(maxW-8, 70))),
 		"",
 		s.muted.Render("current: " + truncate(flatten(db.FormatValue(e.change.OldValue, nullText)), 50)),
 		value,
 	}
-	if e.null && !e.nullable {
+	if e.null && !e.col.Nullable {
 		lines = append(lines, s.danger.Render("column is NOT NULL — the commit will fail"))
 	}
 	lines = append(lines, "", s.muted.Render("enter stage · ctrl+n NULL · esc cancel"))

--- a/internal/ui/rowops.go
+++ b/internal/ui/rowops.go
@@ -458,18 +458,36 @@ func (f *insertRowModal) build() (db.RowInsert, string) {
 	return r, ""
 }
 
+// typeTag is the dimmed hint shown next to each field's label: the
+// column's declared type, plus NOT NULL and its default when the driver
+// reported them.
+func typeTag(c db.Column) string {
+	t := strings.ToLower(c.DataType)
+	if !c.Nullable {
+		t += " NOT NULL"
+	}
+	if c.Default != nil {
+		t += " default:" + flatten(*c.Default)
+	}
+	return t
+}
+
 func (f *insertRowModal) view(s styles, maxW, maxH int) string {
 	width := min(maxW-8, 72)
 	if width < 20 {
 		width = 20
 	}
-	labelW := 0
+	labelW, typeW := 0, 0
 	for _, fl := range f.fields {
 		if w := lipgloss.Width(fl.col.Name); w > labelW {
 			labelW = w
 		}
+		if w := lipgloss.Width(typeTag(fl.col)); w > typeW {
+			typeW = w
+		}
 	}
-	inputW := min(38, maxInt(width-labelW-6, 12))
+	typeW = min(typeW, 20)
+	inputW := min(38, maxInt(width-labelW-typeW-8, 12))
 
 	// title, blank, error, blank, footer, borders
 	rows := maxH - 8
@@ -505,7 +523,10 @@ func (f *insertRowModal) view(s styles, maxW, maxH int) string {
 		} else {
 			label = s.muted.Render(label)
 		}
-		b.WriteString(marker + label + "  " + truncate(f.fieldValue(s, fl), inputW+22) + "\n")
+		typeStr := truncate(typeTag(fl.col), typeW)
+		typeStr += strings.Repeat(" ", typeW-lipgloss.Width(typeStr))
+		b.WriteString(marker + label + "  " + s.muted.Render(typeStr) + "  " +
+			truncate(f.fieldValue(s, fl), inputW+22) + "\n")
 	}
 	if len(f.fields) > rows {
 		b.WriteString(s.muted.Render(fmt.Sprintf("… %d of %d columns\n",


### PR DESCRIPTION
Closes #94

Edit cell modal shows a dimmed subtitle with the column type and NOT NULL flag; insert row form shows a type hint column per field (type, NOT NULL, default). Metadata comes from the existing `db.Column` struct — no driver changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpyuD3vooiDSsmzE5iQr1u