### PR TITLE
fix: confirm before quitting with staged changes (#103)

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -1191,14 +1191,19 @@ func (m Model) updateGlobal(msg tea.KeyPressMsg) (bool, tea.Model, tea.Cmd) {
 		return true, m, nil
 
 	case key.Matches(msg, k.Quit):
-		// Torn down here rather than in a tea.Cmd: tea.Quit can stop the
-		// program before a batched command ever runs, which would leave the
-		// SSH connection and its forwarded sockets to the OS.
-		if m.cfg.RestoreSessionEnabled() {
-			m.saveSession()
+		if n := m.changes.Len(); n > 0 {
+			m.modal = &confirmModal{
+				title:  "Quit",
+				body:   fmt.Sprintf("Quit and discard %s? They are not saved on exit.", countChanges(n)),
+				danger: true,
+				onConfirm: func(mm *Model) tea.Cmd {
+					mm.quit()
+					return tea.Quit
+				},
+			}
+			return true, m, nil
 		}
-		_ = (&config.State{ScreenMode: screenModeNames[m.screen]}).Save()
-		m.closeSession()
+		m.quit()
 		return true, m, tea.Quit
 
 	case key.Matches(msg, k.Help):
@@ -1470,6 +1475,18 @@ func (m Model) dialSelected(test bool) (Model, tea.Cmd) {
 		m.setConnStatus(c.Name, statusPending, "")
 	}
 	return m, redialCmd(req)
+}
+
+// quit saves session/screen state and tears down the connection. Called
+// synchronously (not as a tea.Cmd) because tea.Quit can stop the program
+// before a batched command ever runs, which would leave the SSH connection
+// and its forwarded sockets to the OS.
+func (m *Model) quit() {
+	if m.cfg.RestoreSessionEnabled() {
+		m.saveSession()
+	}
+	_ = (&config.State{ScreenMode: screenModeNames[m.screen]}).Save()
+	m.closeSession()
 }
 
 // closeSession tears down the active driver and its tunnel synchronously.

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -604,6 +604,42 @@ func TestQuitPersistsScreenModeForNextStartup(t *testing.T) {
 	}
 }
 
+// q with a pending changeset must confirm before quitting, and must not
+// persist state or tear down the connection until confirmed — the guard
+// from issue #103.
+func TestQuitWithStagedChangesAsksToConfirm(t *testing.T) {
+	removeState(t)
+	m := dataBrowsing(t)
+	m = send(t, m, press('l'))
+	m = stageEdit(t, m, "tmp")
+	if m.changes.Len() != 1 {
+		t.Fatalf("changeset = %d, want 1", m.changes.Len())
+	}
+
+	m = send(t, m, press('q'))
+	cm, ok := m.modal.(*confirmModal)
+	if !ok {
+		t.Fatalf("q opened %T, want a confirmation", m.modal)
+	}
+	if !strings.Contains(cm.body, "1 staged change") {
+		t.Fatalf("body = %q", cm.body)
+	}
+	if m.driver == nil {
+		t.Fatal("q must not tear down the connection before confirmation")
+	}
+
+	// esc keeps the changeset and the program running.
+	m = send(t, m, special(tea.KeyEscape, 0))
+	if m.changes.Len() != 1 {
+		t.Fatal("esc on the quit confirmation dropped the changeset")
+	}
+
+	m = send(t, m, press('q'), special(tea.KeyEnter, 0))
+	if m.driver != nil {
+		t.Fatal("confirmed quit did not tear down the connection")
+	}
+}
+
 // An unknown value in the state file must never block startup: it degrades
 // to screenNormal like a missing file would.
 func TestNewFallsBackToNormalOnUnknownSavedScreenMode(t *testing.T) {


### PR DESCRIPTION
Closes #103.

`q` with staged changes now opens a confirm modal ("Quit and discard N staged changes?"); esc cancels, enter quits. Empty changeset quits directly as before.

- `internal/ui/model.go`: quit teardown extracted into `m.quit()`; `k.Quit` routes through confirmModal when changeset non-empty.
- `internal/ui/model_test.go`: new `TestQuitWithStagedChangesAsksToConfirm`.

Verified: `go build`, `go vet`, `go test ./internal/ui/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpyuD3vooiDSsmzE5iQr1u