### PR TITLE
fix: clip command log lines to box height (#104)

### DIFF
--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -471,7 +471,15 @@ func (m Model) renderCommandLog(w, h int) string {
 		if e.err {
 			style = m.style.danger
 		}
-		lines = append(lines, style.Render(truncate(e.render(), cw)))
+		for _, l := range strings.Split(e.render(), "\n") {
+			lines = append(lines, style.Render(truncate(l, cw)))
+		}
+	}
+	// An entry can itself span multiple display lines (wrapped SQL), so
+	// the split above may still exceed rows — clip to the newest lines
+	// that fit or the box overflows its border and hides the options bar.
+	if start := len(lines) - rows; start > 0 {
+		lines = lines[start:]
 	}
 	return renderTitledBox(m.style.blurredBorder,
 		m.style.title.Render("Command log"), strings.Join(lines, "\n"), w, h)


### PR DESCRIPTION
Closes #104.

`renderCommandLog` now splits each entry on `\n` before per-line width truncation, then clips total display lines to the box height (keeping newest). Previously it only sliced by entry count, so entries with embedded newlines (wrapped SQL) overflowed the border and covered the options bar.

Verified: `go build`, `go vet`, `go test ./internal/ui/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpyuD3vooiDSsmzE5iQr1u