### PR TITLE
fix: keep completion popup inside main column bounds (#105)

### DIFF
--- a/internal/ui/complete_test.go
+++ b/internal/ui/complete_test.go
@@ -608,6 +608,14 @@ func TestPopupStaysInsideTheTerminal(t *testing.T) {
 		if x < 0 || y < 0 {
 			t.Errorf("%dx%d: popup at (%d,%d)", size[0], size[1], x, y)
 		}
+		// In the split layout (the default screen mode) the side column
+		// sits left of the main column. A popup wide enough to need
+		// sliding must slide only within the main column — left of it is
+		// the side panels' borders, not empty space to float over.
+		mx, _, _, _, mok := mm.mainColumnRect()
+		if mok && x < mx {
+			t.Errorf("%dx%d: popup left edge at %d overlaps the side column (starts at %d)", size[0], size[1], x, mx)
+		}
 		if x+w > size[0] {
 			t.Errorf("%dx%d: popup right edge at %d overflows the terminal", size[0], size[1], x+w)
 		}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -240,12 +240,18 @@ func (m Model) completionLayer() (box string, x, y int, ok bool) {
 	}
 	ax, ay := mx+1+caretCol, my+1+caretRow
 
-	box = m.completionPopup(m.width, m.height-1)
+	// The box is measured and placed against the main column alone, not
+	// the full terminal: in a split layout the side column sits to its
+	// left, and a popup wide enough to slide past mx would draw over the
+	// side panels' borders instead of floating over the editor. Placing
+	// in coordinates relative to the column and translating back keeps
+	// placePopup's own logic untouched.
+	box = m.completionPopup(mw, mh)
 	if box == "" {
 		return "", 0, 0, false
 	}
-	x, y = placePopup(ax, ay, lipgloss.Width(box), lipgloss.Height(box), m.width, m.height-1)
-	return box, x, y, true
+	relX, relY := placePopup(ax-mx, ay-my, lipgloss.Width(box), lipgloss.Height(box), mw, mh)
+	return box, mx + relX, my + relY, true
 }
 
 // placePopup puts a w x h box next to an anchor cell inside a screen of

--- a/wiki/design/schema-aware-autocomplete.md
+++ b/wiki/design/schema-aware-autocomplete.md
@@ -62,6 +62,20 @@ the right edge, flipped above when the bottom would cut it off. It is a
 pure function and unit-tested as one, because with the editor capped at
 half the main view the flip case is not reachable by resizing.
 
+`completionLayer` measures and slides the box against the **main
+column's** bounds, not the full terminal (issue #105). The split layout
+puts the side column left of the main column; `placePopup`'s job is to
+keep the box on screen, and a screen width of `m.width` let it slide the
+box past the main column's left edge and over the side panels' own
+borders whenever the column was narrower than the popup — which happens
+at any width near `minWidth`, since `completionWidth` is a fixed budget,
+not a fraction of the column. `completionLayer` now translates the
+anchor into column-relative coordinates, calls `placePopup` with the
+column's own width, and translates the result back — `placePopup` itself
+stays a pure two-box function with no idea a side column exists.
+`m.completionPopup` also takes the column width as its cap, so the box's
+text can never be wider than the column it has to fit inside.
+
 ## 2. A token scan, not a parser
 
 Which columns are worth offering depends on which tables the statement

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1047,3 +1047,18 @@ Chronological history of wiki changes, newest last.
   check against the CLAUDE.md lazygit conventions, and an explicit
   verified-fine list. Server-based engines and long-running-query feedback
   remain uncovered and need a follow-up pass.
+
+## 2026-08-11
+
+- Fixed F2 of the UX audit (issue #105): the completion popup's placement
+  was computed against the full terminal width instead of the main
+  column's, so in the default split layout a popup wider than a narrow
+  main column slid left over the side panels' own borders — on screen
+  this reads as corrupted box-drawing over `[1]`/`[2]`/`[3]`, not as a
+  suggestion list, which is what the audit read as "no popup rendered
+  anywhere". `completionLayer` (`internal/ui/view.go`) now measures and
+  slides the box in main-column-relative coordinates and caps its text
+  width to the column. Updated
+  [design/schema-aware-autocomplete](design/schema-aware-autocomplete.md)'s
+  anchoring section and added a regression assertion to
+  `TestPopupStaysInsideTheTerminal`.


### PR DESCRIPTION
Closes #105.

Root cause: `completionLayer` in `internal/ui/view.go` placed/sized the popup against the full terminal width. With a narrow main column (split layout, small terminals), `placePopup`'s slide-to-fit pushed the box over the side panels, corrupting their borders — appearing as if no popup rendered.

Fix: cap popup width to the main column and place/slide in column-relative coordinates, then translate back to screen coordinates. `placePopup` untouched.

Verified in real PTY (tmux) at 60×20, 80×20, 120×35, split and full-screen. `TestPopupStaysInsideTheTerminal` extended (fails pre-fix). `go build`, `go vet`, full `go test ./...` pass. Wiki updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpyuD3vooiDSsmzE5iQr1u