### PR TITLE
fix: label sub-context keymap groups in help overlay (#106)

### DIFF
--- a/internal/ui/browse_test.go
+++ b/internal/ui/browse_test.go
@@ -442,7 +442,7 @@ func TestObjectsPanelDocumentsItsTreeKeys(t *testing.T) {
 	k := newKeyMap()
 	want := map[string]bool{"expand": false, "collapse": false}
 	for _, group := range k.helpGroups(panelObjects) {
-		for _, b := range group {
+		for _, b := range group.bindings {
 			if _, ok := want[b.Help().Desc]; ok {
 				want[b.Help().Desc] = true
 			}

--- a/internal/ui/complete_test.go
+++ b/internal/ui/complete_test.go
@@ -657,7 +657,7 @@ func TestCompletionKeysAreDocumented(t *testing.T) {
 	k := newKeyMap()
 	documented := map[string]bool{}
 	for _, group := range k.helpGroups(panelQuery) {
-		for _, b := range group {
+		for _, b := range group.bindings {
 			documented[b.Help().Key] = true
 		}
 	}

--- a/internal/ui/dumprestore_test.go
+++ b/internal/ui/dumprestore_test.go
@@ -489,7 +489,7 @@ func backupLogText(m Model) []string {
 
 func helpMentions(m Model, id panelID, want string) bool {
 	for _, group := range m.keys.helpGroups(id) {
-		for _, b := range group {
+		for _, b := range group.bindings {
 			if b.Help().Desc == want {
 				return true
 			}

--- a/internal/ui/foreignkey_test.go
+++ b/internal/ui/foreignkey_test.go
@@ -306,7 +306,7 @@ func TestForeignKeyBindingsAreDocumented(t *testing.T) {
 	}
 	var listed int
 	for _, group := range k.helpGroups(panelMain) {
-		for _, b := range group {
+		for _, b := range group.bindings {
 			for _, keyName := range want {
 				if len(b.Keys()) > 0 && b.Keys()[0] == keyName {
 					listed++

--- a/internal/ui/history_test.go
+++ b/internal/ui/history_test.go
@@ -218,7 +218,7 @@ func TestHistoryPaneKeysAreInHelp(t *testing.T) {
 	k := newKeyMap()
 	documented := map[string]bool{}
 	for _, group := range k.helpGroups(panelQuery) {
-		for _, b := range group {
+		for _, b := range group.bindings {
 			documented[b.Help().Key] = true
 		}
 	}

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -673,29 +673,47 @@ func withoutBindings(all, hide []key.Binding) []key.Binding {
 	return out
 }
 
+// helpGroup is one labeled column of the `?` listing. The label names the
+// sub-context the bindings belong to, so a key that means one thing while
+// browsing and another inside a modal (h/← , e, tab…) reads as scoped
+// instead of duplicated or conflicting — see issue #106.
+type helpGroup struct {
+	label    string
+	bindings []key.Binding
+}
+
 // helpGroups is the full `?` listing for the focused panel, drawn from the
-// same bindings as the options bar.
-func (k keyMap) helpGroups(id panelID) [][]key.Binding {
-	groups := [][]key.Binding{k.actions(id)}
+// same bindings as the options bar. Every group beyond the first names the
+// sub-context its keys only apply in, since those keys are not live while
+// browsing the panel itself.
+func (k keyMap) helpGroups(id panelID) []helpGroup {
+	groups := []helpGroup{{"", k.actions(id)}}
 	// The editor's insert mode swallows almost every key, so its own
 	// short list is documented next to the panel's normal-mode actions
 	// rather than being reachable only from a mode `?` cannot open.
 	if id == panelQuery {
 		groups = append(groups,
-			k.editorNormal(), k.editorInsert(), k.editorCompletion(),
-			k.historyPane(), k.queryResultKeys())
+			helpGroup{"In vim normal mode:", k.editorNormal()},
+			helpGroup{"In insert mode:", k.editorInsert()},
+			helpGroup{"In the completion popup:", k.editorCompletion()},
+			helpGroup{"In history & snippets:", k.historyPane()},
+			helpGroup{"Result grid (under the editor):", k.queryResultKeys()},
+		)
 	}
 	// The cell editor and the insert form both open from the data grid,
 	// and so does the date picker they hand temporal columns to.
 	if id == panelMain {
-		groups = append(groups, k.datePicker())
+		groups = append(groups, helpGroup{"In the date picker:", k.datePicker()})
 	}
 	// The connection form is opened from the Connections panel, so its
 	// path-completion keys are documented there.
 	if id == panelConnections {
-		groups = append(groups, k.formPathComplete())
+		groups = append(groups, helpGroup{"In forms:", k.formPathComplete()})
 	}
-	return append(groups, k.navigationFor(id), k.global())
+	return append(groups,
+		helpGroup{"", k.navigationFor(id)},
+		helpGroup{"", k.global()},
+	)
 }
 
 // bindingSlot pairs a `[keys]` config action name with the keyMap field it

--- a/internal/ui/keys_override_test.go
+++ b/internal/ui/keys_override_test.go
@@ -79,7 +79,7 @@ func TestKeyOverridePropagatesToOptionsBarAndHelp(t *testing.T) {
 
 	found := false
 	for _, group := range km.helpGroups(panelConnections) {
-		for _, b := range group {
+		for _, b := range group.bindings {
 			if b.Help().Desc == "quit" {
 				found = true
 				if b.Help().Key != "x" {

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -359,7 +359,7 @@ func (c *cellModal) view(s styles, maxW, maxH int) string {
 // options bar is built from.
 type helpModal struct {
 	title  string
-	groups [][]key.Binding
+	groups []helpGroup
 	help   help.Model
 	// offset scrolls the packed columns when they outgrow the terminal —
 	// a narrow window stacks the groups tall, and clipping them would
@@ -367,7 +367,7 @@ type helpModal struct {
 	offset int
 }
 
-func newHelpModal(title string, groups [][]key.Binding) *helpModal {
+func newHelpModal(title string, groups []helpGroup) *helpModal {
 	h := help.New()
 	h.ShowAll = true
 	return &helpModal{title: title, groups: groups, help: h}
@@ -405,10 +405,13 @@ func (hm *helpModal) view(s styles, maxW, maxH int) string {
 	var row []string
 	rowW := 0
 	for _, g := range hm.groups {
-		if len(g) == 0 {
+		if len(g.bindings) == 0 {
 			continue
 		}
-		col := hm.help.FullHelpView([][]key.Binding{g})
+		col := hm.help.FullHelpView([][]key.Binding{g.bindings})
+		if g.label != "" {
+			col = s.muted.Bold(true).Render(g.label) + "\n" + col
+		}
 		w := lipgloss.Width(col)
 		if len(row) > 0 && rowW+gap+w > avail {
 			rows = append(rows, lipgloss.JoinHorizontal(lipgloss.Top, row...))

--- a/internal/ui/model_test.go
+++ b/internal/ui/model_test.go
@@ -735,7 +735,7 @@ func TestOptionsBarAndHelpShareOneSource(t *testing.T) {
 	for id := panelID(0); id <= panelMain; id++ {
 		helpKeys := map[string]bool{}
 		for _, group := range k.helpGroups(id) {
-			for _, b := range group {
+			for _, b := range group.bindings {
 				helpKeys[b.Help().Key] = true
 			}
 		}
@@ -791,7 +791,7 @@ func TestEveryDocumentedKeyIsBound(t *testing.T) {
 		}
 
 		for _, group := range k.helpGroups(id) {
-			for _, b := range group {
+			for _, b := range group.bindings {
 				for _, ks := range b.Keys() {
 					if !global[ks] && !actions[ks] {
 						t.Errorf("panel %v: `?` documents %q but nothing binds it", panelTitles[id], ks)

--- a/internal/ui/query_test.go
+++ b/internal/ui/query_test.go
@@ -199,7 +199,7 @@ func TestEditorKeysAreDocumented(t *testing.T) {
 	k := newKeyMap()
 	documented := map[string]bool{}
 	for _, group := range k.helpGroups(panelQuery) {
-		for _, b := range group {
+		for _, b := range group.bindings {
 			documented[b.Help().Key] = true
 		}
 	}

--- a/internal/ui/readonly_test.go
+++ b/internal/ui/readonly_test.go
@@ -219,10 +219,10 @@ func offersBinding(bindings []key.Binding, desc string) bool {
 	return false
 }
 
-func flattenGroups(groups [][]key.Binding) []key.Binding {
+func flattenGroups(groups []helpGroup) []key.Binding {
 	var out []key.Binding
 	for _, g := range groups {
-		out = append(out, g...)
+		out = append(out, g.bindings...)
 	}
 	return out
 }

--- a/internal/ui/vim_test.go
+++ b/internal/ui/vim_test.go
@@ -392,7 +392,7 @@ func TestNormalModeHelpListsTheVimKeys(t *testing.T) {
 	k := newKeyMap()
 	var flat []string
 	for _, group := range k.helpGroups(panelQuery) {
-		for _, b := range group {
+		for _, b := range group.bindings {
 			flat = append(flat, b.Help().Key)
 		}
 	}

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1062,3 +1062,16 @@ Chronological history of wiki changes, newest last.
   [design/schema-aware-autocomplete](design/schema-aware-autocomplete.md)'s
   anchoring section and added a regression assertion to
   `TestPopupStaysInsideTheTerminal`.
+
+- Fixed F3 of the UX audit (issue #106): `?` packed every sub-context's
+  bindings (date picker, form path-completion, query-editor vim/insert/
+  completion/history) into the same unlabeled column list as the panel's
+  own actions, so a key that means one thing while browsing and another
+  inside a modal — `h`/`←`, `e`, `tab` — read as duplicated or
+  conflicting rather than scoped. `keyMap.helpGroups`
+  (`internal/ui/keys.go`) now returns `[]helpGroup{label, bindings}`
+  instead of bare `[][]key.Binding`; sub-context groups carry a label
+  ("In the date picker:", "In forms:", "In vim normal mode:", etc.), the
+  panel's own actions and the always-on navigation/global groups stay
+  unlabeled. `helpModal.view` (`internal/ui/modal.go`) renders the label
+  above its column when present.


### PR DESCRIPTION
Closes #106.

- `keyMap.helpGroups` (`internal/ui/keys.go`) returns `[]helpGroup{label, bindings}` instead of bare `[][]key.Binding`; sub-context groups get labels ("In the date picker:", "In forms:", "In vim normal mode:", "In insert mode:", "In the completion popup:", "In history & snippets:", "Result grid (under the editor):").
- `helpModal.view` (`internal/ui/modal.go`) renders the label above its column.
- Test call sites updated across 10 test files; wiki log entry added.

Verified: `go build`, `go vet`, full `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpyuD3vooiDSsmzE5iQr1u