### PR TITLE
fix: wrap long values in cell viewer instead of truncating (#107)

### DIFF
--- a/internal/ui/celldetail_test.go
+++ b/internal/ui/celldetail_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 )
 
 func TestClassifyCell(t *testing.T) {
@@ -150,6 +151,31 @@ func TestViewCellRendersBlobAsHexDump(t *testing.T) {
 	}
 	if c.rawText != "\xde\xad\xbe\xef\x00\xff" {
 		t.Errorf("rawText = %q, want the untransformed bytes", c.rawText)
+	}
+}
+
+// A long single-line value wraps to the modal width instead of getting
+// truncated with an ellipsis, and j/k scroll through the wrapped lines.
+func TestViewCellWrapsLongValue(t *testing.T) {
+	m := sized(120, 40)
+	long := strings.Repeat("abcde ", 100) // 600 bytes, well past any modal width or height
+	c := newCellModal("t", "col", "text", long)
+
+	out := c.view(m.style, 60, 12)
+	if strings.Contains(out, "…") {
+		t.Errorf("view = %q, want wrapped content, not an ellipsis-truncated line", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if lipgloss.Width(line) > 60 {
+			t.Errorf("line %q wider than the modal (60)", line)
+		}
+	}
+
+	before := out
+	c.update(press('j'), &m)
+	after := c.view(m.style, 60, 12)
+	if before == after {
+		t.Error("j did not scroll a wrapped multi-line cell value")
 	}
 }
 

--- a/internal/ui/modal.go
+++ b/internal/ui/modal.go
@@ -9,6 +9,7 @@ import (
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"lazysql/internal/db"
 )
@@ -325,14 +326,28 @@ func (c *cellModal) view(s styles, maxW, maxH int) string {
 	if width < 8 {
 		width = 8
 	}
+
+	// Wrap every logical line to the modal width rather than truncating
+	// it — a single 167-byte value is one entry in c.lines, so without
+	// wrapping it would render (and scroll) as exactly one row no matter
+	// how long it is.
+	var wrapped []string
+	for _, line := range c.lines {
+		if line == "" {
+			wrapped = append(wrapped, "")
+			continue
+		}
+		wrapped = append(wrapped, strings.Split(ansi.Wrap(line, width, ""), "\n")...)
+	}
+
 	rows := maxH - 6
 	if rows < 1 {
 		rows = 1
 	}
-	if rows > len(c.lines) {
-		rows = len(c.lines)
+	if rows > len(wrapped) {
+		rows = len(wrapped)
 	}
-	if maxOff := len(c.lines) - rows; c.offset > maxOff {
+	if maxOff := len(wrapped) - rows; c.offset > maxOff {
 		c.offset = maxOff
 	}
 	if c.offset < 0 {
@@ -341,13 +356,13 @@ func (c *cellModal) view(s styles, maxW, maxH int) string {
 
 	var b strings.Builder
 	b.WriteString(s.modalTitle.Render(truncate(c.title, width)) + "\n\n")
-	for _, line := range c.lines[c.offset : c.offset+rows] {
-		b.WriteString(truncate(line, width) + "\n")
+	for _, line := range wrapped[c.offset : c.offset+rows] {
+		b.WriteString(line + "\n")
 	}
 	footer := "y copy · esc close"
-	if len(c.lines) > rows {
+	if len(wrapped) > rows {
 		footer = fmt.Sprintf("lines %d–%d of %d · ↑/↓ scroll · y copy · esc close",
-			c.offset+1, c.offset+rows, len(c.lines))
+			c.offset+1, c.offset+rows, len(wrapped))
 	}
 	b.WriteString("\n" + s.muted.Render(footer))
 	return s.modal.Render(b.String())


### PR DESCRIPTION
Closes #107.

`cellModal.view` (`internal/ui/modal.go`) previously cut each line to one row with an ellipsis. It now wraps each logical line to the modal's content width via `ansi.Wrap` before pagination; `j`/`k`, `ctrl+d/u`, `g`/`G` scroll the wrapped lines, so single long values span multiple rows and are fully reachable. `x` row detail reuses `newCellModal`, so fixed as well.

New `TestViewCellWrapsLongValue`: 600-byte single-line value renders without `…`, no line exceeds modal width, `j` scrolls.

Verified: `go build`, `go vet`, full `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpyuD3vooiDSsmzE5iQr1u