### PR TITLE
fix: render BLOB cells as placeholder, honest empty-table message (#108)

### DIFF
--- a/internal/ui/celldetail_test.go
+++ b/internal/ui/celldetail_test.go
@@ -154,6 +154,20 @@ func TestViewCellRendersBlobAsHexDump(t *testing.T) {
 	}
 }
 
+// A BLOB cell in the grid itself renders as a placeholder, not the raw
+// bytes: control characters in the value would otherwise break the row and
+// misalign the right border.
+func TestGridRendersBlobAsPlaceholder(t *testing.T) {
+	m := binaryBrowsing(t)
+	out := m.View().Content
+	if !strings.Contains(out, "<blob 6 B>") {
+		t.Errorf("view = %q, want a blob placeholder for the payload cell", out)
+	}
+	if strings.ContainsRune(out, 0xDEAD) {
+		t.Errorf("view contains a raw non-UTF-8 rune from the blob")
+	}
+}
+
 // A long single-line value wraps to the modal width instead of getting
 // truncated with an ellipsis, and j/k scroll through the wrapped lines.
 func TestViewCellWrapsLongValue(t *testing.T) {

--- a/internal/ui/data_test.go
+++ b/internal/ui/data_test.go
@@ -289,6 +289,49 @@ func TestBrokenFilterKeepsThePageAndReports(t *testing.T) {
 	}
 }
 
+// A genuinely empty table says so plainly; only a filtered view that
+// matches nothing implies an active filter.
+func TestEmptyTableSaysSoWithoutImplyingAFilter(t *testing.T) {
+	m := browsing(t)
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`DROP TABLE IF EXISTS nobody`,
+		`CREATE TABLE nobody (id INTEGER PRIMARY KEY)`,
+	} {
+		if _, err := m.driver.Exec(ctx, stmt); err != nil {
+			t.Fatalf("fixture %q: %v", stmt, err)
+		}
+	}
+	m = send(t, m, press('2'), press('R'))
+	if !m.panels[panelObjects].selectByName("nobody") {
+		t.Fatalf("fixture table not listed: %v", m.panels[panelObjects].items)
+	}
+	m = send(t, m, special(tea.KeyEnter, 0))
+
+	out := m.View().Content
+	if !strings.Contains(out, "table is empty") {
+		t.Errorf("view = %q, want it to say the table is empty", out)
+	}
+	if strings.Contains(out, "no rows match") {
+		t.Errorf("view = %q, an unfiltered empty table should not imply a filter", out)
+	}
+}
+
+// A filter that matches nothing still says "no rows match", since a
+// filter is active and could plausibly be loosened.
+func TestFilteredEmptyResultSaysNoRowsMatch(t *testing.T) {
+	m := dataBrowsing(t)
+	m = applyWhereFilter(t, m, "id = -1")
+
+	out := m.View().Content
+	if !strings.Contains(out, "no rows match") {
+		t.Errorf("view = %q, want it to say no rows match", out)
+	}
+	if strings.Contains(out, "table is empty") {
+		t.Errorf("view = %q, a filtered view should not say the table is empty", out)
+	}
+}
+
 // `h`/`l` walk the cell cursor and clamp at both ends; `j`/`k` walk rows.
 func TestCellCursorMovesAndClamps(t *testing.T) {
 	m := dataBrowsing(t)

--- a/internal/ui/datagrid.go
+++ b/internal/ui/datagrid.go
@@ -117,7 +117,7 @@ func (m Model) buildGrid() ([]gridColumn, []rowKind) {
 				}
 			}
 			g.nulls[r] = v == nil
-			g.cells[r] = flatten(db.FormatValue(v, nullText))
+			g.cells[r] = gridCellText(v, nullText)
 		}
 		for j, ins := range inserts {
 			r := len(d.rows) + j
@@ -129,7 +129,7 @@ func (m Model) buildGrid() ([]gridColumn, []rowKind) {
 				g.nulls[r] = true
 				g.cells[r] = nullText
 			default:
-				g.cells[r] = flatten(db.FormatValue(v, nullText))
+				g.cells[r] = gridCellText(v, nullText)
 			}
 		}
 		for _, cell := range g.cells {
@@ -164,6 +164,18 @@ func (m Model) stagedRowKeys() [][]any {
 		}
 	}
 	return keys
+}
+
+// gridCellText formats a cell's value for the grid, standing a placeholder
+// in for BLOBs: raw bytes carry control characters that break the row and
+// misalign the right border, and the cell-detail popup (`v`) already gives
+// binary values a proper hex dump, so the grid does not need to show them.
+func gridCellText(v any, null string) string {
+	raw := db.FormatValue(v, null)
+	if classifyCell(raw) == cellBinary {
+		return fmt.Sprintf("<blob %d B>", len(raw))
+	}
+	return flatten(raw)
 }
 
 // flatten collapses whitespace that would otherwise break the row into
@@ -272,7 +284,11 @@ func (m Model) dataBody(w, h int) string {
 			lines = append(lines, m.gridRow(cols[cs:ce], cs, r, kinds[r], w))
 		}
 		if len(kinds) == 0 {
-			lines = append(lines, m.style.muted.Render("no rows match"))
+			msg := "table is empty"
+			if d.filter != nil {
+				msg = "no rows match"
+			}
+			lines = append(lines, m.style.muted.Render(msg))
 		}
 		if cs > 0 || ce < len(cols) {
 			lines = append(lines, m.style.muted.Render(fmt.Sprintf(

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1075,3 +1075,15 @@ Chronological history of wiki changes, newest last.
   panel's own actions and the always-on navigation/global groups stay
   unlabeled. `helpModal.view` (`internal/ui/modal.go`) renders the label
   above its column when present.
+
+- Fixed F5+F6 of the UX audit (issue #108): the data grid formatted BLOB
+  cells the same as any other value, so raw bytes — including control
+  characters — landed straight in the row and broke its layout, misaligning
+  the right border; and an empty result always read "no rows match", which
+  implies an active filter even when the table genuinely has no rows.
+  `gridCellText` (`internal/ui/datagrid.go`) now reuses `classifyCell`
+  (already used by the cell-detail popup's hex dump) to detect binary
+  values and renders `<blob N B>` instead. `dataBody` now checks
+  `d.filter == nil` to say "table is empty" for a genuinely empty,
+  unfiltered result, keeping "no rows match" for a filter that matches
+  nothing.


### PR DESCRIPTION
Closes #108.

- BLOB corruption: new `gridCellText` helper in `internal/ui/datagrid.go` reuses `classifyCell` (same detection as cell-detail hex dump) and renders `<blob N B>` instead of raw bytes.
- Empty message: unfiltered empty table now says "table is empty"; "no rows match" reserved for active filters.

New tests: `TestGridRendersBlobAsPlaceholder`, `TestEmptyTableSaysSoWithoutImplyingAFilter`, `TestFilteredEmptyResultSaysNoRowsMatch`. Wiki log updated.

Verified: `go build`, `go vet`, full `go test ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpyuD3vooiDSsmzE5iQr1u