### PR TITLE
fix: data grid moving left scrolls columns minimally

### DIFF
--- a/internal/ui/data.go
+++ b/internal/ui/data.go
@@ -80,10 +80,18 @@ type dataView struct {
 	total    int64
 	hasTotal bool
 
-	// Cell cursor. The row and column scroll windows are derived from it
-	// at render time rather than stored, so a resize can never leave a
-	// stale offset behind.
+	// Cell cursor. The row window is derived from it at render time rather
+	// than stored, so a resize can never leave a stale offset behind.
 	row, col int
+
+	// colOff is the left edge of the column window, in step with col via
+	// Model.syncColOff so h/l scroll minimally: it only moves when the
+	// cursor would otherwise leave the visible window. Unlike the row
+	// window it cannot be purely re-derived at render time, because for a
+	// given cursor column more than one window can validly contain it —
+	// which one is right depends on where the window was before, not just
+	// on the cursor. columnWindow still re-clamps it against a resize.
+	colOff int
 
 	// extraRows is how many phantom rows (staged inserts) the grid
 	// appends after the page. The changeset owns them; this is the count

--- a/internal/ui/data_test.go
+++ b/internal/ui/data_test.go
@@ -435,11 +435,11 @@ func TestWideTableScrollsHorizontally(t *testing.T) {
 	m = next.(Model)
 
 	cols, _ := m.buildGrid()
-	start, end := columnWindow(cols, 0, 30)
+	start, end := columnWindow(cols, 0, 0, 30)
 	if start != 0 || end >= len(cols) {
 		t.Fatalf("window at the first column = [%d,%d), want a partial window from 0", start, end)
 	}
-	lastStart, lastEnd := columnWindow(cols, len(cols)-1, 30)
+	lastStart, lastEnd := columnWindow(cols, len(cols)-1, 0, 30)
 	if len(cols)-1 < lastStart || len(cols)-1 >= lastEnd {
 		t.Fatalf("window [%d,%d) does not contain the cursor column %d", lastStart, lastEnd, len(cols)-1)
 	}
@@ -451,6 +451,100 @@ func TestWideTableScrollsHorizontally(t *testing.T) {
 	if out := m.View().Content; !strings.Contains(out, "columns ") {
 		t.Error("the grid does not report the visible column range")
 	}
+}
+
+// columnWindow scrolls right minimally (by exactly enough to keep the
+// cursor visible), and moving the cursor back left must not scroll at all
+// while it is still inside that window — it should only scroll once the
+// cursor passes the window's left edge.
+func TestColumnWindowMinimalScroll(t *testing.T) {
+	cols := make([]gridColumn, 5)
+	for i := range cols {
+		cols[i].width = 10
+	}
+	const w = 32 // 10 + 1 + 10 + 1 + 10 = 32: exactly three columns fit.
+
+	start, end := columnWindow(cols, 0, 0, w)
+	if start != 0 || end != 3 {
+		t.Fatalf("initial window = [%d,%d), want [0,3)", start, end)
+	}
+
+	// Cursor moves right past the window: it scrolls by exactly one column.
+	start, end = columnWindow(cols, 3, start, w)
+	if start != 1 || end != 4 {
+		t.Fatalf("scroll-right window = [%d,%d), want [1,4)", start, end)
+	}
+
+	// Cursor moves back left but stays inside [1,4): no shift, no dropped column.
+	start2, end2 := columnWindow(cols, 2, start, w)
+	if start2 != start || end2 != end {
+		t.Fatalf("move left within the window shifted it: [%d,%d) -> [%d,%d)", start, end, start2, end2)
+	}
+
+	// Cursor moves left past the window's left edge (column 1 -> column 0):
+	// the window must scroll left to keep it visible.
+	start3, end3 := columnWindow(cols, 0, start2, w)
+	if start3 != 0 {
+		t.Fatalf("scroll-left window start = %d, want 0", start3)
+	}
+	if end3 <= 0 {
+		t.Fatalf("scroll-left window = [%d,%d), want a non-empty window", start3, end3)
+	}
+}
+
+// A remembered offset from a wider terminal (or a column list that shrank)
+// must not leave the cursor, or the window itself, out of bounds.
+func TestColumnWindowClampsStaleOffset(t *testing.T) {
+	cols := make([]gridColumn, 5)
+	for i := range cols {
+		cols[i].width = 10
+	}
+	if start, end := columnWindow(cols, 1, 4, 32); start > 1 || end <= 1 {
+		t.Fatalf("window [%d,%d) does not contain cursor 1 with a stale offset ahead of it", start, end)
+	}
+	if start, end := columnWindow(cols, 1, 999, 32); start > 1 || end <= 1 {
+		t.Fatalf("window [%d,%d) does not contain cursor 1 with an out-of-range offset", start, end)
+	}
+}
+
+// Moving the cursor left within the currently visible columns must not
+// scroll the grid or drop the rightmost visible column; only moving past
+// the window's left edge should scroll it.
+func TestColumnLeftScrollIsMinimal(t *testing.T) {
+	m := dataBrowsing(t)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 80, Height: 30})
+	m = next.(Model)
+
+	m = send(t, m, press('l'), press('l'), press('l'))
+	scrolled := gridColumnsLine(t, m)
+	if scrolled == "" {
+		t.Fatal("expected the grid to report a scrolled column window")
+	}
+
+	m = send(t, m, press('h'))
+	afterOneLeft := gridColumnsLine(t, m)
+	if afterOneLeft != scrolled {
+		t.Fatalf("moving left within the window scrolled it: %q -> %q", scrolled, afterOneLeft)
+	}
+
+	// Walk the cursor past the window's left edge: it must scroll back.
+	m = send(t, m, press('h'), press('h'), press('h'))
+	afterEdge := gridColumnsLine(t, m)
+	if afterEdge == afterOneLeft {
+		t.Fatalf("moving left past the window's edge did not scroll: stayed at %q", afterEdge)
+	}
+}
+
+// gridColumnsLine returns the "columns X–Y of Z" status line, or "" when
+// the grid renders every column and reports no window at all.
+func gridColumnsLine(t *testing.T, m Model) string {
+	t.Helper()
+	for _, line := range strings.Split(m.View().Content, "\n") {
+		if strings.Contains(line, "columns ") {
+			return line
+		}
+	}
+	return ""
 }
 
 // The grid survives every terminal size the shell claims to support.

--- a/internal/ui/datagrid.go
+++ b/internal/ui/datagrid.go
@@ -188,21 +188,36 @@ func flatten(s string) string {
 }
 
 // columnWindow picks the slice of columns that fits in w cells while
-// keeping the cursor column visible. The window is derived from the
-// cursor rather than remembered, so it survives a resize: the cursor
-// stays put and the window re-packs around it.
-func columnWindow(cols []gridColumn, cursor, w int) (start, end int) {
+// keeping the cursor column visible, scrolling minimally: off (the
+// previous window's left edge) is reused as-is when the cursor is still
+// inside it, only pulled left to the cursor when the cursor moved past
+// its left edge, and only pushed right when the cursor no longer fits
+// within w cells of it. off also survives a resize, since it is re-packed
+// and re-clamped against the current cols/w on every call rather than
+// trusted outright — a stale offset from a wider terminal (or a shrunk
+// column list) can never leave the cursor, or the window itself, out of
+// bounds.
+func columnWindow(cols []gridColumn, cursor, off, w int) (start, end int) {
 	if len(cols) == 0 {
 		return 0, 0
 	}
 	if cursor < 0 {
 		cursor = 0
 	}
-	for start = 0; start <= cursor; start++ {
+	if cursor >= len(cols) {
+		cursor = len(cols) - 1
+	}
+	if off < 0 {
+		off = 0
+	}
+	if off > cursor {
+		off = cursor
+	}
+	for {
 		total := 0
-		for end = start; end < len(cols); end++ {
+		for end = off; end < len(cols); end++ {
 			need := cols[end].width
-			if end > start {
+			if end > off {
 				need += colGap
 			}
 			if total+need > w {
@@ -210,14 +225,31 @@ func columnWindow(cols []gridColumn, cursor, w int) (start, end int) {
 			}
 			total += need
 		}
-		if end == start {
-			end = start + 1 // never render zero columns
+		if end == off {
+			end = off + 1 // never render zero columns
 		}
 		if cursor < end {
-			return start, end
+			return off, end
 		}
+		off++
 	}
-	return cursor, cursor + 1
+}
+
+// syncColOff keeps dataView.colOff in step with the cursor so the next
+// render's columnWindow call resumes from the right offset instead of one
+// left over from wherever the cursor used to be. It runs through every
+// call site that already goes through Model.clampCursor, using the width
+// the grid is actually drawn at.
+func (m *Model) syncColOff() {
+	if !m.data.hasResult() {
+		return
+	}
+	_, _, w, _, ok := m.mainColumnRect()
+	if !ok {
+		return
+	}
+	cols, _ := m.buildGrid()
+	m.data.colOff, _ = columnWindow(cols, m.data.col, m.data.colOff, maxInt(w-2, 1))
 }
 
 // rowWindow keeps the cursor row on screen: the page is anchored at the
@@ -276,7 +308,7 @@ func (m Model) dataBody(w, h int) string {
 		lines = append(lines, "", m.style.muted.Render("no columns"))
 	default:
 		cols, kinds := m.buildGrid()
-		cs, ce := columnWindow(cols, d.col, w)
+		cs, ce := columnWindow(cols, d.col, d.colOff, w)
 		rs, re := rowWindow(len(kinds), d.row, bodyRows)
 
 		lines = append(lines, m.gridHeader(cols[cs:ce], cs, w))

--- a/internal/ui/mouse.go
+++ b/internal/ui/mouse.go
@@ -530,7 +530,7 @@ func (m *Model) clickGrid(row, col int) {
 	ch := maxInt(mh-commandLogHeight(mh)-2, 1)
 
 	cols, kinds := m.buildGrid()
-	cs, ce := columnWindow(cols, m.data.col, cw)
+	cs, ce := columnWindow(cols, m.data.col, m.data.colOff, cw)
 	rs, re := rowWindow(len(kinds), m.data.row, maxInt(ch-4, 0))
 	r := rs + row - 3
 	if r < rs || r >= re {

--- a/internal/ui/rowops.go
+++ b/internal/ui/rowops.go
@@ -58,6 +58,7 @@ func (m *Model) clampCursor() {
 	if m.data.selecting() && len(m.data.selectedRows()) == 0 {
 		m.clearSelection()
 	}
+	m.syncColOff()
 }
 
 // ---------- delete ----------

--- a/wiki/design/data-grid.md
+++ b/wiki/design/data-grid.md
@@ -6,6 +6,10 @@ tags: [tui, db, main-view, pagination, sorting, filtering, security]
 generated:
   by: claude-code/opus-5
   at: 2026-08-09T00:00:00Z
+updated:
+  - by: claude-code/sonnet-5
+    at: 2026-08-12T00:00:00Z
+    note: column window now takes a remembered offset so leftward cursor moves scroll minimally (issue #126)
 ---
 
 # Data grid
@@ -47,15 +51,37 @@ ordered or differently sized result means nothing.
 `s` cycles the column under the cursor ASC → DESC → unsorted, marked in
 the header with `▲`/`▼`.
 
-### Scroll windows are derived, not stored
+### The row window is derived, not stored — the column window can't be
 
-Both the visible row range and the visible column range are computed
-from the cell cursor at render time (`rowWindow`, `columnWindow`) rather
-than kept in the model. `View` has a value receiver, so a window stored
-during rendering would be thrown away anyway — and deriving it means a
-resize can never leave a stale offset behind. The rule is the usual one:
-anchored at the start until the cursor passes the last visible slot,
-then following the cursor.
+The visible row range is computed from the cell cursor at render time
+(`rowWindow`) rather than kept in the model: anchored at the top until the
+cursor passes the last visible row, then following it. That rule works
+because it is a pure function of the cursor alone — for a given cursor row
+there is only one right answer for where the page-window starts.
+
+The column window cannot be purely derived the same way. Minimal-scroll
+means: while the cursor is inside the current window, the window does not
+move — including leftward moves, which is the part issue #126 regressed.
+But "is the cursor still inside the current window" needs the
+current window's left edge as an input, and for a given cursor column more
+than one window can legally contain it (e.g. cursor 2 fits both `[0,3)` and
+`[1,4)`); which one is right depends on where the window was a moment ago,
+not on the cursor value in isolation. So `columnWindow(cols, cursor, off,
+w)` takes the previous left edge `off` (`dataView.colOff`) as an explicit
+argument: it is reused unchanged while `cursor` is still inside `[off,
+end)`, pulled left to `cursor` when the cursor passed the left edge, and
+pushed right only as far as needed when the cursor passed the right edge.
+
+`View` has a value receiver, so it cannot persist `colOff` back into the
+model itself. `Model.clampCursor` — the single choke point every cursor-
+or page-changing action already runs through — calls `syncColOff` after
+clamping, which re-derives the grid's column widths and content width and
+recomputes `colOff` the same way the next render will. That keeps the
+stored offset in step with what's on screen without View ever mutating
+state. `columnWindow` still re-clamps `off` against the current `cols`/`w`
+on every call (`0 <= off <= cursor`, then re-packed to fit `w`), so a
+stale offset — left over from a wider terminal, or a column list that
+shrank — can never leave the cursor, or the window itself, out of bounds.
 
 Column widths come from the *whole page*, not the visible rows, so
 scrolling vertically never makes the grid jitter sideways. Widths are

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1155,3 +1155,29 @@ Chronological history of wiki changes, newest last.
   first row's parameterized statement plus how many more rows share it —
   instead of N near-identical ones, and the selection is consumed by the
   edit the way vim leaves visual mode after an operator.
+
+## 2026-08-12 — Minimal-scroll column window (issue #126)
+
+- Updated [design/data-grid](design/data-grid.md): moving the cursor left
+  used to re-derive the column window from scratch each render, which
+  always restarted the pack from column 0 and dropped the rightmost
+  visible column even when the cursor never left the window. Fixed by
+  giving `columnWindow` a fourth argument, the previous window's left
+  edge (`dataView.colOff`): it is reused unchanged while the cursor is
+  still inside `[off, end)`, pulled left to the cursor when the cursor
+  passes the left edge, and pushed right only as far as needed when the
+  cursor passes the right edge — symmetric with how right-scroll already
+  worked.
+- `columnWindow` still re-clamps `off` to `[0, cursor]` and re-packs it
+  against the current `cols`/`w` on every call, so a stale offset left
+  over from a wider terminal (or a column list that shrank) can never
+  leave the cursor or the window out of bounds — the resize guarantee the
+  row window already had is unchanged.
+- Since `View` has a value receiver and cannot persist state, `colOff` is
+  kept in step from the Update side instead: `Model.clampCursor` (the
+  existing choke point every cursor- or page-changing action already
+  runs through) now calls `syncColOff`, which re-derives the grid's
+  column widths and content width the same way the next render will and
+  recomputes `colOff` to match. The row window needed no such change — a
+  given cursor row has only one valid window, so it stays purely
+  render-derived.


### PR DESCRIPTION
## Summary
- `columnWindow` always re-derived the column window from column 0 on every render, so moving the cursor left past a previous right-scroll re-packed from scratch and dropped the rightmost visible column even when the cursor never left the window.
- `columnWindow` now takes the previous window's left edge as an explicit argument (`dataView.colOff`) and only moves it when the cursor actually leaves the window — mirroring the minimal-scroll rule right-scroll already followed. It still re-clamps against the current columns/width on every call, so the resize-safety guarantee described in its doc comment is unchanged.
- Since `View` has a value receiver and cannot persist state, `colOff` is kept in sync from the Update side: `Model.clampCursor` (the existing choke point every cursor/page-changing action already goes through) now calls `syncColOff`.
- Updated `wiki/design/data-grid.md` and `wiki/log.md` to document why the column window needs this extra state while the row window doesn't.

Closes #126.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] New unit tests: `TestColumnWindowMinimalScroll`, `TestColumnWindowClampsStaleOffset`, `TestColumnLeftScrollIsMinimal` (integration, via real key presses + render)