### PR TITLE
Server activity: sortable columns

### DIFF
--- a/internal/db/activity.go
+++ b/internal/db/activity.go
@@ -140,6 +140,11 @@ func processIDLess(a, b string) bool {
 	return a < b
 }
 
+// ProcessIDLess is processIDLess, exported for the activity view's own
+// column sort: its PID column and its tie-break for every other column
+// order sessions the same way SortProcesses does.
+func ProcessIDLess(a, b string) bool { return processIDLess(a, b) }
+
 // scanProcesses runs a process-list query and reads its fixed column
 // contract, which every dialect's processListSQL produces in this order:
 //

--- a/internal/ui/activity.go
+++ b/internal/ui/activity.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -78,6 +79,12 @@ type activityView struct {
 	gen  int
 
 	rows []db.Process
+	// sort is the client-side column sort `s` cycles through: ASC, DESC,
+	// then nil for the default db.SortProcesses order ListProcesses
+	// already returned. It survives a refresh — applyActivity re-applies
+	// it to every freshly read list, auto-refresh included — the way the
+	// data grid's own dataView.sort survives a page reload.
+	sort *activitySort
 	err  string
 	// unsupported marks an engine that has no server to ask — SQLite and
 	// DuckDB run in this process, so there is no session but ours.
@@ -91,6 +98,23 @@ type activityView struct {
 	// describe the same list — setRows is the only thing that replaces
 	// either.
 	grid roGrid
+}
+
+// activitySort is one active column sort: which of activityHeaders and
+// which direction. A nil *activitySort means the default order.
+type activitySort struct {
+	Column string
+	Desc   bool
+}
+
+// sortOn returns the sort direction for a header, if it is the one being
+// sorted on — the report's equivalent of dataView.sortOn, read by the
+// same header-marking code in gridHeader's roGrid callers.
+func (v *activityView) sortOn(name string) (desc, ok bool) {
+	if v == nil || v.sort == nil || v.sort.Column != name {
+		return false, false
+	}
+	return v.sort.Desc, true
 }
 
 // selected is the process under the cursor.
@@ -118,6 +142,7 @@ func (v *activityView) setRows(rows []db.Process) {
 		anchorID = v.rows[a].ID
 	}
 
+	applyActivitySort(rows, v.sort)
 	v.rows = rows
 	cells := make([][]string, len(rows))
 	kinds := make([]rowKind, len(rows))
@@ -130,7 +155,7 @@ func (v *activityView) setRows(rows []db.Process) {
 			kinds[i] = rowFaded
 		}
 	}
-	v.grid.setCells(activityHeaders, cells, kinds)
+	v.grid.setCells(v.headers(), cells, kinds)
 
 	cursorAt, cursorOK := indexOfProcess(rows, cursorID)
 	if cursorOK {
@@ -568,6 +593,8 @@ func (m Model) activityDispatch(id actionID) (Model, tea.Cmd, bool) {
 	case actColRight:
 		v.grid.col++
 		v.grid.clampCursor()
+	case actSortColumn:
+		return m, m.toggleActivitySort(), true
 	case actNextPage:
 		v.grid.row += activityPageStep
 		v.grid.clampCursor()
@@ -706,6 +733,142 @@ func (m *Model) clickActivity(row, col int) {
 		return
 	}
 	v.grid.clickRow(row, col)
+}
+
+// ---------- sorting ----------
+
+// toggleActivitySort is `s`: cycle the column under the cursor through
+// ASC, DESC and the default order, the way toggleSort does for the data
+// grid. Sorting is client-side — the rows are already on screen — so it
+// takes effect immediately rather than through a reload.
+func (m *Model) toggleActivitySort() tea.Cmd {
+	v := m.activity
+	if v == nil || v.grid.col < 0 || v.grid.col >= len(activityHeaders) {
+		return nil
+	}
+	name := activityHeaders[v.grid.col]
+	switch {
+	case v.sort == nil || v.sort.Column != name:
+		v.sort = &activitySort{Column: name}
+	case !v.sort.Desc:
+		v.sort = &activitySort{Column: name, Desc: true}
+	default:
+		// Back to the default order. applyActivitySort is a no-op with no
+		// sort active — a refresh trusts the driver's own SortProcesses
+		// order rather than re-imposing it — so leaving the rows as DESC
+		// left them would strand the list there until the next refresh.
+		// This is the one place that reaches for db.SortProcesses
+		// directly, to make "default" take effect immediately.
+		v.sort = nil
+		db.SortProcesses(v.rows)
+	}
+	// setRows re-sorts, rebuilds the marked headers and re-anchors the
+	// cursor/selection by session ID — the same path a refresh takes.
+	v.setRows(v.rows)
+	return nil
+}
+
+// headers is the report's columns with the active sort marked, the same
+// way buildGrid marks the data grid's own header.
+func (v *activityView) headers() []string {
+	headers := make([]string, len(activityHeaders))
+	for i, h := range activityHeaders {
+		headers[i] = h
+		if desc, ok := v.sortOn(h); ok {
+			if desc {
+				headers[i] += " ▼"
+			} else {
+				headers[i] += " ▲"
+			}
+		}
+	}
+	return headers
+}
+
+// applyActivitySort orders rows by the report's active client-side sort,
+// in place. It is a no-op with no sort active, which is what leaves the
+// default db.SortProcesses order — already applied by ListProcesses —
+// alone. It runs every time fresh rows land (the initial read, `R`, and
+// every auto-refresh tick), so the same key and direction survive a
+// refresh.
+func applyActivitySort(rows []db.Process, s *activitySort) {
+	if s == nil {
+		return
+	}
+	switch s.Column {
+	case "PID":
+		sortProcessesByID(rows, s.Desc)
+	case "User":
+		sortProcessesByText(rows, s.Desc, func(p db.Process) string { return p.User })
+	case "Database":
+		sortProcessesByText(rows, s.Desc, func(p db.Process) string { return p.Database })
+	case "Client":
+		sortProcessesByText(rows, s.Desc, func(p db.Process) string { return p.Client })
+	case "State":
+		sortProcessesByText(rows, s.Desc, func(p db.Process) string { return p.State })
+	case "Duration":
+		sortProcessesByDuration(rows, s.Desc)
+	case "Blocked by":
+		sortProcessesByText(rows, s.Desc, func(p db.Process) string { return p.BlockedByText() })
+	case "Query":
+		sortProcessesByText(rows, s.Desc, func(p db.Process) string { return flatten(p.Query) })
+	}
+}
+
+// sortProcessesByID orders by session ID numerically, ascending or
+// descending. Equal IDs cannot occur — a session's ID is unique — so
+// there is no further tie-break to keep.
+func sortProcessesByID(ps []db.Process, desc bool) {
+	sort.SliceStable(ps, func(i, j int) bool {
+		if desc {
+			return db.ProcessIDLess(ps[j].ID, ps[i].ID)
+		}
+		return db.ProcessIDLess(ps[i].ID, ps[j].ID)
+	})
+}
+
+// sortProcessesByDuration orders by runtime numerically. Idle sessions
+// (HasDuration false) sort last regardless of direction, the same
+// NULLS-LAST convention SortProcesses' default order uses — a direction
+// that buried the longest query would defeat the column's own point.
+func sortProcessesByDuration(ps []db.Process, desc bool) {
+	sort.SliceStable(ps, func(i, j int) bool {
+		a, b := ps[i], ps[j]
+		if a.HasDuration != b.HasDuration {
+			return a.HasDuration
+		}
+		if !a.HasDuration {
+			return db.ProcessIDLess(a.ID, b.ID)
+		}
+		if a.Duration != b.Duration {
+			if desc {
+				return a.Duration > b.Duration
+			}
+			return a.Duration < b.Duration
+		}
+		return db.ProcessIDLess(a.ID, b.ID)
+	})
+}
+
+// sortProcessesByText orders by a text column lexically, with the
+// session ID as the stable tie-break every column shares. An unreported
+// value (empty string) sorts last regardless of direction — the same
+// place a NULL would land — so asking for the busiest states or the
+// latest client address does not bury them under a page of blanks.
+func sortProcessesByText(ps []db.Process, desc bool, get func(db.Process) string) {
+	sort.SliceStable(ps, func(i, j int) bool {
+		a, b := get(ps[i]), get(ps[j])
+		if ea, eb := a == "", b == ""; ea != eb {
+			return eb
+		}
+		if a != b {
+			if desc {
+				return a > b
+			}
+			return a < b
+		}
+		return db.ProcessIDLess(ps[i].ID, ps[j].ID)
+	})
 }
 
 // ---------- rendering ----------
@@ -900,7 +1063,7 @@ func (m Model) activityFooter() string {
 	// has them: with a side panel focused the list is on display and the
 	// footer says how to get back to it instead.
 	if m.activityFocused() {
-		parts = append(parts, "j/k/h/l move · y copy · R refresh · t auto · K kill · esc close")
+		parts = append(parts, "j/k/h/l move · s sort · y copy · R refresh · t auto · K kill · esc close")
 	} else {
 		parts = append(parts, "tab focuses the report")
 	}

--- a/internal/ui/activity_test.go
+++ b/internal/ui/activity_test.go
@@ -104,6 +104,100 @@ func TestActivityKeepsTheDriversOrder(t *testing.T) {
 	}
 }
 
+// `s` cycles the column under the cursor through ASC, DESC and back to
+// the driver's default order, and marks the header the way the data
+// grid does. Duration is used because it must sort numerically rather
+// than by the formatted "1m 35s" text.
+func TestActivitySortCyclesAscDescDefault(t *testing.T) {
+	m := openReport(t, serverModel(t, false), fixtureProcesses())
+	// Move the column cursor onto Duration (PID, User, Database, Client,
+	// State, Duration).
+	m = send(t, m, press('l'), press('l'), press('l'), press('l'), press('l'))
+	if got := m.activity.grid.header(m.activity.grid.col); got != "Duration" {
+		t.Fatalf("column cursor is on %q, want Duration", got)
+	}
+
+	m = send(t, m, press('s'))
+	if ids := rowIDs(m); !equalStrings(ids, []string{"45", "43", "42", "44"}) {
+		t.Fatalf("ASC duration order = %v, want [45 43 42 44] (idle last)", ids)
+	}
+	if !strings.Contains(m.activityContent(120, 20), "Duration ▲") {
+		t.Errorf("the header does not mark the ascending sort:\n%s", m.activityContent(120, 20))
+	}
+
+	m = send(t, m, press('s'))
+	if ids := rowIDs(m); !equalStrings(ids, []string{"42", "43", "45", "44"}) {
+		t.Fatalf("DESC duration order = %v, want [42 43 45 44] (idle last)", ids)
+	}
+	if !strings.Contains(m.activityContent(120, 20), "Duration ▼") {
+		t.Errorf("the header does not mark the descending sort:\n%s", m.activityContent(120, 20))
+	}
+
+	m = send(t, m, press('s'))
+	if m.activity.sort != nil {
+		t.Fatalf("sort = %+v, want nil after the third `s`", m.activity.sort)
+	}
+	if ids := rowIDs(m); !equalStrings(ids, []string{"42", "43", "45", "44"}) {
+		t.Fatalf("default order = %v, want db.SortProcesses' own order", ids)
+	}
+	if strings.Contains(m.activityContent(120, 20), "Duration ▲") ||
+		strings.Contains(m.activityContent(120, 20), "Duration ▼") {
+		t.Errorf("the header still marks a sort after it was cleared:\n%s", m.activityContent(120, 20))
+	}
+}
+
+// The PID column sorts numerically, not lexically — "9" must not sort
+// ahead of "10".
+func TestActivitySortPIDIsNumeric(t *testing.T) {
+	rows := []db.Process{
+		{ID: "10", User: "app"},
+		{ID: "2", User: "app"},
+		{ID: "9", User: "app"},
+	}
+	m := openReport(t, serverModel(t, false), rows)
+	m = send(t, m, press('s')) // column cursor starts on PID
+	if ids := rowIDs(m); !equalStrings(ids, []string{"2", "9", "10"}) {
+		t.Fatalf("PID ASC order = %v, want numeric order [2 9 10]", ids)
+	}
+}
+
+// Auto-refresh (and a plain `R`) must not lose the active sort: fresh
+// rows land re-sorted by the same column and direction.
+func TestActivitySortSurvivesRefresh(t *testing.T) {
+	m := openReport(t, serverModel(t, false), fixtureProcesses())
+	m = send(t, m, press('l'), press('l'), press('l'), press('l'), press('l'), press('s'))
+	if ids := rowIDs(m); !equalStrings(ids, []string{"45", "43", "42", "44"}) {
+		t.Fatalf("ASC duration order before refresh = %v", ids)
+	}
+
+	// A fresh read arrives in the driver's own (unsorted-by-duration-asc)
+	// order, with one session's duration changed and a new one added.
+	fresh := []db.Process{
+		{ID: "42", User: "app", Duration: 200 * time.Second, HasDuration: true},
+		{ID: "43", User: "app", Duration: 12 * time.Second, HasDuration: true},
+		{ID: "44", User: "reporting"},
+		{ID: "45", User: "app", Duration: time.Second, HasDuration: true},
+		{ID: "46", User: "app", Duration: 5 * time.Second, HasDuration: true},
+	}
+	m.activity.id++ // what refreshActivity does before the round trip
+	m = send(t, m, activityLoadedMsg{id: m.activity.id, conn: m.active, rows: fresh})
+
+	if ids := rowIDs(m); !equalStrings(ids, []string{"45", "46", "43", "42", "44"}) {
+		t.Fatalf("ASC duration order after refresh = %v, want [45 46 43 42 44] (idle last)", ids)
+	}
+	if !strings.Contains(m.activityContent(120, 20), "Duration ▲") {
+		t.Errorf("the header lost its sort mark after refresh:\n%s", m.activityContent(120, 20))
+	}
+}
+
+func rowIDs(m Model) []string {
+	ids := make([]string, len(m.activity.rows))
+	for i, p := range m.activity.rows {
+		ids[i] = p.ID
+	}
+	return ids
+}
+
 func TestActivityCursorMoves(t *testing.T) {
 	m := openReport(t, serverModel(t, false), fixtureProcesses())
 	m = send(t, m, press('j'))

--- a/internal/ui/keys.go
+++ b/internal/ui/keys.go
@@ -696,6 +696,7 @@ func (k keyMap) activityActions() []action {
 		{actColRight, k.ColRight},
 		{actNextPage, k.NextPage},
 		{actPrevPage, k.PrevPage},
+		{actSortColumn, k.SortColumn},
 		{actSelectRows, k.SelectRows},
 		{actSelectColumns, k.SelectColumns},
 		{actExtendSelectionUp, k.ActivitySelectUp},

--- a/wiki/design/server-activity-view.md
+++ b/wiki/design/server-activity-view.md
@@ -55,6 +55,51 @@ The tie-break matters more than it looks: the list is re-read whole on
 every refresh, so without a total order two equal rows could swap places
 between refreshes and move the row `K` is aimed at.
 
+> **Extended by issue #178.** `db.SortProcesses` is still the order the
+> driver hands back and still what "no active sort" means, but the report
+> now also lets `s` sort the client-side list by whichever column the
+> cursor is on — see [Column sorting](#column-sorting) below.
+
+## Column sorting
+
+`s` on the column under the cursor cycles ASC → DESC → the default
+`db.SortProcesses` order, the same three-state cycle `toggleSort` runs
+for the data grid (`internal/ui/data.go`). It is entirely client-side:
+the report already holds the whole list, there is nothing to re-query,
+and the sort has to survive auto-refresh without adding a round trip.
+
+`activityView.sort` (`internal/ui/activity.go`) holds the active column
+and direction; `nil` means "no active sort", which is the same state a
+fresh report or a third `s` press lands in. `setRows` — the one place
+that lands a list, whether from the initial read, `R`, or an
+auto-refresh beat — applies it before the cursor/selection is re-anchored
+by session id, so a re-sort and a refresh go through one path and cannot
+disagree about the order the cursor ends up looking at.
+
+Two rules the per-column comparators share with `db.SortProcesses`
+itself:
+
+- **Numeric columns sort numerically.** PID and Duration parse and
+  compare as numbers rather than as the formatted display text — sorting
+  "PID" lexically would put session `10` ahead of `9`, and Duration is
+  already rendered as `"1m 35s"`, which does not sort at all the way the
+  underlying seconds do.
+- **Unreported values sort last, in both directions.** An idle session's
+  Duration and an empty text column (no client address, no blocker) are
+  not "small" or "before everything else" — they are absent, so they stay
+  at the bottom whether the column reads ASC or DESC. `db.SortProcesses`
+  already makes this call for the default order (`HasDuration` last); the
+  column sort just applies the same convention everywhere else instead of
+  making it column by column.
+
+Reaching for `db.SortProcesses` directly happens in exactly one place:
+the third `s` press, which needs the default order to take effect
+immediately rather than waiting for the next refresh to happen to arrive
+in it. Every other landing of fresh rows leaves them as the driver
+returned them when no client sort is active — the report still does not
+re-order what it was handed, the rule the original decision above
+documents.
+
 ## Why it is not a fourth panel
 
 The side column is three numbered panels and a `1`–`3` jump; a fourth

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1684,3 +1684,22 @@ Chronological history of wiki changes, newest last.
 - Auto-refresh behaviour is now defined and tested: the cursor re-anchors by
   session ID, falls back to its index when that session has ended, and a
   selection is kept only while both of its ends are still listed.
+
+## 2026-08-18 — Server activity: sortable columns (issue #178)
+
+- Updated [design/server-activity-view](design/server-activity-view.md) with a
+  **Column sorting** section: `s` on the column under the grid cursor cycles
+  ASC → DESC → the default `db.SortProcesses` order, client-side, mirroring
+  `toggleSort` on the data grid. `activityView.sort` (`internal/ui/activity.go`)
+  holds the active column/direction; `setRows` — the one place every fresh list
+  lands, refresh and auto-refresh tick included — applies it before the cursor
+  re-anchors by session ID, so a re-sort and a refresh share one path.
+- PID and Duration sort numerically rather than by their formatted display
+  text; every column sorts unreported/idle values last regardless of
+  direction, the same convention `db.SortProcesses`' own default order already
+  used for `HasDuration`. The one place that calls `db.SortProcesses` directly
+  from the UI is the third `s` press, so "back to default" takes effect
+  immediately instead of waiting for the next refresh.
+- `actSortColumn`/`k.SortColumn` (`s`) joined `keyMap.activityActions()`, the
+  single source for the report's dispatch, options bar and `?` — no separate
+  wiring needed for either.


### PR DESCRIPTION
## Summary
- `s` on the column under the cursor in the server activity view cycles ASC → DESC → the default `db.SortProcesses` order, client-side (no extra queries).
- Numeric columns (PID, Duration) sort numerically, not lexically; unreported/idle values sort last regardless of direction.
- The sorted column and direction are marked in the header the same way the data grid does (`▲`/`▼`).
- The sort survives auto-refresh — `setRows` re-applies the active key/direction to every fresh list, refresh and tick included; with no active sort, the driver's default order applies as before.
- `s` is wired through `keyMap.activityActions()`, the single source for the report's dispatch, options bar and `?`, so no separate documentation was needed.
- Depended on #176 (column cursor in the activity table), which has landed, so sorting targets the column under the cursor as specified — no fallback needed.

Closes #178.

## Test plan
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] New tests: `TestActivitySortCyclesAscDescDefault`, `TestActivitySortPIDIsNumeric`, `TestActivitySortSurvivesRefresh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)