### PR TITLE
Make the default row limit (page size) configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,19 @@ progress and drops back to the plain connections panel; a deleted
 connection, an unreachable host or a dropped table degrade the same way,
 with a note in the command log.
 
+### `page_size`
+
+The number of rows fetched per page when browsing a table — the `LIMIT` in
+the query the grid runs on open and on every `ctrl+f`/`ctrl+b` page turn.
+Defaults to 100 when unset:
+
+```toml
+page_size = 500
+```
+
+A missing, zero, negative or otherwise invalid value falls back to the
+default rather than failing to start.
+
 ### Clipboard
 
 `y` copies through the native clipboard (`pbcopy`, `xclip`, `xsel`) when

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,12 +138,31 @@ type Config struct {
 	// navigates back to the last database/table/tab. Opt-in: absent from
 	// the file means false, so a fresh config never auto-connects.
 	RestoreSession bool `toml:"restore_session,omitempty"`
+
+	// PageSize is the LIMIT used when browsing a table page and stepping
+	// through pagination. Zero or absent means DefaultPageSize; an invalid
+	// value (zero, negative, or otherwise unusable) never fails config
+	// load — PageSizeOrDefault degrades it to the default instead.
+	PageSize int `toml:"page_size,omitempty"`
 }
 
 // RestoreSessionEnabled reports whether startup should restore the last
 // session. Absent (false) means no restore.
 func (c *Config) RestoreSessionEnabled() bool {
 	return c.RestoreSession
+}
+
+// DefaultPageSize is the row limit used when the config sets no page size,
+// or sets an invalid one.
+const DefaultPageSize = 100
+
+// PageSizeOrDefault returns the configured page size, falling back to
+// DefaultPageSize when unset or invalid (<= 0).
+func (c *Config) PageSizeOrDefault() int {
+	if c.PageSize <= 0 {
+		return DefaultPageSize
+	}
+	return c.PageSize
 }
 
 // Params converts a profile into the driver-agnostic connection parameters.
@@ -276,6 +295,7 @@ type configFile struct {
 	Keys           map[string]string `toml:"keys,omitempty"`
 	Theme          map[string]string `toml:"theme,omitempty"`
 	RestoreSession bool              `toml:"restore_session,omitempty"`
+	PageSize       int               `toml:"page_size,omitempty"`
 }
 
 func (c *Config) forEncoding() configFile {
@@ -284,6 +304,7 @@ func (c *Config) forEncoding() configFile {
 		Keys:           c.Keys,
 		Theme:          c.Theme,
 		RestoreSession: c.RestoreSession,
+		PageSize:       c.PageSize,
 	}
 	for i, conn := range c.Connections {
 		e := connectionFile{
@@ -579,6 +600,7 @@ func (c *Config) Clone() *Config {
 	out := &Config{
 		Connections:    make([]Connection, len(c.Connections)),
 		RestoreSession: c.RestoreSession,
+		PageSize:       c.PageSize,
 	}
 	copy(out.Connections, c.Connections)
 	if c.Keys != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -493,6 +493,72 @@ func TestRestoreSessionAbsentStaysAbsent(t *testing.T) {
 	}
 }
 
+func TestPageSizeDefaultsWhenAbsent(t *testing.T) {
+	cfg := &Config{}
+	if got := cfg.PageSizeOrDefault(); got != DefaultPageSize {
+		t.Fatalf("PageSizeOrDefault() = %d with the key absent, want %d", got, DefaultPageSize)
+	}
+}
+
+// Zero, negative and other invalid values degrade to the default rather
+// than propagating — a malformed page_size must never crash startup.
+func TestPageSizeFallsBackOnInvalidValues(t *testing.T) {
+	for _, v := range []int{0, -1, -500} {
+		cfg := &Config{PageSize: v}
+		if got := cfg.PageSizeOrDefault(); got != DefaultPageSize {
+			t.Fatalf("PageSizeOrDefault() with page_size=%d = %d, want %d", v, got, DefaultPageSize)
+		}
+	}
+}
+
+func TestPageSizeRoundTrips(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	cfg := &Config{PageSize: 500}
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "page_size = 500") {
+		t.Fatalf("page_size not written:\n%s", raw)
+	}
+	back, err := LoadFrom(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := back.PageSizeOrDefault(); got != 500 {
+		t.Fatalf("PageSizeOrDefault() = %d after loading page_size = 500, want 500", got)
+	}
+}
+
+// A config file without the key at all never writes it back out, and
+// Clone does not share state with the original.
+func TestPageSizeAbsentStaysAbsent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.toml")
+	cfg := &Config{Connections: []Connection{
+		{Name: "dev", Engine: db.EngineSQLite, File: "/tmp/dev.sqlite"},
+	}}
+	if err := cfg.SaveTo(path); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), "page_size") {
+		t.Fatalf("page_size written despite being unset:\n%s", raw)
+	}
+
+	cfg.PageSize = 500
+	clone := cfg.Clone()
+	cfg.PageSize = 0
+	if got := clone.PageSizeOrDefault(); got != 500 {
+		t.Fatal("Clone shared PageSize state with the original")
+	}
+}
+
 func TestStatePathHonoursXDGConfigHome(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg")
 	got, err := StatePath()

--- a/internal/ui/data.go
+++ b/internal/ui/data.go
@@ -10,9 +10,14 @@ import (
 	"lazysql/internal/db"
 )
 
-// dataPageSize is how many rows one page of the grid holds. The grid
-// never keeps more than one page in memory, which is what makes a
-// 100k-row table exactly as cheap to browse as a 100-row one.
+// dataPageSize is the built-in default for how many rows one page of the
+// grid holds, used when a dataView's own pageSize is unset (zero value) —
+// see dataView.limit. The grid never keeps more than one page in memory,
+// which is what makes a 100k-row table exactly as cheap to browse as a
+// 100-row one. The configured default (config.PageSize) is threaded into
+// each dataView at construction time; this constant is only the fallback
+// for a dataView built without going through that path (e.g. a bare
+// dataView{} reset, or a test fixture).
 const dataPageSize = 100
 
 // queryTimeout bounds a page read. It is longer than the catalog
@@ -103,6 +108,22 @@ type dataView struct {
 	// req is bumped on every reload; a reply carrying an older req
 	// belongs to a query the user has already moved past.
 	req int
+
+	// pageSize is how many rows one page holds, threaded in from the
+	// configured default (config.PageSize) at construction time. Zero
+	// means "unset" rather than "no rows" — limit() is what every reader
+	// goes through so a dataView built without it still behaves like the
+	// built-in default.
+	pageSize int
+}
+
+// limit is how many rows one page holds: the configured pageSize, or the
+// built-in default when it was never set.
+func (d dataView) limit() int {
+	if d.pageSize > 0 {
+		return d.pageSize
+	}
+	return dataPageSize
 }
 
 // selecting reports whether a multi-row selection is up.
@@ -209,11 +230,11 @@ func (d *dataView) setPage(p int) {
 		p = 0
 	}
 	d.page = p
-	start := p * dataPageSize
+	start := p * d.limit()
 	if start > len(d.all) {
 		start = len(d.all)
 	}
-	end := start + dataPageSize
+	end := start + d.limit()
 	if end > len(d.all) {
 		end = len(d.all)
 	}
@@ -223,7 +244,7 @@ func (d *dataView) setPage(p int) {
 }
 
 // offset is the row offset of the current page in the full result.
-func (d dataView) offset() int { return d.page * dataPageSize }
+func (d dataView) offset() int { return d.page * d.limit() }
 
 // pageCount is how many pages the count implies; 0 when unknown.
 func (d dataView) pageCount() int {
@@ -233,7 +254,7 @@ func (d dataView) pageCount() int {
 	if d.total <= 0 {
 		return 1
 	}
-	return int((d.total + dataPageSize - 1) / dataPageSize)
+	return int((d.total + int64(d.limit()) - 1) / int64(d.limit()))
 }
 
 // sortOn returns the sort direction for a column name, if it is the one
@@ -307,7 +328,7 @@ func loadPageCmd(drv db.Driver, d dataView, req int) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), queryTimeout)
 		defer cancel()
-		rs, err := drv.QueryPage(ctx, d.database, d.table, d.filter, d.sort, dataPageSize, d.offset())
+		rs, err := drv.QueryPage(ctx, d.database, d.table, d.filter, d.sort, d.limit(), d.offset())
 		return pageLoadedMsg{req: req, conn: d.conn, table: d.table, result: rs, err: err}
 	}
 }
@@ -351,6 +372,7 @@ func (m *Model) openTable(name string) tea.Cmd {
 		database: m.database,
 		table:    name,
 		req:      m.data.req,
+		pageSize: m.pageSize,
 	}
 	// Picking a relation from panel [3] is a fresh start, so the jump
 	// history of whatever chain of references was being followed goes.
@@ -459,7 +481,7 @@ func (m *Model) turnPage(delta int) tea.Cmd {
 	// A query result is already in memory: paging it is a slice, not a
 	// round trip.
 	if m.data.isQuery() {
-		if next > m.data.page && next*dataPageSize >= len(m.data.all) {
+		if next > m.data.page && next*m.data.limit() >= len(m.data.all) {
 			return logCmd("-- already on the last page")
 		}
 		if next == m.data.page {
@@ -470,10 +492,10 @@ func (m *Model) turnPage(delta int) tea.Cmd {
 		return nil
 	}
 	if next > m.data.page {
-		if m.data.hasTotal && next*dataPageSize >= int(m.data.total) {
+		if m.data.hasTotal && next*m.data.limit() >= int(m.data.total) {
 			return logCmd("-- already on the last page")
 		}
-		if !m.data.hasTotal && len(m.data.rows) < dataPageSize {
+		if !m.data.hasTotal && len(m.data.rows) < m.data.limit() {
 			return logCmd("-- already on the last page")
 		}
 	}

--- a/internal/ui/data_test.go
+++ b/internal/ui/data_test.go
@@ -72,6 +72,75 @@ func TestOpenTableFetchesOnePage(t *testing.T) {
 	}
 }
 
+// A configured page_size flows into the LIMIT of the open and every
+// pagination step, and offsets step by the same amount.
+func TestConfiguredPageSizeControlsLimitAndOffset(t *testing.T) {
+	m := browsing(t)
+	m.cfg.PageSize = 60
+	m.pageSize = m.cfg.PageSizeOrDefault()
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`DROP TABLE IF EXISTS grid`,
+		`CREATE TABLE grid (id INTEGER PRIMARY KEY, name TEXT)`,
+		`INSERT INTO grid (id, name)
+		 WITH RECURSIVE seq(n) AS (
+			SELECT 1 UNION ALL SELECT n + 1 FROM seq WHERE n < 250
+		 )
+		 SELECT n, 'name-' || n FROM seq`,
+	} {
+		if _, err := m.driver.Exec(ctx, stmt); err != nil {
+			t.Fatalf("fixture %q: %v", stmt, err)
+		}
+	}
+	m = send(t, m, press('2'), press('R'))
+	if !m.panels[panelObjects].selectByName("grid") {
+		t.Fatalf("fixture table not listed: %v", m.panels[panelObjects].items)
+	}
+	m = send(t, m, special(tea.KeyEnter, 0))
+
+	if got := len(m.data.rows); got != 60 {
+		t.Fatalf("rows in memory = %d, want 60", got)
+	}
+	if !logContains(m, "LIMIT 60 OFFSET 0") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+
+	m = send(t, m, ctrl('f'))
+	if m.data.page != 1 {
+		t.Fatalf("page = %d, want 1", m.data.page)
+	}
+	if !logContains(m, "LIMIT 60 OFFSET 60") {
+		t.Fatalf("command log = %v", m.commandLog)
+	}
+}
+
+// An invalid page_size (zero, negative) never reaches the query: it falls
+// back to the built-in default rather than crashing or emitting a bad
+// LIMIT.
+func TestInvalidPageSizeFallsBackToDefault(t *testing.T) {
+	m := browsing(t)
+	m.cfg.PageSize = -5
+	m.pageSize = m.cfg.PageSizeOrDefault()
+	ctx := context.Background()
+	for _, stmt := range []string{
+		`DROP TABLE IF EXISTS grid`,
+		`CREATE TABLE grid (id INTEGER PRIMARY KEY, name TEXT)`,
+		`INSERT INTO grid (id, name) VALUES (1, 'a')`,
+	} {
+		if _, err := m.driver.Exec(ctx, stmt); err != nil {
+			t.Fatalf("fixture %q: %v", stmt, err)
+		}
+	}
+	m = send(t, m, press('2'), press('R'))
+	if !m.panels[panelObjects].selectByName("grid") {
+		t.Fatalf("fixture table not listed: %v", m.panels[panelObjects].items)
+	}
+	m = send(t, m, special(tea.KeyEnter, 0))
+	if !logContains(m, "LIMIT 100 OFFSET 0") {
+		t.Fatalf("command log = %v, want the default LIMIT 100", m.commandLog)
+	}
+}
+
 // The grid shows the header, the types, the values, a dim NULL and a
 // status line naming the page.
 func TestGridRendersHeaderRowsAndStatus(t *testing.T) {

--- a/internal/ui/foreignkey.go
+++ b/internal/ui/foreignkey.go
@@ -375,6 +375,7 @@ func (m *Model) jumpTo(database, table string, f *db.Filter) tea.Cmd {
 		table:    table,
 		filter:   f,
 		req:      m.data.req,
+		pageSize: m.pageSize,
 	}
 	// The [2] tree follows along whenever the target is in the browsed
 	// namespace, so the shell does not claim a different relation is open.

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -199,6 +199,12 @@ type Model struct {
 	// data is the main view's Data tab: one page of m.table.
 	data dataView
 
+	// pageSize is the configured row limit for browsing a table page and
+	// pagination — config.PageSize resolved to its default at New(). Every
+	// dataView is constructed with this as its own pageSize so limit()
+	// never has to reach back through the Model.
+	pageSize int
+
 	// filterInput is the grid's inline `/` line — the WHERE clause being
 	// typed — nil when none is open. filters is the per-relation filter
 	// history behind its recall keys, newest first, across every scope.
@@ -354,6 +360,7 @@ func New(noRestore bool) (Model, error) {
 		cfg:       cfg,
 		editor:    newQueryEditor(),
 		hl:        &editorCache{},
+		pageSize:  cfg.PageSizeOrDefault(),
 	}
 	m.spin = spinner.New(spinner.WithSpinner(spinner.MiniDot), spinner.WithStyle(m.style.pending))
 	if cfgErr != nil {

--- a/internal/ui/query.go
+++ b/internal/ui/query.go
@@ -877,7 +877,8 @@ func (m *Model) showQueryResult(sql, exec string, args []any, rs *db.ResultSet, 
 		hasTotal:  true,
 		// A bumped req invalidates any page or count still in flight
 		// for the relation this result replaced.
-		req: m.data.req + 1,
+		req:      m.data.req + 1,
+		pageSize: m.pageSize,
 	}
 	m.data.setPage(0)
 	m.clampCursor()
@@ -897,6 +898,7 @@ func (m *Model) showQueryError(sql string, err error) {
 		query:    sql,
 		err:      err.Error(),
 		req:      m.data.req + 1,
+		pageSize: m.pageSize,
 	}
 }
 
@@ -913,6 +915,7 @@ func (m *Model) showQueryNotice(sql string, affected int64) {
 		query:    sql,
 		notice:   db.FirstKeyword(sql) + " — " + countAffected(affected),
 		req:      m.data.req + 1,
+		pageSize: m.pageSize,
 	}
 }
 

--- a/internal/ui/relations.go
+++ b/internal/ui/relations.go
@@ -144,6 +144,7 @@ func (m *Model) walkRelation() tea.Cmd {
 		database: edge.database,
 		table:    edge.table,
 		req:      m.data.req,
+		pageSize: m.pageSize,
 	}
 	// The [2] tree follows along whenever the target is in the browsed
 	// namespace, so the shell does not claim a different relation is open.


### PR DESCRIPTION
## Summary
- Adds a top-level `page_size` config option (`internal/config/config.go`, `config.toml`) that sets the `LIMIT` used when browsing a table page.
- Threads the resolved value (`Model.pageSize`) into every `dataView` — table open, pagination (`ctrl+f`/`ctrl+b`), and drill-in via foreign keys/relations — via `dataView.limit()`.
- Unset or invalid (`<= 0`) values fall back to the existing default of 100, with no crash.
- Documents the new option in the README.

Closes #194

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (existing `LIMIT 100 OFFSET 0` assertions still pass; new tests cover a custom `page_size` and an invalid one falling back to the default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)